### PR TITLE
fix: select all needed cols in chembl_drug_warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.0-dev.34"
+version = "26.03.0-dev.35"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/clinical_report.py
+++ b/src/pts/pyspark/clinical_report.py
@@ -81,7 +81,15 @@ def clinical_report(
         'molregno', 'chembl_id', 'pref_name'
     )
     chembl_drug_warning = pl.read_parquet(source['chembl_drug_warning']).select(
-        'warning_id', 'molregno', 'warning_type', 'warning_year', 'warning_country', 'efo_id', 'efo_term'
+        'warning_id',
+        'molregno',
+        'warning_type',
+        'warning_year',
+        'warning_country',
+        'warning_class',
+        'efo_id',
+        'efo_term',
+        'efo_id_for_warning_class',
     )
     chembl_drug_warning_references = pl.read_parquet(source['chembl_drug_warning_references']).select(
         'warning_id', 'ref_type', 'ref_id', 'ref_url'


### PR DESCRIPTION
Byproduct of this fix in clinical mining https://github.com/opentargets/clinical_mining/pull/42
We use 2 more columns and I had to add them to the select statement

It works 