### PR TITLE
fix(ontology): run mapping step based on cores property

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "25.3.0-rc.1"
+version = "25.3.0-rc.2"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/pts/utils/ontology.py
+++ b/src/pts/utils/ontology.py
@@ -1,21 +1,16 @@
-"""Ontology mapping utilities for disease and phenotype data.
+"""This module provides functionality to map disease information to EFO using the OnToma."""
 
-This module provides functionality to map disease information to EFO (Experimental Factor Ontology)
-using the OnToma library. It includes retry logic and parallel processing capabilities.
-"""
-import os
 import random
 import time
+from pathlib import Path
 
 from loguru import logger
 from numpy import nan
 from ontoma.interface import OnToma
-from pandarallel import pandarallel
 from pyspark.sql.functions import col, when
 from pyspark.sql.types import StringType, StructField, StructType
 
-ONTOMA_MAX_ATTEMPTS = 3
-pandarallel.initialize()
+ONTOMA_MAX_ATTEMPTS = 1
 
 
 def _simple_retry(func, **kwargs):
@@ -23,29 +18,96 @@ def _simple_retry(func, **kwargs):
     for attempt in range(1, ONTOMA_MAX_ATTEMPTS + 1):
         try:
             return func(**kwargs)
-        except Exception:
+        except Exception as e:
             # If this is not the last attempt, wait until the next one.
             if attempt != ONTOMA_MAX_ATTEMPTS:
+                logger.warning(f'OnToma lookup attempt {attempt} failed: {e}. Retrying...')
                 time.sleep(5 + 10 * random.random())
-    logger.error(f'OnToma lookup failed for {kwargs!r}')
+            else:
+                logger.error(f'OnToma lookup failed after {ONTOMA_MAX_ATTEMPTS} attempts for {kwargs!r}: {e}')
     return []
+
+
+def _get_cache_directory(base_cache_dir=None, efo_version=None):
+    """Get or create a persistent cache directory for OnToma.
+
+    Args:
+        base_cache_dir: Custom base directory for cache (optional)
+        efo_version: EFO version string (required, e.g. 'v3.81.0')
+    """
+    if not efo_version:
+        raise ValueError('efo_version is required and cannot be None')
+
+    if base_cache_dir:
+        cache_dir = Path(base_cache_dir)
+    else:
+        # Create cache directory based on explicit version
+        cache_dir = Path.home() / '.ontoma_cache' / f'efo_{efo_version}'
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return str(cache_dir)
+
+
+def _initialize_ontoma_with_cache(ontoma_cache_dir, efo_version):
+    """Initialize OnToma with persistent caching, only parsing EFO if not cached.
+
+    Args:
+        ontoma_cache_dir: Directory path for OnToma cache
+        efo_version: EFO version string (required, e.g. 'v3.81.0')
+    """
+    if not efo_version:
+        raise ValueError('efo_version is required and cannot be None')
+
+    logger.info(f'Initializing OnToma with cache directory: {ontoma_cache_dir}')
+
+    # Check if we have a cached ontology
+    cache_info_file = Path(ontoma_cache_dir) / 'cache_info.txt'
+
+    if cache_info_file.exists():
+        cached_version = Path(cache_info_file).read_text().strip()
+        if cached_version == efo_version:
+            logger.info(f'Found existing EFO {efo_version} cache, reusing...')
+        else:
+            logger.info(
+                f'Cache version mismatch (cached: {cached_version}, requested: {efo_version}), will re-cache...'
+            )
+    else:
+        logger.info(f'No existing cache found, will create new cache for EFO {efo_version}')
+
+    # Initialize OnToma (it will use existing cache if available)
+    start_time = time.time()
+    ontoma_instance = OnToma(cache_dir=ontoma_cache_dir, efo_release=efo_version)
+    initialization_time = time.time() - start_time
+
+    logger.info(f'OnToma initialization completed in {initialization_time:.1f}s')
+
+    # Save cache info for future runs
+    Path(cache_info_file).write_text(efo_version)
+
+    return ontoma_instance
 
 
 def _ontoma_udf(row, ontoma_instance):
     """Try to map first by disease name (because that branch of OnToma is more stable), then by disease ID."""
