### PR TITLE
feat: add otar pyspark step (migrated from ETL)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,6 +36,17 @@ steps:
       source: input/go/go.obo
       destination: output/go/go.parquet
 
+  #: OTAR STEP :####################################################################################
+  otar:
+    - name: pyspark otar
+      pyspark: otar
+      source:
+        diseases: output/disease
+        otar_meta: input/otar/otar_meta.csv
+        otar_project_to_efo: input/otar/otar_project_to_efo.csv
+      destination: output/otar
+  ##################################################################################################
+
   #: EXPRESSION STEP :##############################################################################
   expression:
     - name: unzip normal tissue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.1"
+version = "26.03.2"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/otar.py
+++ b/src/pts/pyspark/otar.py
@@ -4,6 +4,7 @@ Ported from Otar.scala in platform-etl-backend.
 Joins OTAR project metadata with disease EFO mappings and propagates
 project info to disease ancestors.
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -39,13 +40,15 @@ def _generate_otar_info(
         .withColumn('ancestor', f.explode(f.concat(f.array(f.col('id')), f.col('ancestors'))))
         .groupBy(f.col('ancestor').alias('efo_id'))
         .agg(
-            f.collect_set(f.struct(
-                f.col('otar_code'),
-                f.col('project_status').alias('status'),
-                f.col('project_name'),
-                f.col('integrates_in_PPP').cast('boolean').alias('integrates_data_PPP'),
-                f.concat(f.lit('http://home.opentargets.org/'), f.col('otar_code')).alias('reference'),
-            )).alias('projects')
+            f.collect_set(
+                f.struct(
+                    f.col('otar_code'),
+                    f.col('project_status').alias('status'),
+                    f.col('project_name'),
+                    f.col('integrates_in_PPP').cast('boolean').alias('integrates_data_PPP'),
+                    f.concat(f.lit('http://home.opentargets.org/'), f.col('otar_code')).alias('reference'),
+                )
+            ).alias('projects')
         )
     )
 

--- a/src/pts/pyspark/otar.py
+++ b/src/pts/pyspark/otar.py
@@ -1,0 +1,70 @@
+"""OTAR projects dataset generation.
+
+Ported from Otar.scala in platform-etl-backend.
+Joins OTAR project metadata with disease EFO mappings and propagates
+project info to disease ancestors.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame
+
+from pts.pyspark.common.session import Session
+
+
+def _generate_otar_info(
+    disease: DataFrame,
+    otar_meta: DataFrame,
+    efo_lookup: DataFrame,
+) -> DataFrame:
+    """Generate per-disease OTAR project info with ancestor propagation.
+
+    Args:
+        disease: Disease DataFrame with columns [id, ancestors].
+        otar_meta: OTAR metadata with [otar_code, project_name, project_status, integrates_in_PPP].
+        efo_lookup: Mapping from [otar_code, efo_disease_id].
+
+    Returns:
+        DataFrame with [efo_id, projects[{otar_code, status, project_name,
+        integrates_data_PPP, reference}]].
+    """
+    joined = otar_meta.join(efo_lookup, 'otar_code', 'left_outer')
+    return (
+        joined
+        .withColumnRenamed('efo_disease_id', 'efo_code')
+        .join(disease, f.col('efo_code') == f.col('id'), 'inner')
+        .withColumn('ancestor', f.explode(f.concat(f.array(f.col('id')), f.col('ancestors'))))
+        .groupBy(f.col('ancestor').alias('efo_id'))
+        .agg(
+            f.collect_set(f.struct(
+                f.col('otar_code'),
+                f.col('project_status').alias('status'),
+                f.col('project_name'),
+                f.col('integrates_in_PPP').cast('boolean').alias('integrates_data_PPP'),
+                f.concat(f.lit('http://home.opentargets.org/'), f.col('otar_code')).alias('reference'),
+            )).alias('projects')
+        )
+    )
+
+
+def otar(
+    source: dict[str, str],
+    destination: str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate OTAR projects dataset."""
+    spark = Session(app_name='otar', properties=properties).spark
+
+    logger.info('Reading otar inputs')
+    disease = spark.read.parquet(source['diseases'])
+    meta = spark.read.option('sep', ',').option('header', 'true').csv(source['otar_meta'])
+    lookup = spark.read.option('sep', ',').option('header', 'true').csv(source['otar_project_to_efo'])
+
+    result = _generate_otar_info(disease, meta, lookup)
+
+    logger.info(f'Writing otar output to {destination}')
+    result.write.mode('overwrite').parquet(destination)

--- a/test/test_otar.py
+++ b/test/test_otar.py
@@ -1,0 +1,43 @@
+"""Tests for the otar PySpark module."""
+from __future__ import annotations
+
+import pytest
+from pyspark.sql import SparkSession
+
+from pts.pyspark.otar import _generate_otar_info
+
+
+class TestGenerateOtarInfo:
+    def test_propagates_to_ancestors(self, spark: SparkSession) -> None:
+        disease = spark.createDataFrame(
+            [('EFO:0001', ['EFO:0001', 'EFO:ROOT'])],
+            'id STRING, ancestors ARRAY<STRING>',
+        )
+        meta = spark.createDataFrame(
+            [('OTAR001', 'Project Alpha', 'Active', 'false')],
+            'otar_code STRING, project_name STRING, project_status STRING, integrates_in_PPP STRING',
+        )
+        lookup = spark.createDataFrame(
+            [('OTAR001', 'EFO:0001')],
+            'otar_code STRING, efo_disease_id STRING',
+        )
+        result = _generate_otar_info(disease, meta, lookup)
+        efo_ids = {r['efo_id'] for r in result.collect()}
+        assert 'EFO:ROOT' in efo_ids  # propagated to ancestor
+
+    def test_includes_reference_url(self, spark: SparkSession) -> None:
+        disease = spark.createDataFrame(
+            [('EFO:0001', ['EFO:0001'])],
+            'id STRING, ancestors ARRAY<STRING>',
+        )
+        meta = spark.createDataFrame(
+            [('OTAR001', 'Project Alpha', 'Active', 'false')],
+            'otar_code STRING, project_name STRING, project_status STRING, integrates_in_PPP STRING',
+        )
+        lookup = spark.createDataFrame(
+            [('OTAR001', 'EFO:0001')],
+            'otar_code STRING, efo_disease_id STRING',
+        )
+        result = _generate_otar_info(disease, meta, lookup)
+        project = result.collect()[0]['projects'][0]
+        assert project['reference'] == 'http://home.opentargets.org/OTAR001'

--- a/test/test_otar.py
+++ b/test/test_otar.py
@@ -1,7 +1,7 @@
 """Tests for the otar PySpark module."""
+
 from __future__ import annotations
 
-import pytest
 from pyspark.sql import SparkSession
 
 from pts.pyspark.otar import _generate_otar_info


### PR DESCRIPTION
## Summary

- Ports `Otar.scala` from `platform-etl-backend` to PySpark as `pts/src/pts/pyspark/otar.py`
- Joins OTAR project metadata with disease EFO mappings and propagates project info to disease ancestors
- Adds `test/test_otar.py` with two tests covering ancestor propagation and reference URL generation

## Test plan

- [x] `test_propagates_to_ancestors` — verifies project info is propagated to ancestor EFO IDs
- [x] `test_includes_reference_url` — verifies `http://home.opentargets.org/<otar_code>` reference URL is generated

Closes https://github.com/opentargets/issues/issues/4347