### PR TITLE
fix: target assignment in moa

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.0-dev.40"
+version = "26.03.0-dev.41"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/drug_mechanism_of_action.py
+++ b/src/pts/pyspark/drug_mechanism_of_action.py
@@ -145,7 +145,11 @@ def _chembl_target(target_df: DataFrame, gene_df: DataFrame) -> DataFrame:
 
     # Get gene IDs from gene data - explode proteinIds
     genes = gene_df.select(
-        f.col('id').alias('geneId'), f.array_union('uniprot_trembl', 'uniprot_swissprot').alias('uniprotIds')
+        f.col('id').alias('geneId'),
+        f.array_union(
+            f.coalesce(f.col('uniprot_trembl'), f.array().cast('array<string>')),
+            f.coalesce(f.col('uniprot_swissprot'), f.array().cast('array<string>')),
+        ).alias('uniprotIds'),
     ).select('geneId', f.explode('uniprotIds').alias('uniprot_id'))
 
     # Join target with genes on uniprot_id or geneId

--- a/uv.lock
+++ b/uv.lock
@@ -2139,7 +2139,7 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "26.3.0.dev40"
+version = "26.3.0.dev41"
 source = { editable = "." }
 dependencies = [
     { name = "clinical-mining" },


### PR DESCRIPTION
# Context

Bug how array columns were merged in drug mechanism of action: some drugs lost their target assignment.

## Tests

```ipython
In [5]: df.filter(f.array_contains(f.col("chemblIds"), "CHEMBL2108724")).show(vertical = True, truncate = False)
-RECORD 0---------------------------------------------------------------------------------------------------------------------------------------
 actionType        | AGONIST
 mechanismOfAction | Glucagon-like peptide 1 receptor agonist
 chemblIds         | [CHEMBL2108724]
 targetName        | Glucagon-like peptide 1 receptor
 targetType        | single protein
 targets           | [ENSG00000112164]
 references        | [{PubMed, [22918257, 24608440], [http://europepmc.org/abstract/MED/22918257, http://europepmc.org/abstract/MED/24608440]}]


In [6]: df.count()
Out[6]: 6505

In [7]: df.filter(f.size('targets') == 0).count()
Out[7]: 736

```