-    disease_name = None
-    if row['diseaseFromSource']:
-        disease_name = ' '.join(row['diseaseFromSource'].replace('obsolete', '').split())
-    disease_id = row['diseaseFromSourceId'].replace('_', ':') if row['diseaseFromSourceId'] else None
-    mappings = []
-    if disease_name:
-        mappings = _simple_retry(ontoma_instance.find_term, query=disease_name, code=False)
-    if not mappings and disease_id and ':' in disease_id:
-        mappings = _simple_retry(ontoma_instance.find_term, query=disease_id, code=True)
-    return [m.id_ot_schema for m in mappings]
+    try:
+        disease_name = None
+        if row['diseaseFromSource']:
+            disease_name = ' '.join(row['diseaseFromSource'].replace('obsolete', '').split())
+        disease_id = row['diseaseFromSourceId'].replace('_', ':') if row['diseaseFromSourceId'] else None
+
+        mappings = []
+        if disease_name:
+            mappings = _simple_retry(ontoma_instance.find_term, query=disease_name, code=False)
+        if not mappings and disease_id and ':' in disease_id:
+            mappings = _simple_retry(ontoma_instance.find_term, query=disease_id, code=True)
+
+        return [m.id_ot_schema for m in mappings]
+    except Exception as e:
+        logger.warning(f'Mapping failed for row {row.name if hasattr(row, "name") else "unknown"}: {e}')
+        return []
 
 
-def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo_version=None):
+def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo_version=None, cores=1):
     """Given evidence strings with diseaseFromSource and diseaseFromSourceId fields, try to populate EFO mapping.
 
     field diseaseFromSourceMappedId. In case there are multiple matches, the evidence strings will be exploded
@@ -53,51 +115,84 @@ def add_efo_mapping(evidence_strings, spark_instance, ontoma_cache_dir=None, efo
 
     Currently, both source columns (diseaseFromSource and diseaseFromSourceId) need to be present in the original
     schema, although they do not have to be populated for all rows.
+
+    Args:
+        evidence_strings: Spark DataFrame with evidence data
+        spark_instance: Spark session instance
+        ontoma_cache_dir: Directory for OnToma cache (will use default if None)
+        efo_version: EFO version to use (required, e.g. 'v3.81.0')
+        cores: Number of cores to use (1 = sequential, >1 = parallel)
     """
+    if not efo_version:
+        raise ValueError("efo_version is required. Please specify an explicit EFO version (e.g. 'v3.81.0').")
     logger.info('Collect all distinct (disease name, disease ID) pairs.')
     disease_info_to_map = evidence_strings.select('diseaseFromSource', 'diseaseFromSourceId').distinct().toPandas()
+    logger.info(f'Found {len(disease_info_to_map)} unique disease entries to map.')
 
-    # If no EFO version is specified:
-    if not efo_version:
-        # try to extract from environment variable.
-        if 'EFO_VERSION' in os.environ:
-            efo_version = os.environ['EFO_VERSION']
-        # Set default version to latest.
-        else:
-            logger.warning('No EFO version specified. Using latest version.')
-            efo_version = 'latest'
+    # Initialize OnToma with persistent caching
+    ontoma_cache_dir = _get_cache_directory(ontoma_cache_dir, efo_version)
+    logger.info(f'Using OnToma cache directory: {ontoma_cache_dir}')
+    try:
+        ontoma_instance = _initialize_ontoma_with_cache(ontoma_cache_dir, efo_version)
+    except Exception as e:
+        logger.error(f'Failed to initialize OnToma: {e}')
+        raise
 
-    logger.info(f'Initialise OnToma instance. Using EFO version {efo_version}')
-    ontoma_instance = OnToma(cache_dir=ontoma_cache_dir, efo_release=efo_version)
+    # Process based on cores configuration
+    if cores > 1:
+        # Parallel processing
+        logger.info(f'Starting parallel EFO mapping with {cores} cores')
+        try:
+            from pandarallel import pandarallel
 
-    logger.info('Map disease information to EFO.')
-    disease_info_to_map['diseaseFromSourceMappedId'] = disease_info_to_map.parallel_apply(
-        _ontoma_udf, args=(ontoma_instance,), axis=1
-    )
+            pandarallel.initialize(nb_workers=cores, progress_bar=True, verbose=1, use_memory_fs=False)
+
+            disease_info_to_map['diseaseFromSourceMappedId'] = disease_info_to_map.parallel_apply(
+                lambda row: _ontoma_udf(row, ontoma_instance), axis=1
+            )
+
+        except Exception as e:
+            logger.error(f'Parallel processing failed: {e}')
+            raise
+    else:
+        # Sequential processing
+        logger.info(f'Using sequential processing with cached OnToma. EFO version: {efo_version}')
+        mapped_ids = []
+
+        for idx, row in disease_info_to_map.iterrows():
+            if idx % 50 == 0:  # Progress logging every 50 rows
+                logger.info(f'Processing disease mapping {idx}/{len(disease_info_to_map)}')
+
+            try:
+                mapped_id = _ontoma_udf(row, ontoma_instance)
+                mapped_ids.append(mapped_id)
+            except Exception as e:
+                logger.warning(f'Error processing row {idx}: {e}')
+                mapped_ids.append([])  # Empty mapping on error
+
+        disease_info_to_map['diseaseFromSourceMappedId'] = mapped_ids
+
     disease_info_to_map = (
         disease_info_to_map.explode('diseaseFromSourceMappedId')
         # Cast all null values to python None to avoid errors in Spark's DF
-        .fillna(nan).replace([nan], [None])
+        .fillna(nan)
+        .replace([nan], [None])
     )
 
-    logger.info('Join the resulting information into the evidence strings.')
-    schema = StructType(
-        [
-            StructField('diseaseFromSource_right', StringType(), True),
-            StructField('diseaseFromSourceId_right', StringType(), True),
-            StructField('diseaseFromSourceMappedId', StringType(), True),
-        ]
-    )
+    schema = StructType([
+        StructField('diseaseFromSource_right', StringType(), True),
+        StructField('diseaseFromSourceId_right', StringType(), True),
+        StructField('diseaseFromSourceMappedId', StringType(), True),
+    ])
     disease_info_df = spark_instance.createDataFrame(disease_info_to_map, schema=schema).withColumn(
         'diseaseFromSourceMappedId',
         when(col('diseaseFromSourceMappedId') != 'nan', col('diseaseFromSourceMappedId')),
     )
+
     # WARNING: Spark's join operator is not null safe by default and most of the times,
     # `diseaseFromSourceId` will be null. `eqNullSafe` is a special null safe equality
     # operator that is used to join the two dataframes.
-    join_cond = (
-        evidence_strings.diseaseFromSource.eqNullSafe(disease_info_df.diseaseFromSource_right)
-    ) & (
+    join_cond = (evidence_strings.diseaseFromSource.eqNullSafe(disease_info_df.diseaseFromSource_right)) & (
         evidence_strings.diseaseFromSourceId.eqNullSafe(disease_info_df.diseaseFromSourceId_right)
     )
     return evidence_strings.join(disease_info_df, on=join_cond, how='left').drop(

--- a/src/test/test_ontology_utils.py
+++ b/src/test/test_ontology_utils.py
@@ -35,20 +35,18 @@ class TestSimpleRetryCI:
         assert result == 10
 
     def test_retry_on_failure(self):
-        """Test that the function retries on failure and eventually succeeds."""
+        """Test that the function fails immediately with 1 max attempt."""
         call_count = 0
 
         def mock_func():
             nonlocal call_count
             call_count += 1
-            if call_count < 3:
-                raise Exception('Temporary failure')
-            return 'success'
+            raise Exception('Failure')
 
         with patch('time.sleep'):  # Mock sleep to speed up test
             result = _simple_retry(mock_func)
-            assert result == 'success'
-            assert call_count == 3
+            assert result == []  # Should return empty list after 1 failed attempt
+            assert call_count == 1
 
     def test_max_attempts_reached(self):
         """Test that the function returns empty list after max attempts."""
@@ -168,19 +166,18 @@ class TestEdgeCasesCI:
 
     def test_ontoma_max_attempts_constant(self):
         """Test that ONTOMA_MAX_ATTEMPTS constant is defined correctly."""
-        assert ONTOMA_MAX_ATTEMPTS == 3
+        assert ONTOMA_MAX_ATTEMPTS == 1
 
     def test_retry_sleep_timing(self):
-        """Test that retry includes appropriate sleep timing."""
+        """Test that retry doesn't sleep with 1 max attempt."""
 
         def mock_func():
             raise Exception('Test exception')
 
         with patch('time.sleep') as mock_sleep, patch('random.random', return_value=0.5):
             _simple_retry(mock_func)
-            # Should sleep 2 times (max attempts - 1 = 3 - 1 = 2)
-            assert mock_sleep.call_count == 2
-            assert all(call[0][0] == 10.0 for call in mock_sleep.call_args_list)
+            # Should not sleep with only 1 attempt
+            assert mock_sleep.call_count == 0
 
     def test_multiple_mappings_explosion(self):
         """Test that multiple mappings are properly handled."""
@@ -241,7 +238,7 @@ class TestAddEfoMapping:
         # Run the test with mocked dependencies
         with (
             patch('pts.utils.ontology.OnToma') as mock_ontoma_class,
-            patch('pts.utils.ontology.pandarallel.initialize'),
+            patch('pandarallel.pandarallel.initialize'),
         ):
             mock_ontoma_class.return_value = mock_ontoma
 
@@ -264,7 +261,7 @@ class TestAddEfoMapping:
 
             try:
                 # Call the function under test
-                result_df = add_efo_mapping(input_df, spark)
+                result_df = add_efo_mapping(input_df, spark, efo_version='v3.81.0', cores=1)
 
                 # Use PySpark's built-in DataFrame comparison
                 assertDataFrameEqual(result_df, expected_df)

--- a/src/test/test_ontology_utils_simple.py
+++ b/src/test/test_ontology_utils_simple.py
@@ -9,61 +9,44 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 def test_module_import():
     """Test that the ontology module can be imported."""
-    try:
-        from pts.utils.ontology import ONTOMA_MAX_ATTEMPTS, _ontoma_udf, _simple_retry, add_efo_mapping
-        assert ONTOMA_MAX_ATTEMPTS == 3
-        assert callable(_simple_retry)
-        assert callable(_ontoma_udf)
-        assert callable(add_efo_mapping)
-        print('✓ All ontology module functions imported successfully')
-        return True
-    except ImportError as e:
-        print(f'✗ Import failed: {e}')
-        return False
+    from pts.utils.ontology import ONTOMA_MAX_ATTEMPTS, _ontoma_udf, _simple_retry, add_efo_mapping
+    assert ONTOMA_MAX_ATTEMPTS == 1
+    assert callable(_simple_retry)
+    assert callable(_ontoma_udf)
+    assert callable(add_efo_mapping)
+    print('✓ All ontology module functions imported successfully')
 
 
 def test_retry_function_basic():
     """Test basic functionality of _simple_retry without external dependencies."""
-    try:
-        from pts.utils.ontology import _simple_retry
+    from pts.utils.ontology import _simple_retry
 
-        # Test successful function
-        def success_func(x):
-            return x * 2
+    # Test successful function
+    def success_func(x):
+        return x * 2
 
-        result = _simple_retry(success_func, x=5)
-        assert result == 10
-        print('✓ _simple_retry works with successful functions')
+    result = _simple_retry(success_func, x=5)
+    assert result == 10
+    print('✓ _simple_retry works with successful functions')
 
-        # Test failing function (should return empty list after max attempts)
-        def fail_func():
-            raise Exception('Test failure')
+    # Test failing function (should return empty list after max attempts)
+    def fail_func():
+        raise Exception('Test failure')
 
-        result = _simple_retry(fail_func)
-        assert result == []
-        print('✓ _simple_retry handles failures correctly')
-
-        return True
-    except Exception as e:
-        print(f'✗ _simple_retry test failed: {e}')
-        return False
+    result = _simple_retry(fail_func)
+    assert result == []
+    print('✓ _simple_retry handles failures correctly')
 
 
 def test_ontoma_udf_basic():
     """Test basic functionality of _ontoma_udf without external dependencies."""
-    try:
-        from pts.utils.ontology import _ontoma_udf
+    from pts.utils.ontology import _ontoma_udf
 
-        # Test with empty row
-        row = {'diseaseFromSource': None, 'diseaseFromSourceId': None}
-        result = _ontoma_udf(row, None)
-        assert result == []
-        print('✓ _ontoma_udf handles empty rows correctly')
-
-        return True
-    except Exception as e:
-        print(f'✗ _ontoma_udf test failed: {e}')
-        return False
+    # Test with empty row
+    row = {'diseaseFromSource': None, 'diseaseFromSourceId': None}
+    result = _ontoma_udf(row, None)
+    assert result == []
+    print('✓ _ontoma_udf handles empty rows correctly')
 
 
 def run_simple_tests():
@@ -81,8 +64,11 @@ def run_simple_tests():
     total = len(tests)
 
     for test in tests:
-        if test():
+        try:
+            test()
             passed += 1
+        except Exception as e:
+            print(f'✗ Test {test.__name__} failed: {e}')
         print()
 
     print('=' * 50)


### PR DESCRIPTION
This PR implements fixes to the disease mapping module that crashes locally when running the process in parallel. 
1. The process is now controlled by a parameter passed to each step that specifies the number of cores allocated for the mapping step:
- If cores == 1, the process runs sequentially (one mapping at a time). This is the default behaviour, very slow but safe. 
- If cores >= 1, the process is run in parallel. This used to be the default behaviour, useful to test if running the parsers in a VM.
2. Update ONTOMA_MAX_ATTEMPTS to 1 for faster processing. Realistically speaking, if ontoma fails is because Zooma is down. There's no point in testing it more than once
3. Fix all failing tests to match new implementation

I have used this branch to generate clingen evidence locally (2h).

**This approach is temporary, as we will be moving on to the new OnToma implementation once the migration is finished.**