### PR TITLE
feat: add target pyspark step (migrated from ETL)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -256,7 +256,10 @@ steps:
         uniprot: intermediate/target/uniprot/uniprot.parquet
         chembl: input/target/chembl/chembl_target.jsonl
         chemical_probes: intermediate/chemical_probes_evidence.parquet
-      destination: output/target
+        gene_essentiality: intermediate/target/gene-essentiality/essentiality.parquet
+      destination:
+        target: output/target
+        gene_essentiality: output/target_essentiality
   ##################################################################################################
 
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now

--- a/config.yaml
+++ b/config.yaml
@@ -170,8 +170,8 @@ steps:
       transformer: so
   ##################################################################################################
 
-  #: TARGET STEP :##################################################################################
-  target:
+  #: PRE_TARGET STEP :##############################################################################
+  pre_target:
     - name: unzip subcellular location
       source: input/target/hpa/subcellular_location.tsv.zip
       destination: intermediate/target/hpa/subcellular_location.tsv
@@ -218,6 +218,40 @@ steps:
           source: ${uri}
           destination: intermediate/target/homologue/gene_dictionary/${match_path}/${match_stem}.parquet
           transformer: homology
+  ##################################################################################################
+
+  #: TARGET STEP (pyspark) :#######################################################################
+  target:
+    - name: pyspark target
+      pyspark: target
+      source:
+        diseases: output/disease
+        ensembl: intermediate/target/ensembl/homo_sapiens.parquet
+        gene_code: input/target/gencode/gencode.gff3.gz
+        genetic_constraints: input/target/gnomad/gnomad_constraint_metrics.tsv
+        gene_ontology_human: input/target/go/goa_human.gaf.gz
+        gene_ontology_rna: input/target/go/goa_human_rna.gaf.gz
+        gene_ontology_rna_lookup: input/target/go/ensembl.tsv
+        gene_ontology_eco_lookup: input/target/go/goa_human_eco.gpa.gz
+        hallmarks: input/target/hallmarks/cosmic-hallmarks.tsv.gz
+        hgnc: input/target/gennames/hgnc_complete_set.json
+        homology_dictionary: input/target/homologue/species_EnsemblVertebrates.txt
+        homology_coding_proteins: input/target/homologue/homologies/*.tsv.gz
+        homology_gene_dictionary: intermediate/target/homologue/gene_dictionary/*.parquet
+        hpa: intermediate/target/hpa/subcellular_location.tsv.gz
+        hpa_sl: intermediate/target/hpa/subcellular_locations_ssl.parquet
+        ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
+        project_scores_ids: intermediate/target/project-scores/gene_identifiers_latest.parquet
+        project_scores_essentiality_matrix: intermediate/target/project-scores/04_binaryDepScores.parquet
+        reactome_etl: output/reactome
+        reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
+        safety_evidence: intermediate/target/safety.parquet
+        tep: input/target/tep/tep.json.gz
+        tractability: input/target/tractability/tractability.tsv
+        uniprot: input/target/uniprot/uniprot-reviewed_human.xml.gz
+        chembl: input/target/chembl/chembl_target.jsonl
+        chemical_probes: intermediate/chemical_probes_evidence.parquet
+      destination: output/target
   ##################################################################################################
 
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now

--- a/config.yaml
+++ b/config.yaml
@@ -218,6 +218,11 @@ steps:
           source: ${uri}
           destination: intermediate/target/homologue/gene_dictionary/${match_path}/${match_stem}.parquet
           transformer: homology
+
+    - name: transform uniprot
+      transformer: uniprot
+      source: input/target/uniprot/uniprot.txt.gz
+      destination: intermediate/target/uniprot/uniprot.parquet
   ##################################################################################################
 
   #: TARGET STEP (pyspark) :#######################################################################
@@ -234,7 +239,7 @@ steps:
         gene_ontology_rna_lookup: input/target/go/ensembl.tsv
         gene_ontology_eco_lookup: input/target/go/goa_human_eco.gpa.gz
         hallmarks: input/target/hallmarks/cosmic-hallmarks.tsv.gz
-        hgnc: input/target/gennames/hgnc_complete_set.json
+        hgnc: input/target/genenames/hgnc_complete_set.json
         homology_dictionary: input/target/homologue/species_EnsemblVertebrates.txt
         homology_coding_proteins: input/target/homologue/homologies/*.tsv.gz
         homology_gene_dictionary: intermediate/target/homologue/gene_dictionary/*.parquet
@@ -248,7 +253,7 @@ steps:
         safety_evidence: intermediate/target/safety.parquet
         tep: input/target/tep/tep.json.gz
         tractability: input/target/tractability/tractability.tsv
-        uniprot: input/target/uniprot/uniprot-reviewed_human.xml.gz
+        uniprot: intermediate/target/uniprot/uniprot.parquet
         chembl: input/target/chembl/chembl_target.jsonl
         chemical_probes: intermediate/chemical_probes_evidence.parquet
       destination: output/target

--- a/config.yaml
+++ b/config.yaml
@@ -254,6 +254,7 @@ steps:
         tep: input/target/tep/tep.json.gz
         tractability: input/target/tractability/tractability.tsv
         uniprot: intermediate/target/uniprot/uniprot.parquet
+        uniprot_ssl: input/target/uniprot/uniprot-ssl.tsv.gz
         chembl: input/target/chembl/chembl_target.jsonl
         chemical_probes: intermediate/chemical_probes_evidence.parquet
         gene_essentiality: intermediate/target/gene-essentiality/essentiality.parquet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.11"
+version = "26.03.12"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/common/utils.py
+++ b/src/pts/pyspark/common/utils.py
@@ -283,3 +283,11 @@ def rename_columns_to_camel_case(df: DataFrame) -> DataFrame:
 
     new_schema = _transform_schema(df.schema)
     return df.sparkSession.createDataFrame(df.rdd, new_schema)
+
+
+def safe_array_union(*cols: Column) -> Column:
+    """Return union of multiple array columns, treating nulls as empty arrays."""
+    result = f.coalesce(cols[0], f.array())
+    for col in cols[1:]:
+        result = f.array_union(result, f.coalesce(col, f.array()))
+    return result

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -22,6 +22,7 @@ Scala sources ported:
     - Tractability.scala
     - Uniprot.scala
 """
+
 from __future__ import annotations
 
 from typing import Any
@@ -128,71 +129,22 @@ def target(
 
     # --- read inputs --------------------------------------------------------
     ensembl_raw = spark.read.parquet(source['ensembl'])
-    gene_code_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('comment', '#')
-        .csv(source['gene_code'])
-    )
+    gene_code_raw = spark.read.option('sep', '\t').option('comment', '#').csv(source['gene_code'])
     hgnc_raw = spark.read.option('multiline', 'true').json(source['hgnc'])
-    hallmarks_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['hallmarks'])
-    )
-    ncbi_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['ncbi'])
-    )
-    go_human_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('comment', '!')
-        .csv(source['gene_ontology_human'])
-    )
-    go_rna_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('comment', '!')
-        .csv(source['gene_ontology_rna'])
-    )
-    go_rna_lookup_raw = (
-        spark.read
-        .option('sep', '\t')
-        .csv(source['gene_ontology_rna_lookup'])
-    )
-    go_eco_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('comment', '!', )
-        .csv(source['gene_ontology_eco_lookup'])
-    )
+    hallmarks_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['hallmarks'])
+    ncbi_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['ncbi'])
+    go_human_raw = spark.read.option('sep', '\t').option('comment', '!').csv(source['gene_ontology_human'])
+    go_rna_raw = spark.read.option('sep', '\t').option('comment', '!').csv(source['gene_ontology_rna'])
+    go_rna_lookup_raw = spark.read.option('sep', '\t').csv(source['gene_ontology_rna_lookup'])
+    go_eco_raw = spark.read.option('sep', '\t').option('comment', '!').csv(source['gene_ontology_eco_lookup'])
     tep_raw = spark.read.option('multiline', 'true').json(source['tep'])
-    hpa_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['hpa'])
-    )
+    hpa_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['hpa'])
     hpa_sl_raw = spark.read.parquet(source['hpa_sl'])
     ps_ids_raw = spark.read.parquet(source['project_scores_ids'])
     ps_matrix_raw = spark.read.parquet(source['project_scores_essentiality_matrix'])
     chembl_raw = spark.read.json(source['chembl'])
-    genetic_constraints_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['genetic_constraints'])
-    )
-    homology_dict_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['homology_dictionary'])
-    )
+    genetic_constraints_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['genetic_constraints'])
+    homology_dict_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['homology_dictionary'])
     homology_coding_proteins_raw = (
         spark.read
         .option('recursiveFileLookup', 'true')
@@ -200,23 +152,12 @@ def target(
         .option('header', 'true')
         .csv(source['homology_coding_proteins'])
     )
-    homology_gene_dict_raw = (
-        spark.read
-        .option('recursiveFileLookup', 'true')
-        .parquet(source['homology_gene_dictionary'])
+    homology_gene_dict_raw = spark.read.option('recursiveFileLookup', 'true').parquet(
+        source['homology_gene_dictionary']
     )
-    reactome_pathways_raw = (
-        spark.read
-        .option('sep', '\t')
-        .csv(source['reactome_pathways'])
-    )
+    reactome_pathways_raw = spark.read.option('sep', '\t').csv(source['reactome_pathways'])
     reactome_etl_raw = spark.read.parquet(source['reactome_etl'])
-    tractability_raw = (
-        spark.read
-        .option('sep', '\t')
-        .option('header', 'true')
-        .csv(source['tractability'])
-    )
+    tractability_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['tractability'])
     safety_raw = spark.read.parquet(source['safety_evidence'])
     diseases_raw = spark.read.parquet(source['diseases'])
     chemical_probes_raw = spark.read.parquet(source['chemical_probes'])
@@ -225,7 +166,6 @@ def target(
     # produced by the pts_target pre-processing step (uniprot XML→parquet).
     # The pre-processing step writes a parquet with UniprotEntry fields.
     uniprot_raw = spark.read.parquet(source['uniprot'])
-    uniprot_ssl_raw = spark.read.parquet(source['hpa_sl'])  # shared ssl ontology
 
     # --- species whitelist from settings ------------------------------------
     hgnc_ortholog_species: list[str] = settings.get(
@@ -286,8 +226,10 @@ def target(
 
     logger.info('Building Homologues')
     homology_df = _build_homologues(
-        homology_dict_raw, homology_coding_proteins_raw,
-        homology_gene_dict_raw, hgnc_ortholog_species,
+        homology_dict_raw,
+        homology_coding_proteins_raw,
+        homology_gene_dict_raw,
+        hgnc_ortholog_species,
     )
 
     logger.info('Building Reactome')
@@ -298,7 +240,7 @@ def target(
 
     # --- Uniprot (pre-processed parquet schema mirrors UniprotEntry) --------
     logger.info('Building Uniprot')
-    uniprot_df = _build_uniprot(uniprot_raw, uniprot_ssl_raw)
+    uniprot_df = _build_uniprot(uniprot_raw, hpa_sl_raw)
 
     # --- Merge ---------------------------------------------------------------
     logger.info('Merging HGNC + Ensembl + GO + ProjectScores + Hallmarks')
@@ -343,8 +285,16 @@ def target(
         .withColumn('obsoleteSymbols', _safe_array_union(f.col('hgncObsoleteSymbols')))
         .withColumn('obsoleteNames', _safe_array_union(f.col('hgncObsoleteNames')))
         .drop(
-            'pid', 'hgncId', 'hgncSynonyms', 'hgncNameSynonyms', 'hgncSymbolSynonyms',
-            'hgncObsoleteNames', 'hgncObsoleteSymbols', 'uniprotIds', 'signalP', 'xRef',
+            'pid',
+            'hgncId',
+            'hgncSynonyms',
+            'hgncNameSynonyms',
+            'hgncSymbolSynonyms',
+            'hgncObsoleteNames',
+            'hgncObsoleteSymbols',
+            'uniprotIds',
+            'signalP',
+            'xRef',
         )
         .persist()
     )
@@ -381,6 +331,7 @@ def target(
 # Helper: safe array union (mirrors Spark Helpers.safeArrayUnion in Scala)
 # ===========================================================================
 
+
 def _safe_array_union(*cols):
     """Return union of multiple array columns, treating nulls as empty arrays."""
     result = f.coalesce(cols[0], f.array())
@@ -392,6 +343,7 @@ def _safe_array_union(*cols):
 # ===========================================================================
 # GeneCode.scala → _build_gene_code
 # ===========================================================================
+
 
 def _build_gene_code(df: DataFrame) -> DataFrame:
     """Extract canonical transcripts from GFF3 gene-code file.
@@ -416,8 +368,7 @@ def _build_gene_code(df: DataFrame) -> DataFrame:
         .select(
             f.regexp_extract(f.col('gene_id_raw'), r'(.*?)\.', 1).alias('id'),
             f.regexp_extract(f.col('transcript_id_raw'), r'(.*?)\.', 1).alias('ct_id'),
-            f.when(f.col('chromosome_raw') == 'M', 'MT')
-             .otherwise(f.col('chromosome_raw')).alias('chromosome'),
+            f.when(f.col('chromosome_raw') == 'M', 'MT').otherwise(f.col('chromosome_raw')).alias('chromosome'),
             'start',
             'end',
             'strand',
@@ -441,6 +392,7 @@ def _build_gene_code(df: DataFrame) -> DataFrame:
 # Ensembl.scala → _filter_ensembl / _build_ensembl
 # ===========================================================================
 
+
 def _filter_ensembl(df: DataFrame) -> DataFrame:
     """Filter Ensembl genes to canonical chromosomes + reviewed genes.
 
@@ -450,13 +402,8 @@ def _filter_ensembl(df: DataFrame) -> DataFrame:
     Returns:
         Filtered DataFrame.
     """
-    return (
-        df
-        .filter(f.col('id').startswith('ENSG'))
-        .filter(
-            f.col('chromosome').isin(INCLUDE_CHROMOSOMES)
-            | f.col('uniprot_swissprot').isNotNull()
-        )
+    return df.filter(f.col('id').startswith('ENSG')).filter(
+        f.col('chromosome').isin(INCLUDE_CHROMOSOMES) | f.col('uniprot_swissprot').isNotNull()
     )
 
 
@@ -487,9 +434,11 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
             f.col('strand').cast(IntegerType()).alias('strand'),
             f.col('chromosome'),
             f.col('approvedSymbol'),
-            (f.col('transcripts') if has_transcripts else f.lit(None).cast(
-                ArrayType(StructType([StructField('id', StringType())]))
-            )).alias('transcripts_raw'),
+            (
+                f.col('transcripts')
+                if has_transcripts
+                else f.lit(None).cast(ArrayType(StructType([StructField('id', StringType())])))
+            ).alias('transcripts_raw'),
             f.col('signalP') if 'signalP' in df.columns else f.lit(None).alias('signalP'),
             f.col('uniprot_trembl') if 'uniprot_trembl' in df.columns else f.lit(None).alias('uniprot_trembl'),
             f.col('uniprot_swissprot') if 'uniprot_swissprot' in df.columns else f.lit(None).alias('uniprot_swissprot'),
@@ -499,16 +448,11 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
     )
 
     # Join canonical transcript
-    ensembl = (
-        ensembl
-        .join(
-            gene_code.withColumnRenamed('gene_id', 'ct_gene_id'),
-            (ensembl['id'] == f.col('ct_gene_id'))
-            & (ensembl['chromosome'] == f.col('canonicalTranscript.chromosome')),
-            'left_outer',
-        )
-        .drop('ct_gene_id')
-    )
+    ensembl = ensembl.join(
+        gene_code.withColumnRenamed('gene_id', 'ct_gene_id'),
+        (ensembl['id'] == f.col('ct_gene_id')) & (ensembl['chromosome'] == f.col('canonicalTranscript.chromosome')),
+        'left_outer',
+    ).drop('ct_gene_id')
 
     # Build genomicLocation struct
     ensembl = ensembl.withColumn(
@@ -525,39 +469,44 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
     ensembl = (
         ensembl
         .withColumn('_desc_parts', f.split(f.col('description'), r'\['))
-        .withColumn('approvedName',
-                    f.regexp_replace(f.element_at(f.col('_desc_parts'), 1), r'(?i)tec', ''))
+        .withColumn('approvedName', f.regexp_replace(f.element_at(f.col('_desc_parts'), 1), r'(?i)tec', ''))
         .drop('_desc_parts', 'description')
     )
 
     # Parse transcripts: extract id, biotype, uniprotId, etc.
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
 
     # Build proteinIds from uniprot columns
     ensembl = _refactor_ensembl_protein_ids(ensembl)
 
     # Build signalP
-    ensembl = (
-        ensembl
-        .withColumn(
-            'signalP',
-            f.when(
-                f.size(f.col('signalP')) >= 0,
-                f.transform(f.col('signalP'), lambda c: f.struct(c.alias('id'), f.lit('signalP').alias('source'))),
-            ).cast(id_source_schema),
-        )
+    ensembl = ensembl.withColumn(
+        'signalP',
+        f.when(
+            f.size(f.col('signalP')) >= 0,
+            f.transform(f.col('signalP'), lambda c: f.struct(c.alias('id'), f.lit('signalP').alias('source'))),
+        ).cast(id_source_schema),
     )
 
     # Parse transcripts into the structured format
     ensembl = _parse_ensembl_transcripts(ensembl)
 
     return ensembl.select(
-        'id', 'biotype', 'approvedName', 'alternativeGenes',
-        'genomicLocation', 'approvedSymbol', 'proteinIds', 'transcripts',
-        'signalP', 'canonicalTranscript',
+        'id',
+        'biotype',
+        'approvedName',
+        'alternativeGenes',
+        'genomicLocation',
+        'approvedSymbol',
+        'proteinIds',
+        'transcripts',
+        'signalP',
+        'canonicalTranscript',
     )
 
 
@@ -566,38 +515,50 @@ def _refactor_ensembl_protein_ids(df: DataFrame) -> DataFrame:
 
     Also sets alternativeGenes to null (filled later).
     """
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
 
     has_translations = 'translations' in df.columns
 
-    swiss = (
-        f.when(
-            f.size(f.col('uniprot_swissprot')) >= 0,
-            f.transform(f.col('uniprot_swissprot'), lambda c: f.struct(c.alias('id'), f.lit('uniprot_swissprot').alias('source'))),
-        ).cast(id_source_schema)
-    )
-    trembl = (
-        f.when(
-            f.size(f.col('uniprot_trembl')) >= 0,
-            f.transform(f.col('uniprot_trembl'), lambda c: f.struct(c.alias('id'), f.lit('uniprot_trembl').alias('source'))),
-        ).cast(id_source_schema)
-    )
+    swiss = f.when(
+        f.size(f.col('uniprot_swissprot')) >= 0,
+        f.transform(
+            f.col('uniprot_swissprot'),
+            lambda c: f.struct(c.alias('id'), f.lit('uniprot_swissprot').alias('source')),
+        ),
+    ).cast(id_source_schema)
+    trembl = f.when(
+        f.size(f.col('uniprot_trembl')) >= 0,
+        f.transform(
+            f.col('uniprot_trembl'),
+            lambda c: f.struct(c.alias('id'), f.lit('uniprot_trembl').alias('source')),
+        ),
+    ).cast(id_source_schema)
 
     df = df.withColumn('_swiss', swiss).withColumn('_trembl', trembl)
 
     if has_translations:
-        ensembl_pro = (
-            f.when(
-                f.size(f.col('translations')) >= 0,
-                f.transform(f.col('translations'), lambda c: f.struct(c.getField('id').alias('id'), f.lit('ensembl_PRO').alias('source'))),
-            ).cast(id_source_schema)
-        )
+        ensembl_pro = f.when(
+            f.size(f.col('translations')) >= 0,
+            f.transform(
+                f.col('translations'),
+                lambda c: f.struct(c.getField('id').alias('id'), f.lit('ensembl_PRO').alias('source')),
+            ),
+        ).cast(id_source_schema)
         df = df.withColumn('_ensembl_pro', ensembl_pro)
         protein_ids = _safe_array_union(f.col('_swiss'), f.col('_trembl'), f.col('_ensembl_pro'))
-        df = df.withColumn('proteinIds', protein_ids).drop('_swiss', '_trembl', '_ensembl_pro', 'translations', 'uniprot_swissprot', 'uniprot_trembl')
+        df = df.withColumn('proteinIds', protein_ids).drop(
+            '_swiss',
+            '_trembl',
+            '_ensembl_pro',
+            'translations',
+            'uniprot_swissprot',
+            'uniprot_trembl',
+        )
     else:
         protein_ids = _safe_array_union(f.col('_swiss'), f.col('_trembl'))
         df = df.withColumn('proteinIds', protein_ids).drop('_swiss', '_trembl', 'uniprot_swissprot', 'uniprot_trembl')
@@ -607,16 +568,18 @@ def _refactor_ensembl_protein_ids(df: DataFrame) -> DataFrame:
 
 def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
     """Parse raw transcripts array into structured transcript objects."""
-    transcript_schema = ArrayType(StructType([
-        StructField('transcriptId', StringType()),
-        StructField('biotype', StringType()),
-        StructField('uniprotId', StringType()),
-        StructField('isUniprotReviewed', StringType()),
-        StructField('translationId', StringType()),
-        StructField('alphafoldId', StringType()),
-        StructField('uniprotIsoformId', StringType()),
-        StructField('isEnsemblCanonical', StringType()),
-    ]))
+    transcript_schema = ArrayType(
+        StructType([
+            StructField('transcriptId', StringType()),
+            StructField('biotype', StringType()),
+            StructField('uniprotId', StringType()),
+            StructField('isUniprotReviewed', StringType()),
+            StructField('translationId', StringType()),
+            StructField('alphafoldId', StringType()),
+            StructField('uniprotIsoformId', StringType()),
+            StructField('isEnsemblCanonical', StringType()),
+        ])
+    )
 
     if 'transcripts_raw' not in df.columns:
         return df.withColumn('transcripts', f.lit(None).cast(transcript_schema))
@@ -628,12 +591,14 @@ def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
             lambda tr: f.struct(
                 tr.getField('id').alias('transcriptId'),
                 tr.getField('biotype').alias('biotype'),
-                f.when(tr.getField('uniprot_swissprot').isNotNull(), f.element_at(tr.getField('uniprot_swissprot'), 1))
-                 .when(tr.getField('uniprot_trembl').isNotNull(), f.element_at(tr.getField('uniprot_trembl'), 1))
-                 .alias('uniprotId'),
-                f.when(tr.getField('uniprot_swissprot').isNotNull(), f.lit('true'))
-                 .when(tr.getField('uniprot_trembl').isNotNull(), f.lit('false'))
-                 .alias('isUniprotReviewed'),
+                f
+                .when(tr.getField('uniprot_swissprot').isNotNull(), f.element_at(tr.getField('uniprot_swissprot'), 1))
+                .when(tr.getField('uniprot_trembl').isNotNull(), f.element_at(tr.getField('uniprot_trembl'), 1))
+                .alias('uniprotId'),
+                f
+                .when(tr.getField('uniprot_swissprot').isNotNull(), f.lit('true'))
+                .when(tr.getField('uniprot_trembl').isNotNull(), f.lit('false'))
+                .alias('isUniprotReviewed'),
                 f.when(
                     tr.getField('translations').isNotNull(),
                     f.element_at(tr.getField('translations'), 1).getField('id'),
@@ -658,6 +623,7 @@ def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
 # Hgnc.scala → _build_hgnc
 # ===========================================================================
 
+
 def _build_hgnc(df: DataFrame) -> DataFrame:
     """Build the HGNC mapping DataFrame.
 
@@ -669,14 +635,18 @@ def _build_hgnc(df: DataFrame) -> DataFrame:
         hgncSynonyms, hgncSymbolSynonyms, hgncNameSynonyms,
         hgncObsoleteSymbols, hgncObsoleteNames, uniprotIds].
     """
-    label_source_schema = ArrayType(StructType([
-        StructField('label', StringType()),
-        StructField('source', StringType()),
-    ]))
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
+    label_source_schema = ArrayType(
+        StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
 
     docs = df.select(f.explode(f.col('response.docs')).alias('doc')).select('doc.*')
 
@@ -695,20 +665,25 @@ def _build_hgnc(df: DataFrame) -> DataFrame:
             f.col('name').alias('approvedName'),
             f.col('uniprot_ids').alias('uniprotIds'),
             _safe_array_union(
-                f.col('prev_name'), f.col('prev_symbol'),
-                f.col('alias_symbol'), f.col('alias_name'),
+                f.col('prev_name'),
+                f.col('prev_symbol'),
+                f.col('alias_symbol'),
+                f.col('alias_name'),
             ).alias('_all_synonyms'),
             _safe_array_union(f.col('alias_symbol')).alias('_symbol_synonyms'),
             _safe_array_union(f.col('alias_name')).alias('_name_synonyms'),
             _safe_array_union(f.col('prev_symbol')).alias('_obsolete_symbols'),
             _safe_array_union(f.col('prev_name')).alias('_obsolete_names'),
         )
-        .withColumn('hgncId', f.array(
-            f.struct(
-                f.element_at(f.col('_hgnc_parts'), 2).alias('id'),
-                f.element_at(f.col('_hgnc_parts'), 1).alias('source'),
-            )
-        ).cast(id_source_schema))
+        .withColumn(
+            'hgncId',
+            f.array(
+                f.struct(
+                    f.element_at(f.col('_hgnc_parts'), 2).alias('id'),
+                    f.element_at(f.col('_hgnc_parts'), 1).alias('source'),
+                )
+            ).cast(id_source_schema),
+        )
         .drop('_hgnc_parts')
     )
 
@@ -731,6 +706,7 @@ def _build_hgnc(df: DataFrame) -> DataFrame:
 # Hallmarks.scala → _build_hallmarks
 # ===========================================================================
 
+
 def _build_hallmarks(df: DataFrame) -> DataFrame:
     """Build the hallmarks DataFrame.
 
@@ -742,17 +718,13 @@ def _build_hallmarks(df: DataFrame) -> DataFrame:
     """
     cancer_hallmarks_list = list(CANCER_HALLMARKS)
 
-    processed = (
-        df
-        .select(
-            f.col('GENE_SYMBOL').alias('gene_symbol'),
-            f.col('PUBMED_PMID').cast(LongType()).alias('pmid'),
-            f.col('HALLMARK').alias('hallmark'),
-            f.col('IMPACT').alias('impact'),
-            f.col('DESCRIPTION').alias('description'),
-        )
-        .withColumn('is_cancer_hallmark', f.col('hallmark').isin(cancer_hallmarks_list))
-    )
+    processed = df.select(
+        f.col('GENE_SYMBOL').alias('gene_symbol'),
+        f.col('PUBMED_PMID').cast(LongType()).alias('pmid'),
+        f.col('HALLMARK').alias('hallmark'),
+        f.col('IMPACT').alias('impact'),
+        f.col('DESCRIPTION').alias('description'),
+    ).withColumn('is_cancer_hallmark', f.col('hallmark').isin(cancer_hallmarks_list))
 
     cancer_df = (
         processed
@@ -786,7 +758,9 @@ def _build_hallmarks(df: DataFrame) -> DataFrame:
     )
 
     return (
-        processed.select('gene_symbol').distinct()
+        processed
+        .select('gene_symbol')
+        .distinct()
         .join(cancer_df, 'gene_symbol', 'left_outer')
         .join(attrs_df, 'gene_symbol', 'left_outer')
         .select(
@@ -803,6 +777,7 @@ def _build_hallmarks(df: DataFrame) -> DataFrame:
 # Ncbi.scala → _build_ncbi
 # ===========================================================================
 
+
 def _build_ncbi(df: DataFrame) -> DataFrame:
     """Build NCBI Entrez synonym DataFrame.
 
@@ -812,10 +787,12 @@ def _build_ncbi(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with [id, synonyms, symbolSynonyms, nameSynonyms] (LabelAndSource arrays).
     """
-    label_source_schema = ArrayType(StructType([
-        StructField('label', StringType()),
-        StructField('source', StringType()),
-    ]))
+    label_source_schema = ArrayType(
+        StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
 
     sep = r'\|'
 
@@ -865,6 +842,7 @@ def _build_ncbi(df: DataFrame) -> DataFrame:
 # GeneOntology.scala → _build_gene_ontology
 # ===========================================================================
 
+
 def _build_gene_ontology(
     human: DataFrame,
     rna: DataFrame,
@@ -884,20 +862,24 @@ def _build_gene_ontology(
     Returns:
         DataFrame with [ensemblId, go[{id, source, evidence, aspect, geneProduct, ecoId}]].
     """
-    go_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-        StructField('evidence', StringType()),
-        StructField('aspect', StringType()),
-        StructField('geneProduct', StringType()),
-        StructField('ecoId', StringType()),
-    ]))
-
     col_names = [
-        'database', 'dbObjectId', 'dbObjectSymbol', 'qualifier', 'goId',
-        'source', 'evidence', 'withOrFrom', 'aspect', 'dbObjectName',
-        'dbObjectSynonym', 'dbObjectType', 'taxon', 'date', 'assignedBy',
-        'annotationExtension', 'geneProductFormId',
+        'database',
+        'dbObjectId',
+        'dbObjectSymbol',
+        'qualifier',
+        'goId',
+        'source',
+        'evidence',
+        'withOrFrom',
+        'aspect',
+        'dbObjectName',
+        'dbObjectSynonym',
+        'dbObjectType',
+        'taxon',
+        'date',
+        'assignedBy',
+        'annotationExtension',
+        'geneProductFormId',
     ]
 
     def _extract_go_cols(df):
@@ -925,7 +907,8 @@ def _build_gene_ontology(
     rna_lu_cols = ['rnaCentralId', 'database', 'externalId', 'ncbiTaxonId', 'rnaType', 'ensemblId']
     n_rna = len(rna_lookup.columns)
     rna_lu = (
-        rna_lookup.toDF(*rna_lu_cols[:n_rna])
+        rna_lookup
+        .toDF(*rna_lu_cols[:n_rna])
         .select('rnaCentralId', 'ensemblId')
         .filter(f.col('ensemblId').startswith('ENSG0'))
         .withColumn('ensemblId', f.regexp_extract(f.col('ensemblId'), r'ENSG[0-9]+', 0))
@@ -949,18 +932,15 @@ def _build_gene_ontology(
 
     # ECO lookup: (goId, geneProduct, evidence) → ecoId
     if eco_lookup.columns and len(eco_lookup.columns) >= 12:
-        eco_lu = (
-            eco_lookup
-            .select(
-                f.col('_c3').alias('goId'),
-                f.col('_c1').alias('geneProduct'),
-                f.element_at(f.split(f.col('_c11'), '='), 2).alias('evidence'),
-                f.col('_c5').alias('ecoId'),
-            )
-            .distinct()
-        )
+        eco_lu = eco_lookup.select(
+            f.col('_c3').alias('goId'),
+            f.col('_c1').alias('geneProduct'),
+            f.element_at(f.split(f.col('_c11'), '='), 2).alias('evidence'),
+            f.col('_c5').alias('ecoId'),
+        ).distinct()
     else:
         from pyspark.sql import SparkSession
+
         spark = SparkSession.getActiveSession()
         eco_lu = spark.createDataFrame(
             [],
@@ -1020,6 +1000,7 @@ def _build_gene_ontology(
 # GeneWithLocation.scala → _build_gene_with_location
 # ===========================================================================
 
+
 def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
     """Build subcellular locations from HPA data.
 
@@ -1030,12 +1011,6 @@ def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with [id, locations[{location, source, termSL, labelSL}]].
     """
-    location_source_schema = ArrayType(StructType([
-        StructField('location', StringType()),
-        StructField('source', StringType()),
-        StructField('termSL', StringType()),
-        StructField('labelSL', StringType()),
-    ]))
 
     def _to_loc_source(col_expr, source_val):
         return f.when(
@@ -1046,17 +1021,22 @@ def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
             ),
         )
 
-    hpa = (
+    return (
         df
         .select(
             f.col('Gene').alias('id'),
             _to_loc_source(f.col('Main location'), 'HPA_main').alias('HPA_main'),
             _to_loc_source(f.col('Additional location'), 'HPA_additional').alias('HPA_additional'),
-            _to_loc_source(f.col('Extracellular location'), 'HPA_extracellular_location').alias('HPA_extracellular_location'),
+            _to_loc_source(
+                f.col('Extracellular location'),
+                'HPA_extracellular_location',
+            ).alias('HPA_extracellular_location'),
         )
         .withColumn(
             'all_locations',
-            f.explode(_safe_array_union(f.col('HPA_main'), f.col('HPA_additional'), f.col('HPA_extracellular_location'))),
+            f.explode(
+                _safe_array_union(f.col('HPA_main'), f.col('HPA_additional'), f.col('HPA_extracellular_location')),
+            ),
         )
         .select('id', f.col('all_locations.location').alias('location'), f.col('all_locations.source').alias('source'))
         .join(sl_df, f.col('location') == sl_df['HPA_location'], 'left_outer')
@@ -1068,12 +1048,11 @@ def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
         .agg(f.collect_list('locations').alias('locations'))
     )
 
-    return hpa
-
 
 # ===========================================================================
 # ProjectScores.scala → _build_project_scores
 # ===========================================================================
+
 
 def _build_project_scores(ids_df: DataFrame, matrix_df: DataFrame) -> DataFrame:
     """Build project scores (DepMap) cross-references.
@@ -1085,36 +1064,21 @@ def _build_project_scores(ids_df: DataFrame, matrix_df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with [id, xRef[{id, source}]].
     """
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
-
-    ps_ids = (
-        ids_df
-        .filter(f.col('ensembl_gene_id').isNotNull())
-        .select(
-            f.col('gene_id').alias('ps_gene_id'),
-            f.col('ensembl_gene_id'),
-            f.col('hgnc_symbol'),
-        )
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
     )
 
-    # Sum all per-cell-line columns to identify genes with any dependency
-    data_cols = [c for c in matrix_df.columns if c != 'Gene']
-    totals = matrix_df
-    for c in data_cols:
-        totals = totals.withColumn('_total', f.coalesce(f.col('_total') if '_total' in totals.columns else f.lit(0), f.lit(0)) + f.coalesce(f.col(f'`{c}`'), f.lit(0)))
-
-    # Simpler approach: unpivot and sum
-    total_df = (
-        matrix_df
-        .select('Gene', f.lit(1).alias('_present'))
-        .filter(f.col('_present') > 0)
-        .select('Gene')
+    ps_ids = ids_df.filter(f.col('ensembl_gene_id').isNotNull()).select(
+        f.col('gene_id').alias('ps_gene_id'),
+        f.col('ensembl_gene_id'),
+        f.col('hgnc_symbol'),
     )
 
     # Build a proper total using stack expression
+    data_cols = [c for c in matrix_df.columns if c != 'Gene']
     if data_cols:
         stack_expr = f'stack({len(data_cols)}, {", ".join([f"`{c}`" for c in data_cols])}) as val'
         total_df = (
@@ -1125,22 +1089,24 @@ def _build_project_scores(ids_df: DataFrame, matrix_df: DataFrame) -> DataFrame:
             .filter(f.col('total') > 0)
         )
 
-    return (
-        total_df
-        .join(ps_ids, total_df['Gene'] == ps_ids['hgnc_symbol'])
-        .select(
-            f.col('ensembl_gene_id').alias('id'),
-            f.array(f.struct(
+    return total_df.join(ps_ids, total_df['Gene'] == ps_ids['hgnc_symbol']).select(
+        f.col('ensembl_gene_id').alias('id'),
+        f
+        .array(
+            f.struct(
                 f.col('ps_gene_id').alias('id'),
                 f.lit('ProjectScore').alias('source'),
-            )).cast(id_source_schema).alias('xRef'),
+            )
         )
+        .cast(id_source_schema)
+        .alias('xRef'),
     )
 
 
 # ===========================================================================
 # ProteinClassification.scala → _build_protein_classification
 # ===========================================================================
+
 
 def _build_protein_classification(df: DataFrame) -> DataFrame:
     """Build protein target classification from ChEMBL.
@@ -1151,26 +1117,16 @@ def _build_protein_classification(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with [accession, targetClass[{id, label, level}]].
     """
-    pc_schema = ArrayType(StructType([
-        StructField('id', LongType()),
-        StructField('label', StringType()),
-        StructField('level', StringType()),
-    ]))
-
-    accession_pc = (
-        df
-        .select(
-            f.explode(
-                f.arrays_zip(
-                    f.col('_metadata.protein_classification'),
-                    f.col('target_components.accession'),
-                )
-            ).alias('s')
-        )
-        .select(
-            f.col('s.accession').alias('accession'),
-            f.col('s.protein_classification.*'),
-        )
+    accession_pc = df.select(
+        f.explode(
+            f.arrays_zip(
+                f.col('_metadata.protein_classification'),
+                f.col('target_components.accession'),
+            )
+        ).alias('s')
+    ).select(
+        f.col('s.accession').alias('accession'),
+        f.col('s.protein_classification.*'),
     )
 
     levels = [f'l{i}' for i in range(1, 7)]
@@ -1204,6 +1160,7 @@ def _build_protein_classification(df: DataFrame) -> DataFrame:
 # GeneticConstraints.scala → _build_genetic_constraints
 # ===========================================================================
 
+
 def _build_genetic_constraints(df: DataFrame) -> DataFrame:
     """Build genetic constraints (gnomAD).
 
@@ -1214,23 +1171,7 @@ def _build_genetic_constraints(df: DataFrame) -> DataFrame:
         DataFrame with [id, constraint[{constraintType, score, exp, obs, oe, oeLower, oeUpper,
         upperRank, upperBin, upperBin6}]].
     """
-    constraint_schema = ArrayType(StructType([
-        StructField('constraintType', StringType()),
-        StructField('score', FloatType()),
-        StructField('exp', FloatType()),
-        StructField('obs', IntegerType()),
-        StructField('oe', FloatType()),
-        StructField('oeLower', FloatType()),
-        StructField('oeUpper', FloatType()),
-        StructField('upperRank', IntegerType()),
-        StructField('upperBin', IntegerType()),
-        StructField('upperBin6', IntegerType()),
-    ]))
-
-    filtered = (
-        df
-        .filter((f.col('canonical') == 'true') & (f.col('transcript_type') != 'NA'))
-    )
+    filtered = df.filter((f.col('canonical') == 'true') & (f.col('transcript_type') != 'NA'))
 
     # Compute sextile bin for lof
     w = Window.orderBy(f.col('`lof.oe_ci.upper_rank`').cast(IntegerType()))
@@ -1242,55 +1183,53 @@ def _build_genetic_constraints(df: DataFrame) -> DataFrame:
         ).otherwise(None),
     )
 
-    return (
-        filtered
-        .select(
-            f.col('gene_id').cast(StringType()).alias('id'),
-            f.array(
-                f.struct(
-                    f.lit('syn').alias('constraintType'),
-                    f.col('`syn.z_score`').cast(FloatType()).alias('score'),
-                    f.col('`syn.exp`').cast(FloatType()).alias('exp'),
-                    f.col('`syn.obs`').cast(IntegerType()).alias('obs'),
-                    f.col('`syn.oe`').cast(FloatType()).alias('oe'),
-                    f.col('`syn.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
-                    f.col('`syn.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
-                    f.lit(None).cast(IntegerType()).alias('upperRank'),
-                    f.lit(None).cast(IntegerType()).alias('upperBin'),
-                    f.lit(None).cast(IntegerType()).alias('upperBin6'),
-                ),
-                f.struct(
-                    f.lit('mis').alias('constraintType'),
-                    f.col('`mis.z_score`').cast(FloatType()).alias('score'),
-                    f.col('`mis.exp`').cast(FloatType()).alias('exp'),
-                    f.col('`mis.obs`').cast(IntegerType()).alias('obs'),
-                    f.col('`mis.oe`').cast(FloatType()).alias('oe'),
-                    f.col('`mis.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
-                    f.col('`mis.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
-                    f.lit(None).cast(IntegerType()).alias('upperRank'),
-                    f.lit(None).cast(IntegerType()).alias('upperBin'),
-                    f.lit(None).cast(IntegerType()).alias('upperBin6'),
-                ),
-                f.struct(
-                    f.lit('lof').alias('constraintType'),
-                    f.col('`lof.pLI`').cast(FloatType()).alias('score'),
-                    f.col('`lof.exp`').cast(FloatType()).alias('exp'),
-                    f.col('`lof.obs`').cast(IntegerType()).alias('obs'),
-                    f.col('`lof.oe`').cast(FloatType()).alias('oe'),
-                    f.col('`lof.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
-                    f.col('`lof.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
-                    f.col('`lof.oe_ci.upper_rank`').cast(IntegerType()).alias('upperRank'),
-                    f.col('`lof.oe_ci.upper_bin_decile`').cast(IntegerType()).alias('upperBin'),
-                    f.col('lof_upper_bin6').cast(IntegerType()).alias('upperBin6'),
-                ),
-            ).alias('constraint'),
-        )
+    return filtered.select(
+        f.col('gene_id').cast(StringType()).alias('id'),
+        f.array(
+            f.struct(
+                f.lit('syn').alias('constraintType'),
+                f.col('`syn.z_score`').cast(FloatType()).alias('score'),
+                f.col('`syn.exp`').cast(FloatType()).alias('exp'),
+                f.col('`syn.obs`').cast(IntegerType()).alias('obs'),
+                f.col('`syn.oe`').cast(FloatType()).alias('oe'),
+                f.col('`syn.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                f.col('`syn.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                f.lit(None).cast(IntegerType()).alias('upperRank'),
+                f.lit(None).cast(IntegerType()).alias('upperBin'),
+                f.lit(None).cast(IntegerType()).alias('upperBin6'),
+            ),
+            f.struct(
+                f.lit('mis').alias('constraintType'),
+                f.col('`mis.z_score`').cast(FloatType()).alias('score'),
+                f.col('`mis.exp`').cast(FloatType()).alias('exp'),
+                f.col('`mis.obs`').cast(IntegerType()).alias('obs'),
+                f.col('`mis.oe`').cast(FloatType()).alias('oe'),
+                f.col('`mis.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                f.col('`mis.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                f.lit(None).cast(IntegerType()).alias('upperRank'),
+                f.lit(None).cast(IntegerType()).alias('upperBin'),
+                f.lit(None).cast(IntegerType()).alias('upperBin6'),
+            ),
+            f.struct(
+                f.lit('lof').alias('constraintType'),
+                f.col('`lof.pLI`').cast(FloatType()).alias('score'),
+                f.col('`lof.exp`').cast(FloatType()).alias('exp'),
+                f.col('`lof.obs`').cast(IntegerType()).alias('obs'),
+                f.col('`lof.oe`').cast(FloatType()).alias('oe'),
+                f.col('`lof.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                f.col('`lof.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                f.col('`lof.oe_ci.upper_rank`').cast(IntegerType()).alias('upperRank'),
+                f.col('`lof.oe_ci.upper_bin_decile`').cast(IntegerType()).alias('upperBin'),
+                f.col('lof_upper_bin6').cast(IntegerType()).alias('upperBin6'),
+            ),
+        ).alias('constraint'),
     )
 
 
 # ===========================================================================
 # Ortholog.scala → _build_homologues
 # ===========================================================================
+
 
 def _build_homologues(
     homology_dict: DataFrame,
@@ -1314,27 +1253,23 @@ def _build_homologues(
     priority_df_data = [(s.split('-')[0], i) for i, s in enumerate(target_species)]
 
     from pyspark.sql import SparkSession
+
     spark = SparkSession.getActiveSession()
     priority_df = spark.createDataFrame(priority_df_data, ['speciesId', 'priority'])
 
-    homo_dict = (
-        homology_dict
-        .select(
-            f.col('#name').alias('name'),
-            f.col('species').alias('speciesName'),
-            f.col('taxonomy_id'),
-            f.array(*[f.lit(t) for t in tax_ids]).alias('whitelist'),
-        )
-        .filter(f.array_contains(f.col('whitelist'), f.col('taxonomy_id')))
-    )
+    homo_dict = homology_dict.select(
+        f.col('#name').alias('name'),
+        f.col('species').alias('speciesName'),
+        f.col('taxonomy_id'),
+        f.array(*[f.lit(t) for t in tax_ids]).alias('whitelist'),
+    ).filter(f.array_contains(f.col('whitelist'), f.col('taxonomy_id')))
 
-    gene_dict_mapped = (
-        gene_dict
-        .select(
-            f.col('id').alias('homology_gene_stable_id'),
-            f.when(f.col('name').isNotNull() & (f.col('name') != ''), f.col('name'))
-             .otherwise(f.col('id')).alias('targetGeneSymbol'),
-        )
+    gene_dict_mapped = gene_dict.select(
+        f.col('id').alias('homology_gene_stable_id'),
+        f
+        .when(f.col('name').isNotNull() & (f.col('name') != ''), f.col('name'))  # noqa: PLC1901
+        .otherwise(f.col('id'))
+        .alias('targetGeneSymbol'),
     )
 
     reference = 'homo_sapiens'
@@ -1344,19 +1279,12 @@ def _build_homologues(
 
     # paralogs and cross-species
     other_h = (
-        coding_proteins
-        .filter(
+        coding_proteins.filter(
             (
                 (f.col('species') == reference)
-                & (
-                    (f.col('homology_type') == 'other_paralog')
-                    | (f.col('homology_type') == 'within_species_paralog')
-                )
+                & ((f.col('homology_type') == 'other_paralog') | (f.col('homology_type') == 'within_species_paralog'))
             )
-            | (
-                (f.col('species') != reference)
-                & (f.col('homology_species') == reference)
-            )
+            | ((f.col('species') != reference) & (f.col('homology_species') == reference))
         )
         # swap homo_sapiens ↔ homology columns
         .select(
@@ -1402,6 +1330,7 @@ def _build_homologues(
 # ===========================================================================
 # Reactome.scala → _build_reactome
 # ===========================================================================
+
 
 def _build_reactome(reactome_pathways: DataFrame, reactome_etl: DataFrame) -> DataFrame:
     """Build reactome pathways grouped by Ensembl ID.
@@ -1457,6 +1386,7 @@ def _build_reactome(reactome_pathways: DataFrame, reactome_etl: DataFrame) -> Da
 # Tractability.scala → _build_tractability
 # ===========================================================================
 
+
 def _build_tractability(df: DataFrame) -> DataFrame:
     """Build tractability assessments.
 
@@ -1467,6 +1397,7 @@ def _build_tractability(df: DataFrame) -> DataFrame:
         DataFrame with [ensemblGeneId, tractability[{modality, id, value}]].
     """
     import re
+
     bucket_cols = [c for c in df.columns if re.match(r'.*_B\d+_.*', c)]
     tractability = df.select('ensembl_gene_id', *bucket_cols)
     data_cols = [c for c in tractability.columns if c != 'ensembl_gene_id']
@@ -1482,18 +1413,16 @@ def _build_tractability(df: DataFrame) -> DataFrame:
             ),
         )
 
-    return (
-        tractability
-        .select(
-            f.col('ensembl_gene_id').alias('ensemblGeneId'),
-            f.array(*data_cols).alias('tractability'),
-        )
+    return tractability.select(
+        f.col('ensembl_gene_id').alias('ensemblGeneId'),
+        f.array(*data_cols).alias('tractability'),
     )
 
 
 # ===========================================================================
 # Uniprot (pre-processed parquet) → _build_uniprot
 # ===========================================================================
+
 
 def _build_uniprot(df: DataFrame, ssl_df: DataFrame) -> DataFrame:
     """Build Uniprot DataFrame from pre-processed parquet.
@@ -1510,55 +1439,45 @@ def _build_uniprot(df: DataFrame, ssl_df: DataFrame) -> DataFrame:
         DataFrame with [uniprotId, synonyms, symbolSynonyms, nameSynonyms,
         functionDescriptions, proteinIds, subcellularLocations, dbXrefs].
     """
-    label_source_schema = ArrayType(StructType([
-        StructField('label', StringType()),
-        StructField('source', StringType()),
-    ]))
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
-    loc_source_schema = ArrayType(StructType([
-        StructField('location', StringType()),
-        StructField('source', StringType()),
-        StructField('termSL', StringType()),
-        StructField('labelSL', StringType()),
-    ]))
-
-    base = (
-        df
-        .filter(f.size(f.col('accessions')) > 0)
-        .select(
-            f.element_at(f.col('accessions'), 1).alias('uniprotId'),
-            _safe_array_union(f.col('names'), f.col('synonyms')).alias('_name_syns'),
-            _safe_array_union(f.col('symbolSynonyms')).alias('_symbol_syns'),
-            _safe_array_union(
-                _safe_array_union(f.col('names')),
-                _safe_array_union(f.col('symbolSynonyms')),
-            ).alias('_synonyms'),
-            f.col('functions').alias('functionDescriptions'),
-            f.col('dbXrefs'),
-            f.col('accessions'),
-            f.col('locations'),
-        )
+    label_source_schema = ArrayType(
+        StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
+    )
+    base = df.filter(f.size(f.col('accessions')) > 0).select(
+        f.element_at(f.col('accessions'), 1).alias('uniprotId'),
+        _safe_array_union(f.col('names'), f.col('synonyms')).alias('_name_syns'),
+        _safe_array_union(f.col('symbolSynonyms')).alias('_symbol_syns'),
+        _safe_array_union(
+            _safe_array_union(f.col('names')),
+            _safe_array_union(f.col('symbolSynonyms')),
+        ).alias('_synonyms'),
+        f.col('functions').alias('functionDescriptions'),
+        f.col('dbXrefs'),
+        f.col('accessions'),
+        f.col('locations'),
     )
 
     # Handle dbXrefs: "ID SOURCE" → struct(id, source)
-    base = (
-        base
-        .withColumn(
-            'dbXrefs',
-            f.when(
-                f.col('dbXrefs').isNotNull(),
-                f.transform(
-                    f.col('dbXrefs'),
-                    lambda c: f.struct(
-                        f.element_at(f.split(c, ' '), 2).alias('id'),
-                        f.element_at(f.split(c, ' '), 1).alias('source'),
-                    ),
+    base = base.withColumn(
+        'dbXrefs',
+        f.when(
+            f.col('dbXrefs').isNotNull(),
+            f.transform(
+                f.col('dbXrefs'),
+                lambda c: f.struct(
+                    f.element_at(f.split(c, ' '), 1).alias('id'),
+                    f.element_at(f.split(c, ' '), 2).alias('source'),
                 ),
-            ).cast(id_source_schema),
-        )
+            ),
+        ).cast(id_source_schema),
     )
 
     # Map locations → subcellularLocations using SSL ontology
@@ -1569,7 +1488,10 @@ def _build_uniprot(df: DataFrame, ssl_df: DataFrame) -> DataFrame:
         'proteinIds',
         f.when(
             f.col('accessions').isNotNull(),
-            f.transform(f.col('accessions'), lambda c: f.struct(f.trim(c).alias('id'), f.lit('uniprot_obsolete').alias('source'))),
+            f.transform(
+                f.col('accessions'),
+                lambda c: f.struct(f.trim(c).alias('id'), f.lit('uniprot_obsolete').alias('source')),
+            ),
         ).cast(id_source_schema),
     )
 
@@ -1596,18 +1518,23 @@ def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame
     isoforms_regex = r'(\[.+\]:\s([\w\s]+))'
     last_after_comma_regex = r'.*,\s([\w\s]+)'
 
-    ssl_onto = ssl_df.select(
-        f.col('Subcellular location ID').alias('termSL'),
-        f.col('Name').alias('ssl_match'),
-        f.col('Category').alias('labelSL'),
-    ) if 'Subcellular location ID' in ssl_df.columns else ssl_df.select(
-        f.col('termSL'),
-        f.col('ssl_match'),
-        f.col('labelSL'),
+    ssl_onto = (
+        ssl_df.select(
+            f.col('Subcellular location ID').alias('termSL'),
+            f.col('Name').alias('ssl_match'),
+            f.col('Category').alias('labelSL'),
+        )
+        if 'Subcellular location ID' in ssl_df.columns
+        else ssl_df.select(
+            f.col('termSL'),
+            f.col('ssl_match'),
+            f.col('labelSL'),
+        )
     )
 
     loc_df = (
-        df.select('uniprotId', f.explode('locations').alias('location'))
+        df
+        .select('uniprotId', f.explode('locations').alias('location'))
         .select(
             'uniprotId',
             f.trim(f.regexp_extract('location', first_words_regex, 0)).alias('loc1'),
@@ -1617,12 +1544,13 @@ def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame
         )
         .withColumn(
             'ssl_match',
-            f.when(f.col('loc1') != '', f.col('loc1'))
-             .when(f.col('loc2') != '', f.col('loc2'))
-             .when(f.col('loc3') != '', f.col('loc3'))
-             .otherwise(f.lit(None)),
+            f
+            .when(f.col('loc1') != '', f.col('loc1'))  # noqa: PLC1901
+            .when(f.col('loc2') != '', f.col('loc2'))  # noqa: PLC1901
+            .when(f.col('loc3') != '', f.col('loc3'))  # noqa: PLC1901
+            .otherwise(f.lit(None)),
         )
-        .withColumn('location', f.when(f.col('iso') != '', f.col('iso')).otherwise(f.col('ssl_match')))
+        .withColumn('location', f.when(f.col('iso') != '', f.col('iso')).otherwise(f.col('ssl_match')))  # noqa: PLC1901
         .drop('iso', 'loc1', 'loc2', 'loc3')
         .filter(f.col('location').isNotNull())
         .join(f.broadcast(ssl_onto), 'ssl_match', 'left_outer')
@@ -1639,6 +1567,7 @@ def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame
 # ===========================================================================
 # Safety.scala → _build_safety
 # ===========================================================================
+
 
 def _build_safety(
     safety_df: DataFrame,
@@ -1666,9 +1595,8 @@ def _build_safety(
     )
 
     # Replace obsolete EFOs
-    disease_mapping = (
-        diseases_df
-        .select(f.col('id').alias('diseaseId'), f.explode(f.col('obsoleteTerms')).alias('obsoleteTerm'))
+    disease_mapping = diseases_df.select(
+        f.col('id').alias('diseaseId'), f.explode(f.col('obsoleteTerms')).alias('obsoleteTerm')
     )
 
     enriched = (
@@ -1683,8 +1611,14 @@ def _build_safety(
         .select(
             'id',
             f.struct(
-                'event', 'eventId', 'effects', 'biosamples',
-                'datasource', 'literature', 'url', 'studies',
+                'event',
+                'eventId',
+                'effects',
+                'biosamples',
+                'datasource',
+                'literature',
+                'url',
+                'studies',
             ).alias('safety'),
         )
         .groupBy('id')
@@ -1695,6 +1629,7 @@ def _build_safety(
 # ===========================================================================
 # Tep.scala → _build_tep
 # ===========================================================================
+
 
 def _build_tep(df: DataFrame) -> DataFrame:
     """Build TEP (Target Enabling Package) DataFrame.
@@ -1717,6 +1652,7 @@ def _build_tep(df: DataFrame) -> DataFrame:
 # Assembly helpers (mirrors Target.scala private methods)
 # ===========================================================================
 
+
 def _merge_hgnc_ensembl(hgnc_df: DataFrame, ensembl_df: DataFrame) -> DataFrame:
     """Merge HGNC and Ensembl; HGNC fields take precedence.
 
@@ -1727,11 +1663,7 @@ def _merge_hgnc_ensembl(hgnc_df: DataFrame, ensembl_df: DataFrame) -> DataFrame:
     Returns:
         Merged DataFrame.
     """
-    e = (
-        ensembl_df
-        .withColumnRenamed('approvedName', '_an')
-        .withColumnRenamed('approvedSymbol', '_as')
-    )
+    e = ensembl_df.withColumnRenamed('approvedName', '_an').withColumnRenamed('approvedSymbol', '_as')
 
     return (
         e
@@ -1752,24 +1684,22 @@ def _add_ensembl_ids_to_uniprot(hgnc_df: DataFrame, uniprot_df: DataFrame) -> Da
     Returns:
         Uniprot data grouped by Ensembl id (column renamed to 'id').
     """
-    id_source_schema = ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('source', StringType()),
-    ]))
-
-    mapping = (
-        hgnc_df
-        .select('ensemblId', f.explode('uniprotIds').alias('uniprotId'))
-        .withColumn(
-            'uniprotProteinId',
-            f.struct(
-                f.col('uniprotId').alias('id'),
-                f.lit('uniprot_obsolete').alias('source'),
-            ),
-        )
+    id_source_schema = ArrayType(
+        StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ])
     )
 
-    grouped = (
+    mapping = hgnc_df.select('ensemblId', f.explode('uniprotIds').alias('uniprotId')).withColumn(
+        'uniprotProteinId',
+        f.struct(
+            f.col('uniprotId').alias('id'),
+            f.lit('uniprot_obsolete').alias('source'),
+        ),
+    )
+
+    return (
         mapping
         .join(uniprot_df, 'uniprotId')
         .groupBy('ensemblId')
@@ -1796,8 +1726,6 @@ def _add_ensembl_ids_to_uniprot(hgnc_df: DataFrame, uniprot_df: DataFrame) -> Da
         .drop('uniprotId', 'uniprotProteinId')
     )
 
-    return grouped
-
 
 def _add_protein_classification_to_uniprot(
     uniprot_df: DataFrame,
@@ -1808,9 +1736,7 @@ def _add_protein_classification_to_uniprot(
         uniprot_df
         .select(
             'uniprotId',
-            f.explode(
-                _safe_array_union(f.array(f.col('uniprotId')), f.col('proteinIds.id'))
-            ).alias('pid'),
+            f.explode(_safe_array_union(f.array(f.col('uniprotId')), f.col('proteinIds.id'))).alias('pid'),
         )
         .withColumn('pid', f.trim('pid'))
         .join(protein_class_df, f.col('pid') == protein_class_df['accession'], 'left_outer')
@@ -1863,10 +1789,7 @@ def _generate_ensg_lookup(df: DataFrame) -> DataFrame:
 def _add_tep(df: DataFrame, tep_df: DataFrame, lookup: DataFrame) -> DataFrame:
     """Join TEP data using symbol→ENSG lookup."""
     lut = (
-        lookup
-        .select(f.col('ensgId').alias('id'), 'symbols')
-        .withColumn('symbol', f.explode('symbols'))
-        .drop('symbols')
+        lookup.select(f.col('ensgId').alias('id'), 'symbols').withColumn('symbol', f.explode('symbols')).drop('symbols')
     )
 
     tep_fields = ['targetFromSourceId', 'description', 'therapeuticArea', 'url']
@@ -1882,16 +1805,15 @@ def _add_tep(df: DataFrame, tep_df: DataFrame, lookup: DataFrame) -> DataFrame:
 
 def _filter_and_sort_protein_ids(df: DataFrame) -> DataFrame:
     """Deduplicate proteinIds and sort by source preference."""
-    from pyspark.sql import SparkSession
 
     def _sort_protein_ids(accessions):
         """UDF: deduplicate and sort by source priority."""
         if not accessions:
             return []
         seen = {}
-        split_token = '-'
+        delimiter = '|||'
         for entry in accessions:
-            parts = entry.split(split_token, 1)
+            parts = entry.split(delimiter, 1)
             if len(parts) < 2:
                 continue
             pid, src = parts[0].strip(), parts[1]
@@ -1911,13 +1833,14 @@ def _filter_and_sort_protein_ids(df: DataFrame) -> DataFrame:
             return (5, pid)
 
         sorted_items = sorted(seen.items(), key=_priority)
-        return [f'{pid}-{src}' for pid, src in sorted_items]
+        return [f'{pid}|||{src}' for pid, src in sorted_items]
 
     from pyspark.sql.functions import udf
     from pyspark.sql.types import ArrayType, StringType
+
     sort_udf = udf(_sort_protein_ids, ArrayType(StringType()))
 
-    split_token = '-'
+    delimiter = '|||'
     ensembl_id = 'eid'
     protein_id = 'proteinIds'
 
@@ -1925,12 +1848,12 @@ def _filter_and_sort_protein_ids(df: DataFrame) -> DataFrame:
         df
         .select(f.col('id').alias(ensembl_id), f.explode(f.col(protein_id)).alias('p'))
         .select(ensembl_id, f.col('p.*'))
-        .withColumn('arr', f.array_join(f.array(f.trim(f.col('id')), f.col('source')), split_token))
+        .withColumn('arr', f.array_join(f.array(f.trim(f.col('id')), f.col('source')), delimiter))
         .groupBy(ensembl_id)
         .agg(f.collect_list('arr').alias('accessions'))
         .select(f.col(ensembl_id), sort_udf(f.col('accessions')).alias('accessions'))
         .select(f.col(ensembl_id), f.explode('accessions').alias('accessions'))
-        .withColumn('id_and_source', f.split('accessions', split_token))
+        .withColumn('id_and_source', f.split('accessions', r'\|\|\|'))
         .select(
             f.col(ensembl_id),
             f.element_at(f.col('id_and_source'), 1).alias('id'),
@@ -1954,11 +1877,9 @@ def _remove_redundant_xrefs(df: DataFrame) -> DataFrame:
 
 def _add_chemical_probes(df: DataFrame, cp_df: DataFrame, lookup: DataFrame) -> DataFrame:
     """Join chemical probes using symbol lookup."""
-    cp_with_id = (
-        cp_df
-        .join(lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')))
-        .drop(*[c for c in lookup.columns if c != 'ensgId'])
-    )
+    cp_with_id = cp_df.join(lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId'))).drop(*[
+        c for c in lookup.columns if c != 'ensgId'
+    ])
 
     cp_cols = [c for c in cp_df.columns if c != 'ensgId']
     cp_grouped = (
@@ -1978,10 +1899,8 @@ def _add_orthologues(df: DataFrame, orthologs: DataFrame) -> DataFrame:
     """Add homologues to target DataFrame."""
     gene_symbols = df.select('id', 'approvedSymbol').cache()
 
-    paralog_symbols = (
-        gene_symbols
-        .withColumnRenamed('approvedSymbol', 'paralogGeneSymbol')
-        .withColumnRenamed('id', 'paralogId')
+    paralog_symbols = gene_symbols.withColumnRenamed('approvedSymbol', 'paralogGeneSymbol').withColumnRenamed(
+        'id', 'paralogId'
     )
 
     homo_df = (
@@ -2014,11 +1933,7 @@ def _add_orthologues(df: DataFrame, orthologs: DataFrame) -> DataFrame:
 
 def _add_tractability(df: DataFrame, tractability: DataFrame) -> DataFrame:
     """Join tractability data."""
-    return (
-        df
-        .join(tractability, f.col('ensemblGeneId') == f.col('id'), 'left_outer')
-        .drop('ensemblGeneId')
-    )
+    return df.join(tractability, f.col('ensemblGeneId') == f.col('id'), 'left_outer').drop('ensemblGeneId')
 
 
 def _add_ncbi_synonyms(df: DataFrame, ncbi: DataFrame) -> DataFrame:
@@ -2068,6 +1983,7 @@ def _add_tss(df: DataFrame) -> DataFrame:
     """Add transcription start site column."""
     return df.withColumn(
         'tss',
-        f.when(f.col('canonicalTranscript.strand') == '+', f.col('canonicalTranscript.start'))
-         .when(f.col('canonicalTranscript.strand') == '-', f.col('canonicalTranscript.end')),
+        f.when(f.col('canonicalTranscript.strand') == '+', f.col('canonicalTranscript.start')).when(
+            f.col('canonicalTranscript.strand') == '-', f.col('canonicalTranscript.end')
+        ),
     )

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -32,6 +32,7 @@ from loguru import logger
 from pyspark.sql import DataFrame
 from pyspark.sql.types import (
     ArrayType,
+    BooleanType,
     DoubleType,
     FloatType,
     IntegerType,
@@ -43,6 +44,7 @@ from pyspark.sql.types import (
 from pyspark.sql.window import Window
 
 from pts.pyspark.common.session import Session
+from pts.pyspark.common.utils import safe_array_union as _safe_array_union
 
 # ---------------------------------------------------------------------------
 # Public constant — tested for schema compliance
@@ -53,9 +55,11 @@ REQUIRED_OUTPUT_COLUMNS = {
     'approvedName',
     'biotype',
     'transcripts',
+    'transcriptIds',
+    'canonicalExons',
     'genomicLocation',
     'pathways',
-    'geneOntology',
+    'go',
     'constraint',
     'safety',
     'tractability',
@@ -137,7 +141,7 @@ def target(
     go_rna_raw = spark.read.option('sep', '\t').option('comment', '!').csv(source['gene_ontology_rna'])
     go_rna_lookup_raw = spark.read.option('sep', '\t').csv(source['gene_ontology_rna_lookup'])
     go_eco_raw = spark.read.option('sep', '\t').option('comment', '!').csv(source['gene_ontology_eco_lookup'])
-    tep_raw = spark.read.option('multiline', 'true').json(source['tep'])
+    tep_raw = spark.read.json(source['tep'])
     hpa_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['hpa'])
     hpa_sl_raw = spark.read.parquet(source['hpa_sl'])
     ps_ids_raw = spark.read.parquet(source['project_scores_ids'])
@@ -167,27 +171,25 @@ def target(
     # produced by the pts_target pre-processing step (uniprot XML→parquet).
     # The pre-processing step writes a parquet with UniprotEntry fields.
     uniprot_raw = spark.read.parquet(source['uniprot'])
+    uniprot_ssl_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['uniprot_ssl'])
 
     # --- species whitelist from settings ------------------------------------
     hgnc_ortholog_species: list[str] = settings.get(
         'hgncOrthologSpecies',
         [
-            '9606-homo_sapiens',
-            '10090-mus_musculus',
-            '10116-rattus_norvegicus',
-            '9615-canis_lupus_familiaris',
-            '9823-sus_scrofa',
-            '9796-equus_caballus',
-            '9913-bos_taurus',
-            '9986-oryctolagus_cuniculus',
-            '13616-monodelphis_domestica',
-            '9258-ornithorhynchus_anatinus',
-            '9031-gallus_gallus',
-            '8364-xenopus_tropicalis',
-            '7955-danio_rerio',
-            '7227-drosophila_melanogaster',
-            '6239-caenorhabditis_elegans',
-            '4932-saccharomyces_cerevisiae',
+            '9606-human',
+            '9598-chimpanzee',
+            '9544-macaque',
+            '10090-mouse',
+            '10116-rat',
+            '9986-rabbit',
+            '10141-guineapig',
+            '9615-dog',
+            '9823-pig',
+            '8364-frog',
+            '7955-zebrafish',
+            '7227-fly',
+            '6239-worm',
         ],
     )
 
@@ -241,7 +243,7 @@ def target(
 
     # --- Uniprot (pre-processed parquet schema mirrors UniprotEntry) --------
     logger.info('Building Uniprot')
-    uniprot_df = _build_uniprot(uniprot_raw, hpa_sl_raw)
+    uniprot_df = _build_uniprot(uniprot_raw, uniprot_ssl_raw)
 
     # --- Merge ---------------------------------------------------------------
     logger.info('Merging HGNC + Ensembl + GO + ProjectScores + Hallmarks')
@@ -320,10 +322,6 @@ def target(
         .transform(_add_tss)
     )
 
-    # Rename go → geneOntology to match platform schema
-    if 'go' in targets_df.columns:
-        targets_df = targets_df.withColumnRenamed('go', 'geneOntology')
-
     logger.info(f'Writing target output to {destination["target"]}')
     targets_df.write.mode('overwrite').parquet(destination['target'])
 
@@ -331,19 +329,6 @@ def target(
     gene_essentiality_df = _build_gene_essentiality_output(gene_essentiality_raw, ensg_lookup)
     logger.info(f'Writing gene essentiality output to {destination["gene_essentiality"]}')
     gene_essentiality_df.write.mode('overwrite').parquet(destination['gene_essentiality'])
-
-
-# ===========================================================================
-# Helper: safe array union (mirrors Spark Helpers.safeArrayUnion in Scala)
-# ===========================================================================
-
-
-def _safe_array_union(*cols):
-    """Return union of multiple array columns, treating nulls as empty arrays."""
-    result = f.coalesce(cols[0], f.array())
-    for col in cols[1:]:
-        result = f.array_union(result, f.coalesce(col, f.array()))
-    return result
 
 
 # ===========================================================================
@@ -445,7 +430,16 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
                 if has_transcripts
                 else f.lit(None).cast(ArrayType(StructType([StructField('id', StringType())])))
             ).alias('transcripts_raw'),
-            f.col('signalP') if 'signalP' in df.columns else f.lit(None).alias('signalP'),
+            # transcriptIds: flat array of transcript IDs (Ensembl.scala line 45)
+            (f.col('transcripts.id') if has_transcripts else f.lit(None).cast(ArrayType(StringType()))).alias(
+                'transcriptIds'
+            ),
+            # exons: per-transcript exon arrays for canonicalExons computation
+            (f.col('transcripts.exons') if has_transcripts else f.lit(None)).alias('exons_raw'),
+            # translations: flatten transcripts[*].translations[*] into a top-level array
+            # so _refactor_ensembl_protein_ids can build ensembl_PRO protein IDs
+            (f.flatten(f.col('transcripts.translations')) if has_transcripts else f.lit(None)).alias('translations'),
+            f.col('SignalP').alias('signalP') if 'SignalP' in df.columns else f.lit(None).alias('signalP'),
             f.col('uniprot_trembl') if 'uniprot_trembl' in df.columns else f.lit(None).alias('uniprot_trembl'),
             f.col('uniprot_swissprot') if 'uniprot_swissprot' in df.columns else f.lit(None).alias('uniprot_swissprot'),
         )
@@ -490,16 +484,44 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
     # Build proteinIds from uniprot columns
     ensembl = _refactor_ensembl_protein_ids(ensembl)
 
-    # Build signalP
+    # Build signalP — cast to explicit array type first to handle VOID (all-null) columns
+    ensembl = ensembl.withColumn('signalP', f.col('signalP').cast(ArrayType(StringType())))
     ensembl = ensembl.withColumn(
         'signalP',
         f.when(
-            f.size(f.col('signalP')) >= 0,
+            f.col('signalP').isNotNull() & (f.size(f.col('signalP')) >= 0),
             f.transform(f.col('signalP'), lambda c: f.struct(c.alias('id'), f.lit('signalP').alias('source'))),
         ).cast(id_source_schema),
     )
 
-    # Parse transcripts into the structured format
+    # Build canonicalExons: flat array of (start, end) pairs for the canonical transcript
+    # Mirrors addCanonicalExons in Ensembl.scala
+    # Use expr because array_position(col, col) requires SQL expression syntax in PySpark
+    ensembl = ensembl.withColumn(
+        'exonIndex',
+        f.expr('array_position(transcriptIds, canonicalTranscript.id)'),
+    )
+    ensembl = ensembl.withColumn(
+        '_canon_exons_raw',
+        f.when(
+            f.col('exonIndex') > 0,
+            f.element_at(f.col('exons_raw'), f.col('exonIndex').cast(IntegerType())),
+        ),
+    )
+    ensembl = ensembl.withColumn(
+        'canonicalExons',
+        f.when(
+            f.col('_canon_exons_raw').isNotNull(),
+            f.flatten(
+                f.transform(
+                    f.col('_canon_exons_raw'),
+                    lambda x: f.array(x.getField('start'), x.getField('end')),
+                )
+            ),
+        ),
+    ).drop('exonIndex', 'exons_raw', '_canon_exons_raw')
+
+    # Parse transcripts into the structured format (also sets isEnsemblCanonical)
     ensembl = _parse_ensembl_transcripts(ensembl)
 
     return ensembl.select(
@@ -510,6 +532,8 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
         'genomicLocation',
         'approvedSymbol',
         'proteinIds',
+        'transcriptIds',
+        'canonicalExons',
         'transcripts',
         'signalP',
         'canonicalTranscript',
@@ -579,16 +603,18 @@ def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
             StructField('transcriptId', StringType()),
             StructField('biotype', StringType()),
             StructField('uniprotId', StringType()),
-            StructField('isUniprotReviewed', StringType()),
+            StructField('isUniprotReviewed', BooleanType()),
             StructField('translationId', StringType()),
             StructField('alphafoldId', StringType()),
             StructField('uniprotIsoformId', StringType()),
-            StructField('isEnsemblCanonical', StringType()),
+            StructField('isEnsemblCanonical', BooleanType()),
         ])
     )
 
     if 'transcripts_raw' not in df.columns:
         return df.withColumn('transcripts', f.lit(None).cast(transcript_schema))
+
+    canon_id = f.col('canonicalTranscript.id')
 
     parsed = f.when(
         f.col('transcripts_raw').isNotNull(),
@@ -602,8 +628,8 @@ def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
                 .when(tr.getField('uniprot_trembl').isNotNull(), f.element_at(tr.getField('uniprot_trembl'), 1))
                 .alias('uniprotId'),
                 f
-                .when(tr.getField('uniprot_swissprot').isNotNull(), f.lit('true'))
-                .when(tr.getField('uniprot_trembl').isNotNull(), f.lit('false'))
+                .when(tr.getField('uniprot_swissprot').isNotNull(), f.lit(True))
+                .when(tr.getField('uniprot_trembl').isNotNull(), f.lit(False))
                 .alias('isUniprotReviewed'),
                 f.when(
                     tr.getField('translations').isNotNull(),
@@ -617,7 +643,11 @@ def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
                     tr.getField('uniprot_isoform').isNotNull(),
                     f.element_at(tr.getField('uniprot_isoform'), 1),
                 ).alias('uniprotIsoformId'),
-                f.lit(None).cast(StringType()).alias('isEnsemblCanonical'),
+                # isEnsemblCanonical: true when this transcript is the canonical one
+                f
+                .when(canon_id.isNotNull(), tr.getField('id') == canon_id)
+                .cast(BooleanType())
+                .alias('isEnsemblCanonical'),
             ),
         ),
     ).cast(transcript_schema)
@@ -1261,7 +1291,9 @@ def _build_homologues(
     from pyspark.sql import SparkSession
 
     spark = SparkSession.getActiveSession()
-    priority_df = spark.createDataFrame(priority_df_data, ['speciesId', 'priority'])
+    priority_df = spark.createDataFrame(priority_df_data, ['speciesId', 'priority']).withColumn(
+        'priority', f.col('priority').cast('int')
+    )
 
     homo_dict = homology_dict.select(
         f.col('#name').alias('name'),
@@ -1533,7 +1565,7 @@ def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame
         if 'Subcellular location ID' in ssl_df.columns
         else ssl_df.select(
             f.col('termSL'),
-            f.col('ssl_match'),
+            f.col('HPA_location').alias('ssl_match'),
             f.col('labelSL'),
         )
     )

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -1,0 +1,2073 @@
+"""Target dataset generation.
+
+Ported from platform-etl-backend target step. Integrates ~15 data sources to
+produce the canonical target index used by the Open Targets Platform.
+
+Scala sources ported:
+    - Target.scala (main assembly)
+    - Ensembl.scala
+    - GeneCode.scala
+    - GeneOntology.scala
+    - GeneticConstraints.scala
+    - GeneWithLocation.scala
+    - Hallmarks.scala
+    - Hgnc.scala
+    - Ncbi.scala
+    - Ortholog.scala
+    - ProjectScores.scala
+    - ProteinClassification.scala
+    - Reactome.scala
+    - Safety.scala
+    - Tep.scala
+    - Tractability.scala
+    - Uniprot.scala
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame
+from pyspark.sql.types import (
+    ArrayType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+from pyspark.sql.window import Window
+
+from pts.pyspark.common.session import Session
+
+# ---------------------------------------------------------------------------
+# Public constant — tested for schema compliance
+# ---------------------------------------------------------------------------
+REQUIRED_OUTPUT_COLUMNS = {
+    'id',
+    'approvedSymbol',
+    'approvedName',
+    'biotype',
+    'transcripts',
+    'genomicLocation',
+    'pathways',
+    'geneOntology',
+    'constraint',
+    'safety',
+    'tractability',
+    'homologues',
+    'subcellularLocations',
+    'targetClass',
+    'hallmarks',
+    'chemicalProbes',
+    'tep',
+    'synonyms',
+    'symbolSynonyms',
+    'nameSynonyms',
+    'functionDescriptions',
+    'proteinIds',
+    'dbXrefs',
+    'alternativeGenes',
+    'obsoleteSymbols',
+    'obsoleteNames',
+    'canonicalTranscript',
+    'tss',
+}
+
+# Canonical chromosomes (mirroring Ensembl.scala)
+INCLUDE_CHROMOSOMES = [str(i) for i in range(1, 23)] + ['X', 'Y', 'MT']
+
+# Cancer hallmarks from Hallmarks.scala
+CANCER_HALLMARKS = {
+    'proliferative signalling',
+    'invasion and metastasis',
+    'suppression of growth',
+    'angiogenesis',
+    'change of cellular energetics',
+    'genome instability and mutations',
+    'escaping programmed cell death',
+    'tumour promoting inflammation',
+    'cell replicative immortality',
+    'escaping immune response to cancer',
+}
+
+# Protein-ID source priority for deduplication (lower = higher priority)
+_PROTEIN_SOURCE_PRIORITY = {
+    'uniprot_swissprot': 1,
+    'uniprot_trembl': 2,
+    'uniprot': 3,
+    'ensembl_PRO': 4,
+}
+
+
+# ===========================================================================
+# Entry point
+# ===========================================================================
+
+
+def target(
+    source: dict[str, str],
+    destination: str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate the target index dataset.
+
+    Args:
+        source: Mapping of logical input names to paths.
+        destination: Output path for the target parquet.
+        settings: Step settings (hgncOrthologSpecies list, etc.).
+        properties: Spark properties.
+    """
+    spark = Session(app_name='target', properties=properties).spark
+
+    logger.info('Reading target inputs')
+
+    # --- read inputs --------------------------------------------------------
+    ensembl_raw = spark.read.parquet(source['ensembl'])
+    gene_code_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('comment', '#')
+        .csv(source['gene_code'])
+    )
+    hgnc_raw = spark.read.option('multiline', 'true').json(source['hgnc'])
+    hallmarks_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['hallmarks'])
+    )
+    ncbi_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['ncbi'])
+    )
+    go_human_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('comment', '!')
+        .csv(source['gene_ontology_human'])
+    )
+    go_rna_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('comment', '!')
+        .csv(source['gene_ontology_rna'])
+    )
+    go_rna_lookup_raw = (
+        spark.read
+        .option('sep', '\t')
+        .csv(source['gene_ontology_rna_lookup'])
+    )
+    go_eco_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('comment', '!', )
+        .csv(source['gene_ontology_eco_lookup'])
+    )
+    tep_raw = spark.read.option('multiline', 'true').json(source['tep'])
+    hpa_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['hpa'])
+    )
+    hpa_sl_raw = spark.read.parquet(source['hpa_sl'])
+    ps_ids_raw = spark.read.parquet(source['project_scores_ids'])
+    ps_matrix_raw = spark.read.parquet(source['project_scores_essentiality_matrix'])
+    chembl_raw = spark.read.json(source['chembl'])
+    genetic_constraints_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['genetic_constraints'])
+    )
+    homology_dict_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['homology_dictionary'])
+    )
+    homology_coding_proteins_raw = (
+        spark.read
+        .option('recursiveFileLookup', 'true')
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['homology_coding_proteins'])
+    )
+    homology_gene_dict_raw = (
+        spark.read
+        .option('recursiveFileLookup', 'true')
+        .parquet(source['homology_gene_dictionary'])
+    )
+    reactome_pathways_raw = (
+        spark.read
+        .option('sep', '\t')
+        .csv(source['reactome_pathways'])
+    )
+    reactome_etl_raw = spark.read.parquet(source['reactome_etl'])
+    tractability_raw = (
+        spark.read
+        .option('sep', '\t')
+        .option('header', 'true')
+        .csv(source['tractability'])
+    )
+    safety_raw = spark.read.parquet(source['safety_evidence'])
+    diseases_raw = spark.read.parquet(source['diseases'])
+    chemical_probes_raw = spark.read.parquet(source['chemical_probes'])
+
+    # Uniprot is a gzipped XML flat-file — we read a pre-processed parquet
+    # produced by the pts_target pre-processing step (uniprot XML→parquet).
+    # The pre-processing step writes a parquet with UniprotEntry fields.
+    uniprot_raw = spark.read.parquet(source['uniprot'])
+    uniprot_ssl_raw = spark.read.parquet(source['hpa_sl'])  # shared ssl ontology
+
+    # --- species whitelist from settings ------------------------------------
+    hgnc_ortholog_species: list[str] = settings.get(
+        'hgncOrthologSpecies',
+        [
+            '9606-homo_sapiens',
+            '10090-mus_musculus',
+            '10116-rattus_norvegicus',
+            '9615-canis_lupus_familiaris',
+            '9823-sus_scrofa',
+            '9796-equus_caballus',
+            '9913-bos_taurus',
+            '9986-oryctolagus_cuniculus',
+            '13616-monodelphis_domestica',
+            '9258-ornithorhynchus_anatinus',
+            '9031-gallus_gallus',
+            '8364-xenopus_tropicalis',
+            '7955-danio_rerio',
+            '7227-drosophila_melanogaster',
+            '6239-caenorhabditis_elegans',
+            '4932-saccharomyces_cerevisiae',
+        ],
+    )
+
+    # --- intermediate DataFrames --------------------------------------------
+    logger.info('Building GeneCode canonical transcripts')
+    gene_code = _build_gene_code(gene_code_raw)
+
+    logger.info('Building Ensembl genes')
+    ensembl_df = _build_ensembl(ensembl_raw, gene_code)
+
+    logger.info('Building HGNC')
+    hgnc_df = _build_hgnc(hgnc_raw)
+
+    logger.info('Building Hallmarks')
+    hallmarks_df = _build_hallmarks(hallmarks_raw)
+
+    logger.info('Building NCBI')
+    ncbi_df = _build_ncbi(ncbi_raw)
+
+    logger.info('Building Gene Ontology')
+    go_df = _build_gene_ontology(go_human_raw, go_rna_raw, go_rna_lookup_raw, go_eco_raw, ensembl_df)
+
+    logger.info('Building TEP')
+    tep_df = _build_tep(tep_raw)
+
+    logger.info('Building HPA subcellular locations')
+    hpa_df = _build_gene_with_location(hpa_raw, hpa_sl_raw)
+
+    logger.info('Building ProjectScores')
+    project_scores_df = _build_project_scores(ps_ids_raw, ps_matrix_raw)
+
+    logger.info('Building ProteinClassification')
+    protein_class_df = _build_protein_classification(chembl_raw)
+
+    logger.info('Building GeneticConstraints')
+    genetic_constraints_df = _build_genetic_constraints(genetic_constraints_raw)
+
+    logger.info('Building Homologues')
+    homology_df = _build_homologues(
+        homology_dict_raw, homology_coding_proteins_raw,
+        homology_gene_dict_raw, hgnc_ortholog_species,
+    )
+
+    logger.info('Building Reactome')
+    reactome_df = _build_reactome(reactome_pathways_raw, reactome_etl_raw)
+
+    logger.info('Building Tractability')
+    tractability_df = _build_tractability(tractability_raw)
+
+    # --- Uniprot (pre-processed parquet schema mirrors UniprotEntry) --------
+    logger.info('Building Uniprot')
+    uniprot_df = _build_uniprot(uniprot_raw, uniprot_ssl_raw)
+
+    # --- Merge ---------------------------------------------------------------
+    logger.info('Merging HGNC + Ensembl + GO + ProjectScores + Hallmarks')
+    hgnc_ensembl = _merge_hgnc_ensembl(hgnc_df, ensembl_df)
+
+    hgnc_ensembl_go = (
+        hgnc_ensembl
+        .join(go_df, hgnc_ensembl['id'] == go_df['ensemblId'], 'left_outer')
+        .drop('ensemblId')
+        .join(project_scores_df, 'id', 'left_outer')
+        .join(hallmarks_df, 'approvedSymbol', 'left_outer')
+    )
+
+    logger.info('Adding Uniprot + ProteinClassification + HPA')
+    uniprot_with_class = _add_protein_classification_to_uniprot(uniprot_df, protein_class_df)
+    uniprot_by_ensembl = (
+        _add_ensembl_ids_to_uniprot(hgnc_df, uniprot_with_class)
+        .withColumnRenamed('proteinIds', 'pid')
+        .join(hpa_df, 'id', 'left_outer')
+        .withColumn(
+            'subcellularLocations',
+            _safe_array_union(f.col('subcellularLocations'), f.col('locations')),
+        )
+        .drop('locations')
+    )
+
+    logger.info('Building interim target DataFrame')
+    target_interim = (
+        hgnc_ensembl_go
+        .join(uniprot_by_ensembl, 'id', 'left_outer')
+        .withColumn('proteinIds', _safe_array_union(f.col('proteinIds'), f.col('pid')))
+        .withColumn(
+            'dbXrefs',
+            _safe_array_union(f.col('hgncId'), f.col('dbXrefs'), f.col('signalP'), f.col('xRef')),
+        )
+        .withColumn('symbolSynonyms', _safe_array_union(f.col('symbolSynonyms'), f.col('hgncSymbolSynonyms')))
+        .withColumn('nameSynonyms', _safe_array_union(f.col('nameSynonyms'), f.col('hgncNameSynonyms')))
+        .withColumn(
+            'synonyms',
+            _safe_array_union(f.col('synonyms'), f.col('symbolSynonyms'), f.col('nameSynonyms')),
+        )
+        .withColumn('obsoleteSymbols', _safe_array_union(f.col('hgncObsoleteSymbols')))
+        .withColumn('obsoleteNames', _safe_array_union(f.col('hgncObsoleteNames')))
+        .drop(
+            'pid', 'hgncId', 'hgncSynonyms', 'hgncNameSynonyms', 'hgncSymbolSynonyms',
+            'hgncObsoleteNames', 'hgncObsoleteSymbols', 'uniprotIds', 'signalP', 'xRef',
+        )
+        .persist()
+    )
+
+    logger.info('Building ENSG→symbol lookup')
+    ensg_lookup = _generate_ensg_lookup(target_interim).persist()
+
+    logger.info('Assembling final target DataFrame')
+    targets_df = (
+        target_interim
+        .join(genetic_constraints_df, 'id', 'left_outer')
+        .transform(lambda df: _add_tep(df, tep_df, ensg_lookup))
+        .transform(_filter_and_sort_protein_ids)
+        .transform(_remove_redundant_xrefs)
+        .transform(lambda df: _add_chemical_probes(df, chemical_probes_raw, ensg_lookup))
+        .transform(lambda df: _add_orthologues(df, homology_df))
+        .transform(lambda df: _add_tractability(df, tractability_df))
+        .transform(lambda df: _add_ncbi_synonyms(df, ncbi_df))
+        .transform(lambda df: _add_target_safety(df, safety_raw, ensg_lookup, diseases_raw))
+        .transform(lambda df: _add_reactome(df, reactome_df))
+        .transform(_remove_duplicated_synonyms)
+        .transform(_add_tss)
+    )
+
+    # Rename go → geneOntology to match platform schema
+    if 'go' in targets_df.columns:
+        targets_df = targets_df.withColumnRenamed('go', 'geneOntology')
+
+    logger.info(f'Writing target output to {destination}')
+    targets_df.write.mode('overwrite').parquet(destination)
+
+
+# ===========================================================================
+# Helper: safe array union (mirrors Spark Helpers.safeArrayUnion in Scala)
+# ===========================================================================
+
+def _safe_array_union(*cols):
+    """Return union of multiple array columns, treating nulls as empty arrays."""
+    result = f.coalesce(cols[0], f.array())
+    for col in cols[1:]:
+        result = f.array_union(result, f.coalesce(col, f.array()))
+    return result
+
+
+# ===========================================================================
+# GeneCode.scala → _build_gene_code
+# ===========================================================================
+
+def _build_gene_code(df: DataFrame) -> DataFrame:
+    """Extract canonical transcripts from GFF3 gene-code file.
+
+    Args:
+        df: Raw GFF3 DataFrame (tab-separated, no header, no comment lines).
+
+    Returns:
+        DataFrame with [id, canonicalTranscript{id, chromosome, start, end, strand}].
+    """
+    return (
+        df
+        .filter((f.col('_c2') == 'transcript') & f.col('_c8').contains('Ensembl_canonical'))
+        .select(
+            f.regexp_extract(f.col('_c8'), r'gene_id=(.*?);', 1).alias('gene_id_raw'),
+            f.regexp_extract(f.col('_c8'), r'transcript_id=(.*?);', 1).alias('transcript_id_raw'),
+            f.regexp_extract(f.col('_c0'), r'([0-9]{1,2}|X|Y|M)', 1).alias('chromosome_raw'),
+            f.col('_c3').cast(LongType()).alias('start'),
+            f.col('_c4').cast(LongType()).alias('end'),
+            f.col('_c6').alias('strand'),
+        )
+        .select(
+            f.regexp_extract(f.col('gene_id_raw'), r'(.*?)\.', 1).alias('id'),
+            f.regexp_extract(f.col('transcript_id_raw'), r'(.*?)\.', 1).alias('ct_id'),
+            f.when(f.col('chromosome_raw') == 'M', 'MT')
+             .otherwise(f.col('chromosome_raw')).alias('chromosome'),
+            'start',
+            'end',
+            'strand',
+        )
+        .distinct()
+        .select(
+            'id',
+            f.struct(
+                f.col('ct_id').alias('id'),
+                f.col('chromosome'),
+                f.col('start'),
+                f.col('end'),
+                f.col('strand'),
+            ).alias('canonicalTranscript'),
+        )
+        .withColumnRenamed('id', 'gene_id')
+    )
+
+
+# ===========================================================================
+# Ensembl.scala → _filter_ensembl / _build_ensembl
+# ===========================================================================
+
+def _filter_ensembl(df: DataFrame) -> DataFrame:
+    """Filter Ensembl genes to canonical chromosomes + reviewed genes.
+
+    Args:
+        df: Raw Ensembl DataFrame with at minimum: id, chromosome, uniprot_swissprot.
+
+    Returns:
+        Filtered DataFrame.
+    """
+    return (
+        df
+        .filter(f.col('id').startswith('ENSG'))
+        .filter(
+            f.col('chromosome').isin(INCLUDE_CHROMOSOMES)
+            | f.col('uniprot_swissprot').isNotNull()
+        )
+    )
+
+
+def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
+    """Build the Ensembl gene DataFrame.
+
+    Applies canonical chromosome filter, joins canonical transcript from GeneCode,
+    parses protein IDs and signalP, and deduplicates by id.
+
+    Args:
+        df: Raw Ensembl parquet (from intermediate/target/ensembl/homo_sapiens.parquet).
+        gene_code: Canonical transcript lookup from _build_gene_code.
+
+    Returns:
+        Ensembl DataFrame with structured fields.
+    """
+    # Parse transcripts array if present in the schema
+    has_transcripts = 'transcripts' in df.columns
+
+    ensembl = (
+        _filter_ensembl(df)
+        .select(
+            f.trim(f.col('id')).alias('id'),
+            f.regexp_replace(f.col('biotype'), r'(?i)tec', '').alias('biotype'),
+            f.col('description'),
+            f.col('end').cast(LongType()).alias('end'),
+            f.col('start').cast(LongType()).alias('start'),
+            f.col('strand').cast(IntegerType()).alias('strand'),
+            f.col('chromosome'),
+            f.col('approvedSymbol'),
+            (f.col('transcripts') if has_transcripts else f.lit(None).cast(
+                ArrayType(StructType([StructField('id', StringType())]))
+            )).alias('transcripts_raw'),
+            f.col('signalP') if 'signalP' in df.columns else f.lit(None).alias('signalP'),
+            f.col('uniprot_trembl') if 'uniprot_trembl' in df.columns else f.lit(None).alias('uniprot_trembl'),
+            f.col('uniprot_swissprot') if 'uniprot_swissprot' in df.columns else f.lit(None).alias('uniprot_swissprot'),
+        )
+        .orderBy('id')
+        .dropDuplicates(['id'])
+    )
+
+    # Join canonical transcript
+    ensembl = (
+        ensembl
+        .join(
+            gene_code.withColumnRenamed('gene_id', 'ct_gene_id'),
+            (ensembl['id'] == f.col('ct_gene_id'))
+            & (ensembl['chromosome'] == f.col('canonicalTranscript.chromosome')),
+            'left_outer',
+        )
+        .drop('ct_gene_id')
+    )
+
+    # Build genomicLocation struct
+    ensembl = ensembl.withColumn(
+        'genomicLocation',
+        f.struct(
+            f.col('chromosome'),
+            f.col('start'),
+            f.col('end'),
+            f.col('strand'),
+        ),
+    )
+
+    # approvedName from description
+    ensembl = (
+        ensembl
+        .withColumn('_desc_parts', f.split(f.col('description'), r'\['))
+        .withColumn('approvedName',
+                    f.regexp_replace(f.element_at(f.col('_desc_parts'), 1), r'(?i)tec', ''))
+        .drop('_desc_parts', 'description')
+    )
+
+    # Parse transcripts: extract id, biotype, uniprotId, etc.
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    # Build proteinIds from uniprot columns
+    ensembl = _refactor_ensembl_protein_ids(ensembl)
+
+    # Build signalP
+    ensembl = (
+        ensembl
+        .withColumn(
+            'signalP',
+            f.when(
+                f.size(f.col('signalP')) >= 0,
+                f.transform(f.col('signalP'), lambda c: f.struct(c.alias('id'), f.lit('signalP').alias('source'))),
+            ).cast(id_source_schema),
+        )
+    )
+
+    # Parse transcripts into the structured format
+    ensembl = _parse_ensembl_transcripts(ensembl)
+
+    return ensembl.select(
+        'id', 'biotype', 'approvedName', 'alternativeGenes',
+        'genomicLocation', 'approvedSymbol', 'proteinIds', 'transcripts',
+        'signalP', 'canonicalTranscript',
+    )
+
+
+def _refactor_ensembl_protein_ids(df: DataFrame) -> DataFrame:
+    """Build proteinIds from uniprot_swissprot, uniprot_trembl columns.
+
+    Also sets alternativeGenes to null (filled later).
+    """
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    has_translations = 'translations' in df.columns
+
+    swiss = (
+        f.when(
+            f.size(f.col('uniprot_swissprot')) >= 0,
+            f.transform(f.col('uniprot_swissprot'), lambda c: f.struct(c.alias('id'), f.lit('uniprot_swissprot').alias('source'))),
+        ).cast(id_source_schema)
+    )
+    trembl = (
+        f.when(
+            f.size(f.col('uniprot_trembl')) >= 0,
+            f.transform(f.col('uniprot_trembl'), lambda c: f.struct(c.alias('id'), f.lit('uniprot_trembl').alias('source'))),
+        ).cast(id_source_schema)
+    )
+
+    df = df.withColumn('_swiss', swiss).withColumn('_trembl', trembl)
+
+    if has_translations:
+        ensembl_pro = (
+            f.when(
+                f.size(f.col('translations')) >= 0,
+                f.transform(f.col('translations'), lambda c: f.struct(c.getField('id').alias('id'), f.lit('ensembl_PRO').alias('source'))),
+            ).cast(id_source_schema)
+        )
+        df = df.withColumn('_ensembl_pro', ensembl_pro)
+        protein_ids = _safe_array_union(f.col('_swiss'), f.col('_trembl'), f.col('_ensembl_pro'))
+        df = df.withColumn('proteinIds', protein_ids).drop('_swiss', '_trembl', '_ensembl_pro', 'translations', 'uniprot_swissprot', 'uniprot_trembl')
+    else:
+        protein_ids = _safe_array_union(f.col('_swiss'), f.col('_trembl'))
+        df = df.withColumn('proteinIds', protein_ids).drop('_swiss', '_trembl', 'uniprot_swissprot', 'uniprot_trembl')
+
+    return df.withColumn('alternativeGenes', f.lit(None).cast(ArrayType(StringType())))
+
+
+def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
+    """Parse raw transcripts array into structured transcript objects."""
+    transcript_schema = ArrayType(StructType([
+        StructField('transcriptId', StringType()),
+        StructField('biotype', StringType()),
+        StructField('uniprotId', StringType()),
+        StructField('isUniprotReviewed', StringType()),
+        StructField('translationId', StringType()),
+        StructField('alphafoldId', StringType()),
+        StructField('uniprotIsoformId', StringType()),
+        StructField('isEnsemblCanonical', StringType()),
+    ]))
+
+    if 'transcripts_raw' not in df.columns:
+        return df.withColumn('transcripts', f.lit(None).cast(transcript_schema))
+
+    parsed = f.when(
+        f.col('transcripts_raw').isNotNull(),
+        f.transform(
+            f.col('transcripts_raw'),
+            lambda tr: f.struct(
+                tr.getField('id').alias('transcriptId'),
+                tr.getField('biotype').alias('biotype'),
+                f.when(tr.getField('uniprot_swissprot').isNotNull(), f.element_at(tr.getField('uniprot_swissprot'), 1))
+                 .when(tr.getField('uniprot_trembl').isNotNull(), f.element_at(tr.getField('uniprot_trembl'), 1))
+                 .alias('uniprotId'),
+                f.when(tr.getField('uniprot_swissprot').isNotNull(), f.lit('true'))
+                 .when(tr.getField('uniprot_trembl').isNotNull(), f.lit('false'))
+                 .alias('isUniprotReviewed'),
+                f.when(
+                    tr.getField('translations').isNotNull(),
+                    f.element_at(tr.getField('translations'), 1).getField('id'),
+                ).alias('translationId'),
+                f.when(
+                    tr.getField('alphafold').isNotNull(),
+                    f.element_at(tr.getField('alphafold'), 1),
+                ).alias('alphafoldId'),
+                f.when(
+                    tr.getField('uniprot_isoform').isNotNull(),
+                    f.element_at(tr.getField('uniprot_isoform'), 1),
+                ).alias('uniprotIsoformId'),
+                f.lit(None).cast(StringType()).alias('isEnsemblCanonical'),
+            ),
+        ),
+    ).cast(transcript_schema)
+
+    return df.withColumn('transcripts', parsed).drop('transcripts_raw')
+
+
+# ===========================================================================
+# Hgnc.scala → _build_hgnc
+# ===========================================================================
+
+def _build_hgnc(df: DataFrame) -> DataFrame:
+    """Build the HGNC mapping DataFrame.
+
+    Args:
+        df: Raw HGNC JSON with nested response.docs array.
+
+    Returns:
+        DataFrame with [ensemblId, hgncId, approvedSymbol, approvedName,
+        hgncSynonyms, hgncSymbolSynonyms, hgncNameSynonyms,
+        hgncObsoleteSymbols, hgncObsoleteNames, uniprotIds].
+    """
+    label_source_schema = ArrayType(StructType([
+        StructField('label', StringType()),
+        StructField('source', StringType()),
+    ]))
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    docs = df.select(f.explode(f.col('response.docs')).alias('doc')).select('doc.*')
+
+    def _array_to_label_source(col_expr, source_val):
+        return f.when(
+            col_expr.isNotNull(),
+            f.transform(col_expr, lambda c: f.struct(c.alias('label'), f.lit(source_val).alias('source'))),
+        ).cast(label_source_schema)
+
+    hgnc = (
+        docs
+        .select(
+            f.col('ensembl_gene_id').alias('ensemblId'),
+            f.split(f.col('hgnc_id'), ':').alias('_hgnc_parts'),
+            f.col('symbol').alias('approvedSymbol'),
+            f.col('name').alias('approvedName'),
+            f.col('uniprot_ids').alias('uniprotIds'),
+            _safe_array_union(
+                f.col('prev_name'), f.col('prev_symbol'),
+                f.col('alias_symbol'), f.col('alias_name'),
+            ).alias('_all_synonyms'),
+            _safe_array_union(f.col('alias_symbol')).alias('_symbol_synonyms'),
+            _safe_array_union(f.col('alias_name')).alias('_name_synonyms'),
+            _safe_array_union(f.col('prev_symbol')).alias('_obsolete_symbols'),
+            _safe_array_union(f.col('prev_name')).alias('_obsolete_names'),
+        )
+        .withColumn('hgncId', f.array(
+            f.struct(
+                f.element_at(f.col('_hgnc_parts'), 2).alias('id'),
+                f.element_at(f.col('_hgnc_parts'), 1).alias('source'),
+            )
+        ).cast(id_source_schema))
+        .drop('_hgnc_parts')
+    )
+
+    for src_col, dst_col in [
+        ('_all_synonyms', 'hgncSynonyms'),
+        ('_symbol_synonyms', 'hgncSymbolSynonyms'),
+        ('_name_synonyms', 'hgncNameSynonyms'),
+        ('_obsolete_symbols', 'hgncObsoleteSymbols'),
+        ('_obsolete_names', 'hgncObsoleteNames'),
+    ]:
+        hgnc = hgnc.withColumn(
+            dst_col,
+            _array_to_label_source(f.col(src_col), 'HGNC'),
+        ).drop(src_col)
+
+    return hgnc.dropDuplicates(['ensemblId'])
+
+
+# ===========================================================================
+# Hallmarks.scala → _build_hallmarks
+# ===========================================================================
+
+def _build_hallmarks(df: DataFrame) -> DataFrame:
+    """Build the hallmarks DataFrame.
+
+    Args:
+        df: Raw COSMIC hallmarks TSV with GENE_SYMBOL, PUBMED_PMID, HALLMARK, IMPACT, DESCRIPTION.
+
+    Returns:
+        DataFrame with [approvedSymbol, hallmarks{attributes, cancerHallmarks}].
+    """
+    cancer_hallmarks_list = list(CANCER_HALLMARKS)
+
+    processed = (
+        df
+        .select(
+            f.col('GENE_SYMBOL').alias('gene_symbol'),
+            f.col('PUBMED_PMID').cast(LongType()).alias('pmid'),
+            f.col('HALLMARK').alias('hallmark'),
+            f.col('IMPACT').alias('impact'),
+            f.col('DESCRIPTION').alias('description'),
+        )
+        .withColumn('is_cancer_hallmark', f.col('hallmark').isin(cancer_hallmarks_list))
+    )
+
+    cancer_df = (
+        processed
+        .filter(f.col('is_cancer_hallmark'))
+        .select(
+            'gene_symbol',
+            f.struct(
+                f.col('pmid'),
+                f.col('description'),
+                f.col('impact'),
+                f.col('hallmark').alias('label'),
+            ).alias('cancerHallmarks'),
+        )
+        .groupBy('gene_symbol')
+        .agg(f.collect_set('cancerHallmarks').alias('cancerHallmarks'))
+    )
+
+    attrs_df = (
+        processed
+        .filter(~f.col('is_cancer_hallmark'))
+        .select(
+            'gene_symbol',
+            f.struct(
+                f.col('pmid'),
+                f.col('description'),
+                f.col('hallmark').alias('name'),
+            ).alias('attributes'),
+        )
+        .groupBy('gene_symbol')
+        .agg(f.collect_set('attributes').alias('attributes'))
+    )
+
+    return (
+        processed.select('gene_symbol').distinct()
+        .join(cancer_df, 'gene_symbol', 'left_outer')
+        .join(attrs_df, 'gene_symbol', 'left_outer')
+        .select(
+            f.col('gene_symbol').alias('approvedSymbol'),
+            f.struct(
+                f.col('attributes'),
+                f.col('cancerHallmarks'),
+            ).alias('hallmarks'),
+        )
+    )
+
+
+# ===========================================================================
+# Ncbi.scala → _build_ncbi
+# ===========================================================================
+
+def _build_ncbi(df: DataFrame) -> DataFrame:
+    """Build NCBI Entrez synonym DataFrame.
+
+    Args:
+        df: Raw NCBI gene_info TSV.
+
+    Returns:
+        DataFrame with [id, synonyms, symbolSynonyms, nameSynonyms] (LabelAndSource arrays).
+    """
+    label_source_schema = ArrayType(StructType([
+        StructField('label', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    sep = r'\|'
+
+    ncbi = (
+        df
+        .select(
+            f.split(f.col('Symbol'), sep).alias('sy'),
+            f.split(f.col('dbXrefs'), sep).alias('id_parts'),
+            f.split(f.col('Synonyms'), sep).alias('s'),
+            f.split(f.col('Other_designations'), sep).alias('od'),
+        )
+        .withColumn('id_part', f.explode(f.col('id_parts')))
+        .filter(f.col('id_part').startswith('Ensembl'))
+        .withColumn('id_split', f.split(f.col('id_part'), ':'))
+        .withColumn('ensg', f.explode(f.col('id_split')))
+        .filter(f.col('ensg').startswith('ENSG'))
+        .select(
+            f.col('ensg').alias('id'),
+            _safe_array_union(f.col('s'), f.col('od'), f.col('sy')).alias('synonyms'),
+            _safe_array_union(f.col('s'), f.col('sy')).alias('symbolSynonyms'),
+            _safe_array_union(f.col('od')).alias('nameSynonyms'),
+        )
+        .groupBy('id')
+        .agg(
+            f.flatten(f.collect_set('synonyms')).alias('synonyms'),
+            f.flatten(f.collect_set('symbolSynonyms')).alias('symbolSynonyms'),
+            f.flatten(f.collect_set('nameSynonyms')).alias('nameSynonyms'),
+        )
+    )
+
+    def _to_label_source(col_name):
+        return f.when(
+            f.col(col_name).isNotNull(),
+            f.transform(
+                f.filter(f.col(col_name), lambda c: c != '-'),
+                lambda c: f.struct(c.alias('label'), f.lit('NCBI_entrez').alias('source')),
+            ),
+        ).cast(label_source_schema)
+
+    for col_name in ['synonyms', 'symbolSynonyms', 'nameSynonyms']:
+        ncbi = ncbi.withColumn(col_name, _to_label_source(col_name))
+
+    return ncbi
+
+
+# ===========================================================================
+# GeneOntology.scala → _build_gene_ontology
+# ===========================================================================
+
+def _build_gene_ontology(
+    human: DataFrame,
+    rna: DataFrame,
+    rna_lookup: DataFrame,
+    eco_lookup: DataFrame,
+    ensembl_df: DataFrame,
+) -> DataFrame:
+    """Build gene ontology annotations grouped by Ensembl ID.
+
+    Args:
+        human: Raw human GAF file (17 columns, tab-separated).
+        rna: Raw RNA GAF file.
+        rna_lookup: RNACentral → Ensembl mapping TSV.
+        eco_lookup: ECO lookup GPA file.
+        ensembl_df: Ensembl DataFrame (used to map UniprotKB → ENSG).
+
+    Returns:
+        DataFrame with [ensemblId, go[{id, source, evidence, aspect, geneProduct, ecoId}]].
+    """
+    go_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+        StructField('evidence', StringType()),
+        StructField('aspect', StringType()),
+        StructField('geneProduct', StringType()),
+        StructField('ecoId', StringType()),
+    ]))
+
+    col_names = [
+        'database', 'dbObjectId', 'dbObjectSymbol', 'qualifier', 'goId',
+        'source', 'evidence', 'withOrFrom', 'aspect', 'dbObjectName',
+        'dbObjectSynonym', 'dbObjectType', 'taxon', 'date', 'assignedBy',
+        'annotationExtension', 'geneProductFormId',
+    ]
+
+    def _extract_go_cols(df):
+        n = len(df.columns)
+        actual_names = col_names[:n]
+        renamed = df.toDF(*actual_names)
+        return renamed.select(
+            f.col('dbObjectId'),
+            f.col('goId'),
+            f.col('source'),
+            f.col('evidence'),
+            f.col('aspect'),
+            f.col('dbObjectId').alias('geneProduct'),
+        )
+
+    human_go = _extract_go_cols(human).orderBy('goId')
+
+    rna_go = (
+        _extract_go_cols(rna)
+        .withColumn('dbObjectId', f.element_at(f.split(f.col('dbObjectId'), '_', 0), 1))
+        .orderBy('goId')
+    )
+
+    # RNA lookup: rnaCentralId → ensemblId
+    rna_lu_cols = ['rnaCentralId', 'database', 'externalId', 'ncbiTaxonId', 'rnaType', 'ensemblId']
+    n_rna = len(rna_lookup.columns)
+    rna_lu = (
+        rna_lookup.toDF(*rna_lu_cols[:n_rna])
+        .select('rnaCentralId', 'ensemblId')
+        .filter(f.col('ensemblId').startswith('ENSG0'))
+        .withColumn('ensemblId', f.regexp_extract(f.col('ensemblId'), r'ENSG[0-9]+', 0))
+    )
+
+    # Ensembl lookup: uniprotId → ensemblId
+    # Mirrors Scala: map uniprot proteinIds + approvedSymbol → ensemblId
+    human_lu = (
+        ensembl_df
+        .filter(f.col('proteinIds').isNotNull())
+        .select(
+            f.col('id').alias('ensemblId'),
+            f.col('approvedSymbol'),
+            f.col('proteinIds'),
+        )
+        # Explode proteinIds to get one row per protein accession
+        .withColumn('pid', f.explode(_safe_array_union(f.col('proteinIds.id'), f.array(f.col('approvedSymbol')))))
+        .drop('proteinIds', 'approvedSymbol')
+        .withColumnRenamed('pid', 'uniprotId')
+    )
+
+    # ECO lookup: (goId, geneProduct, evidence) → ecoId
+    if eco_lookup.columns and len(eco_lookup.columns) >= 12:
+        eco_lu = (
+            eco_lookup
+            .select(
+                f.col('_c3').alias('goId'),
+                f.col('_c1').alias('geneProduct'),
+                f.element_at(f.split(f.col('_c11'), '='), 2).alias('evidence'),
+                f.col('_c5').alias('ecoId'),
+            )
+            .distinct()
+        )
+    else:
+        from pyspark.sql import SparkSession
+        spark = SparkSession.getActiveSession()
+        eco_lu = spark.createDataFrame(
+            [],
+            StructType([
+                StructField('goId', StringType()),
+                StructField('geneProduct', StringType()),
+                StructField('evidence', StringType()),
+                StructField('ecoId', StringType()),
+            ]),
+        )
+
+    def _nest_go(df):
+        return (
+            df
+            .drop('dbObjectId')
+            .withColumnRenamed('goId', 'id')
+            .select(
+                'ensemblId',
+                f.struct('id', 'source', 'evidence', 'aspect', 'geneProduct', 'ecoId').alias('go'),
+            )
+            .groupBy('ensemblId')
+            .agg(f.collect_set('go').alias('go'))
+            .withColumn('go', f.coalesce(f.col('go'), f.array()))
+        )
+
+    rna_with_ensembl = (
+        rna_go
+        .join(rna_lu, rna_go['dbObjectId'] == rna_lu['rnaCentralId'])
+        .join(eco_lu, ['goId', 'geneProduct', 'evidence'], 'left_outer')
+        .drop('rnaCentralId')
+        .transform(_nest_go)
+    )
+
+    human_with_ensembl = (
+        human_go
+        .join(human_lu, human_go['dbObjectId'] == human_lu['uniprotId'])
+        .join(eco_lu, ['goId', 'geneProduct', 'evidence'], 'left_outer')
+        .drop('uniprotId')
+        .transform(_nest_go)
+    )
+
+    return (
+        rna_with_ensembl
+        .withColumnRenamed('go', 'go_rna')
+        .join(human_with_ensembl, 'ensemblId', 'outer')
+        .select(
+            'ensemblId',
+            f.array_union(
+                f.coalesce(f.col('go'), f.array()),
+                f.coalesce(f.col('go_rna'), f.array()),
+            ).alias('go'),
+        )
+    )
+
+
+# ===========================================================================
+# GeneWithLocation.scala → _build_gene_with_location
+# ===========================================================================
+
+def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
+    """Build subcellular locations from HPA data.
+
+    Args:
+        df: Raw HPA TSV with Gene, Main location, Additional location, Extracellular location.
+        sl_df: Subcellular location SSL ontology (HPA_location → termSL, labelSL).
+
+    Returns:
+        DataFrame with [id, locations[{location, source, termSL, labelSL}]].
+    """
+    location_source_schema = ArrayType(StructType([
+        StructField('location', StringType()),
+        StructField('source', StringType()),
+        StructField('termSL', StringType()),
+        StructField('labelSL', StringType()),
+    ]))
+
+    def _to_loc_source(col_expr, source_val):
+        return f.when(
+            col_expr.isNotNull(),
+            f.transform(
+                f.split(col_expr, ';'),
+                lambda c: f.struct(f.trim(c).alias('location'), f.lit(source_val).alias('source')),
+            ),
+        )
+
+    hpa = (
+        df
+        .select(
+            f.col('Gene').alias('id'),
+            _to_loc_source(f.col('Main location'), 'HPA_main').alias('HPA_main'),
+            _to_loc_source(f.col('Additional location'), 'HPA_additional').alias('HPA_additional'),
+            _to_loc_source(f.col('Extracellular location'), 'HPA_extracellular_location').alias('HPA_extracellular_location'),
+        )
+        .withColumn(
+            'all_locations',
+            f.explode(_safe_array_union(f.col('HPA_main'), f.col('HPA_additional'), f.col('HPA_extracellular_location'))),
+        )
+        .select('id', f.col('all_locations.location').alias('location'), f.col('all_locations.source').alias('source'))
+        .join(sl_df, f.col('location') == sl_df['HPA_location'], 'left_outer')
+        .select(
+            'id',
+            f.struct('location', 'source', 'termSL', 'labelSL').alias('locations'),
+        )
+        .groupBy('id')
+        .agg(f.collect_list('locations').alias('locations'))
+    )
+
+    return hpa
+
+
+# ===========================================================================
+# ProjectScores.scala → _build_project_scores
+# ===========================================================================
+
+def _build_project_scores(ids_df: DataFrame, matrix_df: DataFrame) -> DataFrame:
+    """Build project scores (DepMap) cross-references.
+
+    Args:
+        ids_df: Gene identifiers mapping (gene_id, ensembl_gene_id, hgnc_symbol).
+        matrix_df: Binary dependency scores matrix (Gene column + per-cell-line columns).
+
+    Returns:
+        DataFrame with [id, xRef[{id, source}]].
+    """
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    ps_ids = (
+        ids_df
+        .filter(f.col('ensembl_gene_id').isNotNull())
+        .select(
+            f.col('gene_id').alias('ps_gene_id'),
+            f.col('ensembl_gene_id'),
+            f.col('hgnc_symbol'),
+        )
+    )
+
+    # Sum all per-cell-line columns to identify genes with any dependency
+    data_cols = [c for c in matrix_df.columns if c != 'Gene']
+    totals = matrix_df
+    for c in data_cols:
+        totals = totals.withColumn('_total', f.coalesce(f.col('_total') if '_total' in totals.columns else f.lit(0), f.lit(0)) + f.coalesce(f.col(f'`{c}`'), f.lit(0)))
+
+    # Simpler approach: unpivot and sum
+    total_df = (
+        matrix_df
+        .select('Gene', f.lit(1).alias('_present'))
+        .filter(f.col('_present') > 0)
+        .select('Gene')
+    )
+
+    # Build a proper total using stack expression
+    if data_cols:
+        stack_expr = f'stack({len(data_cols)}, {", ".join([f"`{c}`" for c in data_cols])}) as val'
+        total_df = (
+            matrix_df
+            .select('Gene', f.expr(stack_expr).alias('val'))
+            .groupBy('Gene')
+            .agg(f.sum('val').alias('total'))
+            .filter(f.col('total') > 0)
+        )
+
+    return (
+        total_df
+        .join(ps_ids, total_df['Gene'] == ps_ids['hgnc_symbol'])
+        .select(
+            f.col('ensembl_gene_id').alias('id'),
+            f.array(f.struct(
+                f.col('ps_gene_id').alias('id'),
+                f.lit('ProjectScore').alias('source'),
+            )).cast(id_source_schema).alias('xRef'),
+        )
+    )
+
+
+# ===========================================================================
+# ProteinClassification.scala → _build_protein_classification
+# ===========================================================================
+
+def _build_protein_classification(df: DataFrame) -> DataFrame:
+    """Build protein target classification from ChEMBL.
+
+    Args:
+        df: Raw ChEMBL target JSONL.
+
+    Returns:
+        DataFrame with [accession, targetClass[{id, label, level}]].
+    """
+    pc_schema = ArrayType(StructType([
+        StructField('id', LongType()),
+        StructField('label', StringType()),
+        StructField('level', StringType()),
+    ]))
+
+    accession_pc = (
+        df
+        .select(
+            f.explode(
+                f.arrays_zip(
+                    f.col('_metadata.protein_classification'),
+                    f.col('target_components.accession'),
+                )
+            ).alias('s')
+        )
+        .select(
+            f.col('s.accession').alias('accession'),
+            f.col('s.protein_classification.*'),
+        )
+    )
+
+    levels = [f'l{i}' for i in range(1, 7)]
+
+    def _to_struct(level):
+        return f.struct(
+            f.col('protein_class_id').alias('id'),
+            f.col(level).alias('label'),
+            f.lit(level).alias('level'),
+        )
+
+    expanded = accession_pc
+    for lvl in levels:
+        expanded = expanded.withColumn(lvl, _to_struct(lvl))
+
+    return (
+        expanded
+        .select('accession', f.array(*levels).alias('levels'))
+        .groupBy('accession')
+        .agg(f.flatten(f.collect_set('levels')).alias('levels'))
+        .select('accession', f.explode('levels').alias('l'))
+        .select('accession', f.col('l.*'))
+        .filter(f.col('label').isNotNull())
+        .select('accession', f.struct('id', 'label', 'level').alias('pc'))
+        .groupBy('accession')
+        .agg(f.collect_set('pc').alias('targetClass'))
+    )
+
+
+# ===========================================================================
+# GeneticConstraints.scala → _build_genetic_constraints
+# ===========================================================================
+
+def _build_genetic_constraints(df: DataFrame) -> DataFrame:
+    """Build genetic constraints (gnomAD).
+
+    Args:
+        df: Raw gnomAD constraint metrics TSV.
+
+    Returns:
+        DataFrame with [id, constraint[{constraintType, score, exp, obs, oe, oeLower, oeUpper,
+        upperRank, upperBin, upperBin6}]].
+    """
+    constraint_schema = ArrayType(StructType([
+        StructField('constraintType', StringType()),
+        StructField('score', FloatType()),
+        StructField('exp', FloatType()),
+        StructField('obs', IntegerType()),
+        StructField('oe', FloatType()),
+        StructField('oeLower', FloatType()),
+        StructField('oeUpper', FloatType()),
+        StructField('upperRank', IntegerType()),
+        StructField('upperBin', IntegerType()),
+        StructField('upperBin6', IntegerType()),
+    ]))
+
+    filtered = (
+        df
+        .filter((f.col('canonical') == 'true') & (f.col('transcript_type') != 'NA'))
+    )
+
+    # Compute sextile bin for lof
+    w = Window.orderBy(f.col('`lof.oe_ci.upper_rank`').cast(IntegerType()))
+    filtered = filtered.withColumn(
+        'lof_upper_bin6',
+        f.when(
+            f.col('`lof.oe_ci.upper_rank`') != 'NA',
+            f.ntile(6).over(w) - 1,
+        ).otherwise(None),
+    )
+
+    return (
+        filtered
+        .select(
+            f.col('gene_id').cast(StringType()).alias('id'),
+            f.array(
+                f.struct(
+                    f.lit('syn').alias('constraintType'),
+                    f.col('`syn.z_score`').cast(FloatType()).alias('score'),
+                    f.col('`syn.exp`').cast(FloatType()).alias('exp'),
+                    f.col('`syn.obs`').cast(IntegerType()).alias('obs'),
+                    f.col('`syn.oe`').cast(FloatType()).alias('oe'),
+                    f.col('`syn.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                    f.col('`syn.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                    f.lit(None).cast(IntegerType()).alias('upperRank'),
+                    f.lit(None).cast(IntegerType()).alias('upperBin'),
+                    f.lit(None).cast(IntegerType()).alias('upperBin6'),
+                ),
+                f.struct(
+                    f.lit('mis').alias('constraintType'),
+                    f.col('`mis.z_score`').cast(FloatType()).alias('score'),
+                    f.col('`mis.exp`').cast(FloatType()).alias('exp'),
+                    f.col('`mis.obs`').cast(IntegerType()).alias('obs'),
+                    f.col('`mis.oe`').cast(FloatType()).alias('oe'),
+                    f.col('`mis.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                    f.col('`mis.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                    f.lit(None).cast(IntegerType()).alias('upperRank'),
+                    f.lit(None).cast(IntegerType()).alias('upperBin'),
+                    f.lit(None).cast(IntegerType()).alias('upperBin6'),
+                ),
+                f.struct(
+                    f.lit('lof').alias('constraintType'),
+                    f.col('`lof.pLI`').cast(FloatType()).alias('score'),
+                    f.col('`lof.exp`').cast(FloatType()).alias('exp'),
+                    f.col('`lof.obs`').cast(IntegerType()).alias('obs'),
+                    f.col('`lof.oe`').cast(FloatType()).alias('oe'),
+                    f.col('`lof.oe_ci.lower`').cast(FloatType()).alias('oeLower'),
+                    f.col('`lof.oe_ci.upper`').cast(FloatType()).alias('oeUpper'),
+                    f.col('`lof.oe_ci.upper_rank`').cast(IntegerType()).alias('upperRank'),
+                    f.col('`lof.oe_ci.upper_bin_decile`').cast(IntegerType()).alias('upperBin'),
+                    f.col('lof_upper_bin6').cast(IntegerType()).alias('upperBin6'),
+                ),
+            ).alias('constraint'),
+        )
+    )
+
+
+# ===========================================================================
+# Ortholog.scala → _build_homologues
+# ===========================================================================
+
+def _build_homologues(
+    homology_dict: DataFrame,
+    coding_proteins: DataFrame,
+    gene_dict: DataFrame,
+    target_species: list[str],
+) -> DataFrame:
+    """Build homologue/ortholog DataFrame.
+
+    Args:
+        homology_dict: Ensembl vertebrates species dictionary.
+        coding_proteins: Ensembl compara homologies TSV (protein + ncrna).
+        gene_dict: Gene ID → gene name mapping (pre-processed parquet).
+        target_species: Whitelisted species in format "TAXID-species_name".
+
+    Returns:
+        DataFrame with homolog fields including speciesId, speciesName, homologyType, etc.
+    """
+    # Extract tax IDs from whitelist
+    tax_ids = [s.split('-')[0] for s in target_species]
+    priority_df_data = [(s.split('-')[0], i) for i, s in enumerate(target_species)]
+
+    from pyspark.sql import SparkSession
+    spark = SparkSession.getActiveSession()
+    priority_df = spark.createDataFrame(priority_df_data, ['speciesId', 'priority'])
+
+    homo_dict = (
+        homology_dict
+        .select(
+            f.col('#name').alias('name'),
+            f.col('species').alias('speciesName'),
+            f.col('taxonomy_id'),
+            f.array(*[f.lit(t) for t in tax_ids]).alias('whitelist'),
+        )
+        .filter(f.array_contains(f.col('whitelist'), f.col('taxonomy_id')))
+    )
+
+    gene_dict_mapped = (
+        gene_dict
+        .select(
+            f.col('id').alias('homology_gene_stable_id'),
+            f.when(f.col('name').isNotNull() & (f.col('name') != ''), f.col('name'))
+             .otherwise(f.col('id')).alias('targetGeneSymbol'),
+        )
+    )
+
+    reference = 'homo_sapiens'
+
+    # homo_sapiens homologies
+    homo_sapiens_h = coding_proteins.filter(f.col('species') == reference)
+
+    # paralogs and cross-species
+    other_h = (
+        coding_proteins
+        .filter(
+            (
+                (f.col('species') == reference)
+                & (
+                    (f.col('homology_type') == 'other_paralog')
+                    | (f.col('homology_type') == 'within_species_paralog')
+                )
+            )
+            | (
+                (f.col('species') != reference)
+                & (f.col('homology_species') == reference)
+            )
+        )
+        # swap homo_sapiens ↔ homology columns
+        .select(
+            f.col('homology_gene_stable_id').alias('gene_stable_id'),
+            f.col('homology_protein_stable_id').alias('protein_stable_id'),
+            f.col('homology_species').alias('species'),
+            f.col('homology_identity').alias('identity'),
+            f.col('homology_type'),
+            f.col('gene_stable_id').alias('homology_gene_stable_id'),
+            f.col('protein_stable_id').alias('homology_protein_stable_id'),
+            f.col('species').alias('homology_species'),
+            f.col('identity').alias('homology_identity'),
+            f.col('dn'),
+            f.col('ds'),
+            f.col('goc_score'),
+            f.col('wga_coverage'),
+            f.col('is_high_confidence'),
+            f.col('homology_id'),
+        )
+    )
+
+    all_homologies = homo_sapiens_h.unionByName(other_h)
+
+    return (
+        all_homologies
+        .join(homo_dict, all_homologies['homology_species'] == homo_dict['speciesName'])
+        .join(gene_dict_mapped, 'homology_gene_stable_id', 'left_outer')
+        .select(
+            f.col('gene_stable_id').alias('id'),
+            f.col('taxonomy_id').alias('speciesId'),
+            f.col('name').alias('speciesName'),
+            f.col('homology_type').alias('homologyType'),
+            f.col('homology_gene_stable_id').alias('targetGeneId'),
+            f.col('is_high_confidence').alias('isHighConfidence'),
+            f.col('targetGeneSymbol'),
+            f.col('identity').cast(DoubleType()).alias('queryPercentageIdentity'),
+            f.col('homology_identity').cast(DoubleType()).alias('targetPercentageIdentity'),
+        )
+        .join(f.broadcast(priority_df), 'speciesId', 'left_outer')
+    )
+
+
+# ===========================================================================
+# Reactome.scala → _build_reactome
+# ===========================================================================
+
+def _build_reactome(reactome_pathways: DataFrame, reactome_etl: DataFrame) -> DataFrame:
+    """Build reactome pathways grouped by Ensembl ID.
+
+    Args:
+        reactome_pathways: Ensembl2Reactome.txt (6-column TSV).
+        reactome_etl: Reactome ETL output (id, label, path).
+
+    Returns:
+        DataFrame with [id, pathways[{pathwayId, pathway, topLevelTerm}]].
+    """
+    rp_cols = ['ensemblId', 'reactomeId', 'url', 'eventName', 'eventCode', 'species']
+
+    rp = (
+        reactome_pathways
+        .toDF(*rp_cols)
+        .filter(f.col('species') == 'Homo sapiens')
+        .filter(f.col('ensemblId').startswith('ENSG'))
+        .select('ensemblId', 'reactomeId', 'eventName')
+    )
+
+    top_level_terms = (
+        reactome_etl
+        .select(
+            f.col('id'),
+            f.element_at(f.element_at(f.col('path'), 1), 1).alias('tlId'),
+        )
+        .join(
+            reactome_etl.select(f.col('id').alias('tlId'), f.col('label').alias('topLevelTerm')),
+            'tlId',
+        )
+        .select(f.col('id').alias('reactomeId'), 'topLevelTerm')
+    )
+
+    return (
+        rp
+        .join(top_level_terms, 'reactomeId')
+        .groupBy('ensemblId')
+        .agg(
+            f.collect_set(
+                f.struct(
+                    f.col('reactomeId').alias('pathwayId'),
+                    f.col('eventName').alias('pathway'),
+                    f.col('topLevelTerm'),
+                )
+            ).alias('pathways')
+        )
+        .withColumnRenamed('ensemblId', 'id')
+    )
+
+
+# ===========================================================================
+# Tractability.scala → _build_tractability
+# ===========================================================================
+
+def _build_tractability(df: DataFrame) -> DataFrame:
+    """Build tractability assessments.
+
+    Args:
+        df: Raw tractability TSV. Columns with pattern *_B{N}_* are tractability buckets.
+
+    Returns:
+        DataFrame with [ensemblGeneId, tractability[{modality, id, value}]].
+    """
+    import re
+    bucket_cols = [c for c in df.columns if re.match(r'.*_B\d+_.*', c)]
+    tractability = df.select('ensembl_gene_id', *bucket_cols)
+    data_cols = [c for c in tractability.columns if c != 'ensembl_gene_id']
+
+    for col_name in data_cols:
+        parts = col_name.split('_')
+        tractability = tractability.withColumn(
+            col_name,
+            f.struct(
+                f.lit(parts[0]).alias('modality'),
+                f.lit(parts[-1]).alias('id'),
+                f.when(f.col(f'`{col_name}`') == 1, True).otherwise(False).alias('value'),
+            ),
+        )
+
+    return (
+        tractability
+        .select(
+            f.col('ensembl_gene_id').alias('ensemblGeneId'),
+            f.array(*data_cols).alias('tractability'),
+        )
+    )
+
+
+# ===========================================================================
+# Uniprot (pre-processed parquet) → _build_uniprot
+# ===========================================================================
+
+def _build_uniprot(df: DataFrame, ssl_df: DataFrame) -> DataFrame:
+    """Build Uniprot DataFrame from pre-processed parquet.
+
+    The pre-processing step in pts_pre_target converts the Uniprot XML flat-file
+    into a parquet with UniprotEntry fields:
+        accessions, names, synonyms, symbolSynonyms, functions, dbXrefs, locations.
+
+    Args:
+        df: Pre-processed Uniprot parquet.
+        ssl_df: Subcellular location SSL ontology mapping.
+
+    Returns:
+        DataFrame with [uniprotId, synonyms, symbolSynonyms, nameSynonyms,
+        functionDescriptions, proteinIds, subcellularLocations, dbXrefs].
+    """
+    label_source_schema = ArrayType(StructType([
+        StructField('label', StringType()),
+        StructField('source', StringType()),
+    ]))
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+    loc_source_schema = ArrayType(StructType([
+        StructField('location', StringType()),
+        StructField('source', StringType()),
+        StructField('termSL', StringType()),
+        StructField('labelSL', StringType()),
+    ]))
+
+    base = (
+        df
+        .filter(f.size(f.col('accessions')) > 0)
+        .select(
+            f.element_at(f.col('accessions'), 1).alias('uniprotId'),
+            _safe_array_union(f.col('names'), f.col('synonyms')).alias('_name_syns'),
+            _safe_array_union(f.col('symbolSynonyms')).alias('_symbol_syns'),
+            _safe_array_union(
+                _safe_array_union(f.col('names')),
+                _safe_array_union(f.col('symbolSynonyms')),
+            ).alias('_synonyms'),
+            f.col('functions').alias('functionDescriptions'),
+            f.col('dbXrefs'),
+            f.col('accessions'),
+            f.col('locations'),
+        )
+    )
+
+    # Handle dbXrefs: "ID SOURCE" → struct(id, source)
+    base = (
+        base
+        .withColumn(
+            'dbXrefs',
+            f.when(
+                f.col('dbXrefs').isNotNull(),
+                f.transform(
+                    f.col('dbXrefs'),
+                    lambda c: f.struct(
+                        f.element_at(f.split(c, ' '), 2).alias('id'),
+                        f.element_at(f.split(c, ' '), 1).alias('source'),
+                    ),
+                ),
+            ).cast(id_source_schema),
+        )
+    )
+
+    # Map locations → subcellularLocations using SSL ontology
+    base = _map_uniprot_locations_to_ssl(base, ssl_df)
+
+    # Build proteinIds (old accessions → uniprot_obsolete)
+    base = base.withColumn(
+        'proteinIds',
+        f.when(
+            f.col('accessions').isNotNull(),
+            f.transform(f.col('accessions'), lambda c: f.struct(f.trim(c).alias('id'), f.lit('uniprot_obsolete').alias('source'))),
+        ).cast(id_source_schema),
+    )
+
+    # Add synonyms as LabelAndSource
+    for src_col, dst_col in [
+        ('_synonyms', 'synonyms'),
+        ('_symbol_syns', 'symbolSynonyms'),
+        ('_name_syns', 'nameSynonyms'),
+    ]:
+        base = base.withColumn(
+            dst_col,
+            f.when(
+                f.col(src_col).isNotNull(),
+                f.transform(f.col(src_col), lambda c: f.struct(c.alias('label'), f.lit('uniprot').alias('source'))),
+            ).cast(label_source_schema),
+        ).drop(src_col)
+
+    return base.drop('accessions', 'locations')
+
+
+def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame:
+    """Map raw Uniprot location strings to SSL ontology terms."""
+    first_words_regex = r'^([\w\s]+)'
+    isoforms_regex = r'(\[.+\]:\s([\w\s]+))'
+    last_after_comma_regex = r'.*,\s([\w\s]+)'
+
+    ssl_onto = ssl_df.select(
+        f.col('Subcellular location ID').alias('termSL'),
+        f.col('Name').alias('ssl_match'),
+        f.col('Category').alias('labelSL'),
+    ) if 'Subcellular location ID' in ssl_df.columns else ssl_df.select(
+        f.col('termSL'),
+        f.col('ssl_match'),
+        f.col('labelSL'),
+    )
+
+    loc_df = (
+        df.select('uniprotId', f.explode('locations').alias('location'))
+        .select(
+            'uniprotId',
+            f.trim(f.regexp_extract('location', first_words_regex, 0)).alias('loc1'),
+            f.trim(f.regexp_extract('location', isoforms_regex, 1)).alias('iso'),
+            f.trim(f.regexp_extract('location', isoforms_regex, 2)).alias('loc2'),
+            f.trim(f.regexp_extract('location', last_after_comma_regex, 1)).alias('loc3'),
+        )
+        .withColumn(
+            'ssl_match',
+            f.when(f.col('loc1') != '', f.col('loc1'))
+             .when(f.col('loc2') != '', f.col('loc2'))
+             .when(f.col('loc3') != '', f.col('loc3'))
+             .otherwise(f.lit(None)),
+        )
+        .withColumn('location', f.when(f.col('iso') != '', f.col('iso')).otherwise(f.col('ssl_match')))
+        .drop('iso', 'loc1', 'loc2', 'loc3')
+        .filter(f.col('location').isNotNull())
+        .join(f.broadcast(ssl_onto), 'ssl_match', 'left_outer')
+        .drop('ssl_match')
+        .withColumn('source', f.lit('uniprot'))
+        .select('uniprotId', f.struct('location', 'source', 'termSL', 'labelSL').alias('loc'))
+        .groupBy('uniprotId')
+        .agg(f.collect_list('loc').alias('subcellularLocations'))
+    )
+
+    return df.drop('locations').join(loc_df, 'uniprotId', 'left_outer')
+
+
+# ===========================================================================
+# Safety.scala → _build_safety
+# ===========================================================================
+
+def _build_safety(
+    safety_df: DataFrame,
+    ensg_lookup: DataFrame,
+    diseases_df: DataFrame,
+) -> DataFrame:
+    """Build target safety liabilities.
+
+    Args:
+        safety_df: Pre-processed safety evidence parquet.
+        ensg_lookup: ENSG ID lookup table (ensgId, name array).
+        diseases_df: Disease index (id, obsoleteTerms).
+
+    Returns:
+        DataFrame with [id, safetyLiabilities[{event, eventId, effects, ...}]].
+    """
+    # Add missing ENSG IDs for entries that only have symbol (e.g. ToxCast)
+    enriched = (
+        safety_df
+        .join(ensg_lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')), 'left_outer')
+        .drop(*[c for c in ensg_lookup.columns if c != 'ensgId'])
+        .withColumn('temp_id', f.coalesce(f.col('id'), f.col('ensgId')))
+        .drop('id', 'ensgId')
+        .withColumnRenamed('temp_id', 'id')
+    )
+
+    # Replace obsolete EFOs
+    disease_mapping = (
+        diseases_df
+        .select(f.col('id').alias('diseaseId'), f.explode(f.col('obsoleteTerms')).alias('obsoleteTerm'))
+    )
+
+    enriched = (
+        enriched
+        .join(disease_mapping, enriched['eventId'] == disease_mapping['obsoleteTerm'], 'left_outer')
+        .withColumn('eventId', f.coalesce(f.col('diseaseId'), f.col('eventId')))
+        .drop('obsoleteTerm', 'diseaseId')
+    )
+
+    return (
+        enriched
+        .select(
+            'id',
+            f.struct(
+                'event', 'eventId', 'effects', 'biosamples',
+                'datasource', 'literature', 'url', 'studies',
+            ).alias('safety'),
+        )
+        .groupBy('id')
+        .agg(f.collect_set('safety').alias('safetyLiabilities'))
+    )
+
+
+# ===========================================================================
+# Tep.scala → _build_tep
+# ===========================================================================
+
+def _build_tep(df: DataFrame) -> DataFrame:
+    """Build TEP (Target Enabling Package) DataFrame.
+
+    Args:
+        df: Raw TEP JSON.
+
+    Returns:
+        DataFrame with [targetFromSourceId, description, therapeuticArea, url].
+    """
+    return df.select(
+        f.trim(f.col('targetFromSourceId')).alias('targetFromSourceId'),
+        f.trim(f.col('description')).alias('description'),
+        f.trim(f.col('therapeuticArea')).alias('therapeuticArea'),
+        f.trim(f.col('url')).alias('url'),
+    )
+
+
+# ===========================================================================
+# Assembly helpers (mirrors Target.scala private methods)
+# ===========================================================================
+
+def _merge_hgnc_ensembl(hgnc_df: DataFrame, ensembl_df: DataFrame) -> DataFrame:
+    """Merge HGNC and Ensembl; HGNC fields take precedence.
+
+    Args:
+        hgnc_df: HGNC DataFrame from _build_hgnc.
+        ensembl_df: Ensembl DataFrame from _build_ensembl.
+
+    Returns:
+        Merged DataFrame.
+    """
+    e = (
+        ensembl_df
+        .withColumnRenamed('approvedName', '_an')
+        .withColumnRenamed('approvedSymbol', '_as')
+    )
+
+    return (
+        e
+        .join(hgnc_df, e['id'] == hgnc_df['ensemblId'], 'left_outer')
+        .withColumn('approvedName', f.coalesce(f.col('approvedName'), f.col('_an'), f.lit('')))
+        .withColumn('approvedSymbol', f.coalesce(f.col('approvedSymbol'), f.col('_as'), f.col('id')))
+        .drop('_an', '_as', 'ensemblId')
+    )
+
+
+def _add_ensembl_ids_to_uniprot(hgnc_df: DataFrame, uniprot_df: DataFrame) -> DataFrame:
+    """Group Uniprot entries by Ensembl ID using HGNC as the mapping key.
+
+    Args:
+        hgnc_df: HGNC DataFrame with [ensemblId, uniprotIds, ...].
+        uniprot_df: Uniprot DataFrame with [uniprotId, ...].
+
+    Returns:
+        Uniprot data grouped by Ensembl id (column renamed to 'id').
+    """
+    id_source_schema = ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))
+
+    mapping = (
+        hgnc_df
+        .select('ensemblId', f.explode('uniprotIds').alias('uniprotId'))
+        .withColumn(
+            'uniprotProteinId',
+            f.struct(
+                f.col('uniprotId').alias('id'),
+                f.lit('uniprot_obsolete').alias('source'),
+            ),
+        )
+    )
+
+    grouped = (
+        mapping
+        .join(uniprot_df, 'uniprotId')
+        .groupBy('ensemblId')
+        .agg(
+            f.flatten(f.collect_set('synonyms')).alias('synonyms'),
+            f.flatten(f.collect_set('symbolSynonyms')).alias('symbolSynonyms'),
+            f.flatten(f.collect_set('nameSynonyms')).alias('nameSynonyms'),
+            f.flatten(f.collect_set('functionDescriptions')).alias('functionDescriptions'),
+            f.flatten(f.collect_set('proteinIds')).alias('proteinIds'),
+            f.flatten(f.collect_set('subcellularLocations')).alias('subcellularLocations'),
+            f.flatten(f.collect_set('dbXrefs')).alias('dbXrefs'),
+            f.collect_set('uniprotProteinId').alias('uniprotProteinId'),
+            f.flatten(f.collect_set('targetClass')).alias('targetClass'),
+        )
+        .withColumn(
+            'targetClass',
+            f.when(f.size('targetClass') < 1, f.lit(None)).otherwise(f.col('targetClass')),
+        )
+        .withColumnRenamed('ensemblId', 'id')
+        .withColumn(
+            'proteinIds',
+            _safe_array_union(f.col('proteinIds'), f.col('uniprotProteinId').cast(id_source_schema)),
+        )
+        .drop('uniprotId', 'uniprotProteinId')
+    )
+
+    return grouped
+
+
+def _add_protein_classification_to_uniprot(
+    uniprot_df: DataFrame,
+    protein_class_df: DataFrame,
+) -> DataFrame:
+    """Add protein classification (targetClass) to Uniprot entries."""
+    pc_with_uniprot = (
+        uniprot_df
+        .select(
+            'uniprotId',
+            f.explode(
+                _safe_array_union(f.array(f.col('uniprotId')), f.col('proteinIds.id'))
+            ).alias('pid'),
+        )
+        .withColumn('pid', f.trim('pid'))
+        .join(protein_class_df, f.col('pid') == protein_class_df['accession'], 'left_outer')
+        .drop('accession')
+        .groupBy('uniprotId')
+        .agg(f.flatten(f.collect_set('targetClass')).alias('targetClass'))
+    )
+
+    return uniprot_df.join(pc_with_uniprot, 'uniprotId', 'left_outer')
+
+
+def _generate_ensg_lookup(df: DataFrame) -> DataFrame:
+    """Generate ENSG → symbol / uniprot / HGNC lookup table."""
+    safe_union = _safe_array_union
+
+    return (
+        df
+        .select(
+            'id',
+            f.col('proteinIds.id').alias('pid'),
+            f.array(f.col('approvedSymbol')).alias('as_arr'),
+            f.filter(f.col('synonyms'), lambda c: c.getField('source') == 'uniprot').alias('uniprot'),
+            f.filter(f.col('synonyms'), lambda c: c.getField('source') == 'HGNC').alias('HGNC_syns'),
+            f.array_distinct(
+                safe_union(
+                    f.col('proteinIds.id'),
+                    f.col('symbolSynonyms.label'),
+                    f.col('obsoleteSymbols.label') if 'obsoleteSymbols' in df.columns else f.array(),
+                    f.array(f.col('approvedSymbol')),
+                )
+            ).alias('symbols'),
+        )
+        .select(
+            'id',
+            f.flatten(f.array(f.col('pid'), f.col('as_arr'))).alias('name'),
+            f.col('uniprot.label').alias('uniprot'),
+            f.col('HGNC_syns.label').alias('HGNC'),
+            'symbols',
+        )
+        .select(
+            f.col('id').alias('ensgId'),
+            f.col('name'),
+            'uniprot',
+            'HGNC',
+            'symbols',
+        )
+    )
+
+
+def _add_tep(df: DataFrame, tep_df: DataFrame, lookup: DataFrame) -> DataFrame:
+    """Join TEP data using symbol→ENSG lookup."""
+    lut = (
+        lookup
+        .select(f.col('ensgId').alias('id'), 'symbols')
+        .withColumn('symbol', f.explode('symbols'))
+        .drop('symbols')
+    )
+
+    tep_fields = ['targetFromSourceId', 'description', 'therapeuticArea', 'url']
+    tep_with_id = (
+        tep_df
+        .join(lut, lut['symbol'] == tep_df['targetFromSourceId'])
+        .withColumn('tep', f.struct(*tep_fields))
+        .select('id', 'tep')
+    )
+
+    return df.join(tep_with_id, 'id', 'left_outer')
+
+
+def _filter_and_sort_protein_ids(df: DataFrame) -> DataFrame:
+    """Deduplicate proteinIds and sort by source preference."""
+    from pyspark.sql import SparkSession
+
+    def _sort_protein_ids(accessions):
+        """UDF: deduplicate and sort by source priority."""
+        if not accessions:
+            return []
+        seen = {}
+        split_token = '-'
+        for entry in accessions:
+            parts = entry.split(split_token, 1)
+            if len(parts) < 2:
+                continue
+            pid, src = parts[0].strip(), parts[1]
+            if pid not in seen:
+                seen[pid] = src
+
+        def _priority(item):
+            pid, src = item
+            if 'swiss' in src:
+                return (1, pid)
+            if 'trembl' in src:
+                return (2, pid)
+            if src.endswith('uniprot'):
+                return (3, pid)
+            if 'ensembl' in src:
+                return (4, pid)
+            return (5, pid)
+
+        sorted_items = sorted(seen.items(), key=_priority)
+        return [f'{pid}-{src}' for pid, src in sorted_items]
+
+    from pyspark.sql.functions import udf
+    from pyspark.sql.types import ArrayType, StringType
+    sort_udf = udf(_sort_protein_ids, ArrayType(StringType()))
+
+    split_token = '-'
+    ensembl_id = 'eid'
+    protein_id = 'proteinIds'
+
+    deduped = (
+        df
+        .select(f.col('id').alias(ensembl_id), f.explode(f.col(protein_id)).alias('p'))
+        .select(ensembl_id, f.col('p.*'))
+        .withColumn('arr', f.array_join(f.array(f.trim(f.col('id')), f.col('source')), split_token))
+        .groupBy(ensembl_id)
+        .agg(f.collect_list('arr').alias('accessions'))
+        .select(f.col(ensembl_id), sort_udf(f.col('accessions')).alias('accessions'))
+        .select(f.col(ensembl_id), f.explode('accessions').alias('accessions'))
+        .withColumn('id_and_source', f.split('accessions', split_token))
+        .select(
+            f.col(ensembl_id),
+            f.element_at(f.col('id_and_source'), 1).alias('id'),
+            f.element_at(f.col('id_and_source'), 2).alias('source'),
+        )
+        .select(f.col(ensembl_id), f.struct('id', 'source').alias(protein_id))
+        .groupBy(ensembl_id)
+        .agg(f.collect_list(protein_id).alias(protein_id))
+        .withColumnRenamed(ensembl_id, 'id')
+    )
+
+    return df.drop(protein_id).join(deduped, 'id', 'left_outer')
+
+
+def _remove_redundant_xrefs(df: DataFrame) -> DataFrame:
+    """Remove GO and Ensembl entries from dbXrefs."""
+    cols = [c for c in df.columns if c != 'dbXrefs']
+    cols.append("filter(dbXrefs, s -> s.source != 'GO' and s.source != 'Ensembl') as dbXrefs")
+    return df.selectExpr(*cols)
+
+
+def _add_chemical_probes(df: DataFrame, cp_df: DataFrame, lookup: DataFrame) -> DataFrame:
+    """Join chemical probes using symbol lookup."""
+    cp_with_id = (
+        cp_df
+        .join(lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')))
+        .drop(*[c for c in lookup.columns if c != 'ensgId'])
+    )
+
+    cp_cols = [c for c in cp_df.columns if c != 'ensgId']
+    cp_grouped = (
+        cp_with_id
+        .select(
+            f.col('ensgId').alias('id'),
+            f.struct(*cp_cols).alias('probe'),
+        )
+        .groupBy('id')
+        .agg(f.collect_list('probe').alias('chemicalProbes'))
+    )
+
+    return df.join(f.broadcast(cp_grouped), 'id', 'left_outer')
+
+
+def _add_orthologues(df: DataFrame, orthologs: DataFrame) -> DataFrame:
+    """Add homologues to target DataFrame."""
+    gene_symbols = df.select('id', 'approvedSymbol').cache()
+
+    paralog_symbols = (
+        gene_symbols
+        .withColumnRenamed('approvedSymbol', 'paralogGeneSymbol')
+        .withColumnRenamed('id', 'paralogId')
+    )
+
+    homo_df = (
+        orthologs
+        .join(f.broadcast(gene_symbols), 'id')
+        .join(
+            f.broadcast(paralog_symbols),
+            f.col('paralogId') == f.col('targetGeneId'),
+            'left_outer',
+        )
+        .withColumn(
+            'targetGeneSymbol',
+            f.coalesce(f.col('paralogGeneSymbol'), f.col('targetGeneSymbol'), f.col('approvedSymbol')),
+        )
+        .drop('approvedSymbol', 'paralogGeneSymbol', 'paralogId')
+    )
+
+    homo_cols = [c for c in homo_df.columns if c != 'id']
+    grouped = (
+        homo_df
+        .select('id', f.struct(*homo_cols).alias('homologues'))
+        .groupBy('id')
+        .agg(f.collect_list('homologues').alias('homologues'))
+        # Sort by priority (ascending = closest species first)
+        .withColumn('homologues', f.expr('array_sort(homologues, (x, y) -> x.priority - y.priority)'))
+    )
+
+    return df.join(grouped, 'id', 'left_outer').drop('humanGeneId')
+
+
+def _add_tractability(df: DataFrame, tractability: DataFrame) -> DataFrame:
+    """Join tractability data."""
+    return (
+        df
+        .join(tractability, f.col('ensemblGeneId') == f.col('id'), 'left_outer')
+        .drop('ensemblGeneId')
+    )
+
+
+def _add_ncbi_synonyms(df: DataFrame, ncbi: DataFrame) -> DataFrame:
+    """Add NCBI Entrez synonyms."""
+    ncbi_renamed = (
+        ncbi
+        .withColumnRenamed('synonyms', '_s')
+        .withColumnRenamed('nameSynonyms', '_ns')
+        .withColumnRenamed('symbolSynonyms', '_ss')
+    )
+
+    return (
+        df
+        .join(ncbi_renamed, 'id', 'left_outer')
+        .withColumn('symbolSynonyms', _safe_array_union(f.col('symbolSynonyms'), f.col('_ss')))
+        .withColumn('nameSynonyms', _safe_array_union(f.col('nameSynonyms'), f.col('_ns')))
+        .withColumn('synonyms', _safe_array_union(f.col('synonyms'), f.col('_s'), f.col('_ns'), f.col('_ss')))
+        .drop('_s', '_ss', '_ns')
+    )
+
+
+def _add_target_safety(
+    df: DataFrame,
+    safety_raw: DataFrame,
+    ensg_lookup: DataFrame,
+    diseases_df: DataFrame,
+) -> DataFrame:
+    """Add target safety liabilities."""
+    safety = _build_safety(safety_raw, ensg_lookup, diseases_df)
+    return df.join(safety, 'id', 'left_outer')
+
+
+def _add_reactome(df: DataFrame, reactome: DataFrame) -> DataFrame:
+    """Add Reactome pathways."""
+    return df.join(reactome, 'id', 'left_outer')
+
+
+def _remove_duplicated_synonyms(df: DataFrame) -> DataFrame:
+    """Deduplicate synonym arrays."""
+    for col_name in ['synonyms', 'symbolSynonyms', 'nameSynonyms', 'obsoleteNames', 'obsoleteSymbols']:
+        if col_name in df.columns:
+            df = df.withColumn(col_name, f.array_distinct(f.col(col_name)))
+    return df
+
+
+def _add_tss(df: DataFrame) -> DataFrame:
+    """Add transcription start site column."""
+    return df.withColumn(
+        'tss',
+        f.when(f.col('canonicalTranscript.strand') == '+', f.col('canonicalTranscript.start'))
+         .when(f.col('canonicalTranscript.strand') == '-', f.col('canonicalTranscript.end')),
+    )

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -111,7 +111,7 @@ _PROTEIN_SOURCE_PRIORITY = {
 
 def target(
     source: dict[str, str],
-    destination: str,
+    destination: dict[str, str],
     settings: dict[str, Any],
     properties: dict[str, str],
 ) -> None:
@@ -119,7 +119,7 @@ def target(
 
     Args:
         source: Mapping of logical input names to paths.
-        destination: Output path for the target parquet.
+        destination: Dict with keys 'target' and 'gene_essentiality' output paths.
         settings: Step settings (hgncOrthologSpecies list, etc.).
         properties: Spark properties.
     """
@@ -161,6 +161,7 @@ def target(
     safety_raw = spark.read.parquet(source['safety_evidence'])
     diseases_raw = spark.read.parquet(source['diseases'])
     chemical_probes_raw = spark.read.parquet(source['chemical_probes'])
+    gene_essentiality_raw = spark.read.parquet(source['gene_essentiality'])
 
     # Uniprot is a gzipped XML flat-file — we read a pre-processed parquet
     # produced by the pts_target pre-processing step (uniprot XML→parquet).
@@ -323,8 +324,13 @@ def target(
     if 'go' in targets_df.columns:
         targets_df = targets_df.withColumnRenamed('go', 'geneOntology')
 
-    logger.info(f'Writing target output to {destination}')
-    targets_df.write.mode('overwrite').parquet(destination)
+    logger.info(f'Writing target output to {destination["target"]}')
+    targets_df.write.mode('overwrite').parquet(destination['target'])
+
+    logger.info('Building gene essentiality output')
+    gene_essentiality_df = _build_gene_essentiality_output(gene_essentiality_raw, ensg_lookup)
+    logger.info(f'Writing gene essentiality output to {destination["gene_essentiality"]}')
+    gene_essentiality_df.write.mode('overwrite').parquet(destination['gene_essentiality'])
 
 
 # ===========================================================================
@@ -1783,6 +1789,47 @@ def _generate_ensg_lookup(df: DataFrame) -> DataFrame:
             'HGNC',
             'symbols',
         )
+    )
+
+
+def _build_gene_essentiality_output(
+    essentiality_df: DataFrame,
+    ensg_lookup: DataFrame,
+) -> DataFrame:
+    """Build gene essentiality output mapped to ENSG IDs.
+
+    Ports addGeneEssentiality from Target.scala.
+
+    Args:
+        essentiality_df: Gene essentiality intermediate with targetSymbol column.
+        ensg_lookup: ENSG→symbol lookup from _generate_ensg_lookup.
+
+    Returns:
+        DataFrame with [id, geneEssentiality] where geneEssentiality is a list
+        of essentiality structs per ENSG ID.
+    """
+    lookup = (
+        ensg_lookup
+        .select('ensgId', 'name')
+        .withColumn('approvedTarget', f.explode('name'))
+        .drop('name')
+        .orderBy('approvedTarget')
+    )
+    essentiality_cols = [c for c in essentiality_df.columns if c != 'targetSymbol']
+    essentiality_with_ensg = (
+        essentiality_df
+        .join(lookup, lookup['approvedTarget'] == essentiality_df['targetSymbol'], 'inner')
+        .drop(*[c for c in lookup.columns if c != 'ensgId'])
+        .drop('targetSymbol')
+    )
+    return (
+        essentiality_with_ensg
+        .select(
+            f.col('ensgId').alias('id'),
+            f.struct(*[f.col(c) for c in essentiality_cols]).alias('ts'),
+        )
+        .groupBy('id')
+        .agg(f.collect_list('ts').alias('geneEssentiality'))
     )
 
 

--- a/src/pts/transformers/uniprot.py
+++ b/src/pts/transformers/uniprot.py
@@ -38,6 +38,7 @@ def _parse_record(lines: list[str]) -> dict:
     db_xrefs: list[str] = []
     functions: list[str] = []
     locations: list[str] = []
+    gn_lines: list[str] = []  # accumulated across continuation lines
 
     # CC state machine
     cc_topic: str | None = None
@@ -47,17 +48,21 @@ def _parse_record(lines: list[str]) -> dict:
         if cc_topic is None:
             return
         text = ' '.join(cc_lines).strip()
-        text = _strip_braces(text)
         if cc_topic == 'FUNCTION':
             if text:
                 functions.append(text)
         elif cc_topic == 'SUBCELLULAR LOCATION':
-            # Split by period, skip Note= segments
+            text = _strip_braces(text)
+            # Split by period; stop at first Note= segment (its continuation
+            # sentences don't start with Note= but are still part of the note)
             parts = text.split('.')
             for part in parts:
                 p = part.strip()
-                if p and not p.startswith('Note=') and not p.startswith('Note '):
-                    locations.append(p)
+                if not p:
+                    continue
+                if p.startswith(('Note=', 'Note ')):
+                    break
+                locations.append(p)
 
     for raw in lines:
         if len(raw) < 2:
@@ -90,30 +95,14 @@ def _parse_record(lines: list[str]) -> dict:
             elif content_clean.startswith('AltName: CD_antigen='):
                 val = content_clean[len('AltName: CD_antigen=') :].rstrip(';').strip()
                 if val:
-                    synonyms.append(val)
+                    symbol_synonyms.append(val)
             elif content_clean.startswith('Short='):
-                # Short names go into synonyms
                 val = content_clean[len('Short=') :].rstrip(';').strip()
                 if val:
-                    synonyms.append(val)
+                    symbol_synonyms.append(val)
 
         elif code == 'GN':
-            # Collect all GN line content, then parse
-            content_clean = _strip_braces(content).strip()
-            # Parse key=value pairs split by ";"
-            for segment in content_clean.split(';'):
-                segment = segment.strip()
-                if not segment:
-                    continue
-                if '=' in segment:
-                    key, _, value = segment.partition('=')
-                    key = key.strip()
-                    value = value.strip()
-                    if key in ('Name', 'Synonyms', 'ORFNames'):
-                        for v in value.split(','):
-                            v = v.strip().rstrip(';')
-                            if v:
-                                symbol_synonyms.append(v)
+            gn_lines.append(content)
 
         elif code == 'DR':
             content_clean = _strip_braces(content).strip()
@@ -125,7 +114,12 @@ def _parse_record(lines: list[str]) -> dict:
 
         elif code == 'CC':
             content_clean = _strip_braces(content)
-            if content_clean.startswith('-!- '):
+            if content_clean.lstrip().startswith('-----'):
+                # Copyright separator — flush and stop CC parsing
+                _flush_cc()
+                cc_topic = None
+                cc_lines = []
+            elif content_clean.startswith('-!- '):
                 # Flush previous CC block
                 _flush_cc()
                 cc_lines = []
@@ -146,6 +140,23 @@ def _parse_record(lines: list[str]) -> dict:
                     cc_lines.append(continuation)
 
     _flush_cc()
+
+    # Parse accumulated GN lines as one block so _strip_braces handles
+    # multi-line {ECO:...} evidence codes correctly.
+    gn_text = _strip_braces(' '.join(gn_lines))
+    for segment in gn_text.split(';'):
+        segment = segment.strip()
+        if not segment:
+            continue
+        if '=' in segment:
+            key, _, value = segment.partition('=')
+            key = key.strip()
+            value = value.strip()
+            if key in ('Name', 'Synonyms', 'ORFNames'):
+                for v in value.split(','):
+                    v = v.strip().rstrip(';')
+                    if v:
+                        symbol_synonyms.append(v)
 
     return {
         'id': entry_id,

--- a/src/pts/transformers/uniprot.py
+++ b/src/pts/transformers/uniprot.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+import gzip
+import re
+from typing import Any
+
+import polars as pl
+from loguru import logger
+from otter.config.model import Config
+from otter.storage.synchronous.handle import StorageHandle
+
+_UNIPROT_SCHEMA = pl.Schema({
+    'id': pl.String,
+    'accessions': pl.List(pl.String),
+    'names': pl.List(pl.String),
+    'synonyms': pl.List(pl.String),
+    'symbolSynonyms': pl.List(pl.String),
+    'dbXrefs': pl.List(pl.String),
+    'functions': pl.List(pl.String),
+    'locations': pl.List(pl.String),
+})
+
+_DB_INTEREST = {'ChEMBL', 'DrugBank', 'PDB', 'Ensembl', 'GO', 'InterPro', 'Reactome'}
+
+_BRACES_RE = re.compile(r'\{[^}]*\}')
+
+
+def _strip_braces(text: str) -> str:
+    return _BRACES_RE.sub('', text).strip()
+
+
+def _parse_record(lines: list[str]) -> dict:
+    entry_id = ''
+    accessions: list[str] = []
+    names: list[str] = []
+    synonyms: list[str] = []
+    symbol_synonyms: list[str] = []
+    db_xrefs: list[str] = []
+    functions: list[str] = []
+    locations: list[str] = []
+
+    # CC state machine
+    cc_topic: str | None = None
+    cc_lines: list[str] = []
+
+    def _flush_cc() -> None:
+        if cc_topic is None:
+            return
+        text = ' '.join(cc_lines).strip()
+        text = _strip_braces(text)
+        if cc_topic == 'FUNCTION':
+            if text:
+                functions.append(text)
+        elif cc_topic == 'SUBCELLULAR LOCATION':
+            # Split by period, skip Note= segments
+            parts = text.split('.')
+            for part in parts:
+                p = part.strip()
+                if p and not p.startswith('Note=') and not p.startswith('Note '):
+                    locations.append(p)
+
+    for raw in lines:
+        if len(raw) < 2:
+            continue
+        code = raw[:2]
+        content = raw[5:] if len(raw) > 5 else ''
+
+        if code == 'ID':
+            tokens = content.split()
+            if tokens:
+                entry_id = tokens[0]
+
+        elif code == 'AC':
+            content_clean = _strip_braces(content)
+            for ac in content_clean.split(';'):
+                ac = ac.strip()
+                if ac:
+                    accessions.append(ac)
+
+        elif code == 'DE':
+            content_clean = _strip_braces(content).strip()
+            if content_clean.startswith('RecName: Full='):
+                val = content_clean[len('RecName: Full=') :].rstrip(';').strip()
+                if val:
+                    names.append(val)
+            elif content_clean.startswith('AltName: Full='):
+                val = content_clean[len('AltName: Full=') :].rstrip(';').strip()
+                if val:
+                    synonyms.append(val)
+            elif content_clean.startswith('AltName: CD_antigen='):
+                val = content_clean[len('AltName: CD_antigen=') :].rstrip(';').strip()
+                if val:
+                    synonyms.append(val)
+            elif content_clean.startswith('Short='):
+                # Short names go into synonyms
+                val = content_clean[len('Short=') :].rstrip(';').strip()
+                if val:
+                    synonyms.append(val)
+
+        elif code == 'GN':
+            # Collect all GN line content, then parse
+            content_clean = _strip_braces(content).strip()
+            # Parse key=value pairs split by ";"
+            for segment in content_clean.split(';'):
+                segment = segment.strip()
+                if not segment:
+                    continue
+                if '=' in segment:
+                    key, _, value = segment.partition('=')
+                    key = key.strip()
+                    value = value.strip()
+                    if key in ('Name', 'Synonyms', 'ORFNames'):
+                        for v in value.split(','):
+                            v = v.strip().rstrip(';')
+                            if v:
+                                symbol_synonyms.append(v)
+
+        elif code == 'DR':
+            content_clean = _strip_braces(content).strip()
+            tokens = [t.rstrip(';').rstrip('.').strip() for t in content_clean.split(';')]
+            tokens = [t for t in tokens if t]
+            if tokens and tokens[0] in _DB_INTEREST:
+                if len(tokens) >= 2:
+                    db_xrefs.append(f'{tokens[1]} {tokens[0]}')
+
+        elif code == 'CC':
+            content_clean = _strip_braces(content)
+            if content_clean.startswith('-!- '):
+                # Flush previous CC block
+                _flush_cc()
+                cc_lines = []
+                # Extract topic and first line of content
+                rest = content_clean[4:]
+                if ': ' in rest:
+                    topic, _, first_line = rest.partition(': ')
+                    cc_topic = topic.strip()
+                    first_line = first_line.strip()
+                    if first_line:
+                        cc_lines.append(first_line)
+                else:
+                    cc_topic = rest.strip()
+            elif cc_topic is not None:
+                # Continuation line — strip leading spaces
+                continuation = content_clean.strip()
+                if continuation:
+                    cc_lines.append(continuation)
+
+    _flush_cc()
+
+    return {
+        'id': entry_id,
+        'accessions': accessions,
+        'names': names,
+        'synonyms': synonyms,
+        'symbolSynonyms': symbol_synonyms,
+        'dbXrefs': db_xrefs,
+        'functions': functions,
+        'locations': locations,
+    }
+
+
+def _parse_uniprot(file_obj) -> list[dict]:
+    records: list[dict] = []
+    current_lines: list[str] = []
+    count = 0
+
+    for raw_line in file_obj:
+        if isinstance(raw_line, bytes):
+            line = raw_line.decode('utf-8', errors='replace').rstrip('\n')
+        else:
+            line = raw_line.rstrip('\n')
+
+        if line.startswith('//'):
+            if current_lines:
+                records.append(_parse_record(current_lines))
+                count += 1
+                if count % 10000 == 0:
+                    logger.info(f'parsed {count} uniprot records')
+                current_lines = []
+        else:
+            current_lines.append(line)
+
+    # Handle any trailing record without '//'
+    if current_lines:
+        records.append(_parse_record(current_lines))
+
+    logger.info(f'parsed {len(records)} uniprot records total')
+    return records
+
+
+def uniprot(
+    source: str,
+    destination: str,
+    settings: dict[str, Any],
+    config: Config,
+) -> None:
+    logger.info(f'loading uniprot flat file from {source}')
+    h = StorageHandle(source)
+
+    with h.open('rb') as raw:
+        if source.endswith('.gz'):
+            with gzip.open(raw, 'rb') as gz:
+                rows = _parse_uniprot(gz)
+        else:
+            rows = _parse_uniprot(raw)
+
+    logger.info('creating dataframe from parsed uniprot data')
+    df = pl.DataFrame(rows, schema=_UNIPROT_SCHEMA)
+
+    logger.info(f'writing uniprot parquet to {destination}')
+    df.write_parquet(destination)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -1,0 +1,674 @@
+"""Tests for the target pyspark module.
+
+Ported from platform-etl-backend target step.
+"""
+
+import pytest
+from pyspark.sql import Row
+from pyspark.sql import functions as f
+from pyspark.sql.types import (
+    ArrayType,
+    BooleanType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from pts.pyspark.target import (
+    _build_gene_ontology,
+    _build_genetic_constraints,
+    _build_hallmarks,
+    _build_hgnc,
+    _build_homologues,
+    _build_reactome,
+    _build_safety,
+    _filter_ensembl,
+    _merge_hgnc_ensembl,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper builders
+# ---------------------------------------------------------------------------
+
+INCLUDE_CHROMS = [str(i) for i in range(1, 23)] + ['X', 'Y', 'MT']
+
+
+def _spark_df(spark, data, schema):
+    return spark.createDataFrame(data, schema)
+
+
+# ---------------------------------------------------------------------------
+# 1. Ensembl gene filtering (canonical chromosomes, protein-coding filter)
+# ---------------------------------------------------------------------------
+
+ENSEMBL_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('chromosome', StringType()),
+    StructField('biotype', StringType()),
+    StructField('start', LongType()),
+    StructField('end', LongType()),
+    StructField('strand', IntegerType()),
+    StructField('description', StringType()),
+    StructField('approvedSymbol', StringType()),
+    StructField('transcripts', ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('biotype', StringType()),
+    ]))),
+    StructField('uniprot_swissprot', ArrayType(StringType())),
+    StructField('uniprot_trembl', ArrayType(StringType())),
+    StructField('translations', ArrayType(StructType([StructField('id', StringType())]))),
+    StructField('signalP', ArrayType(StringType())),
+])
+
+
+def _ensembl_row(id, chromosome, biotype='protein_coding', swissprot=None):
+    return Row(
+        id=id,
+        chromosome=chromosome,
+        biotype=biotype,
+        start=1000,
+        end=2000,
+        strand=1,
+        description='test description [Source:test]',
+        approvedSymbol=id,
+        transcripts=[],
+        uniprot_swissprot=swissprot,
+        uniprot_trembl=None,
+        translations=[],
+        signalP=None,
+    )
+
+
+def test_ensembl_keeps_canonical_chromosomes(spark):
+    """Genes on canonical chromosomes 1-22, X, Y, MT are retained."""
+    data = [
+        _ensembl_row('ENSG00000001', '1'),
+        _ensembl_row('ENSG00000002', 'X'),
+        _ensembl_row('ENSG00000003', 'MT'),
+        _ensembl_row('ENSG00000004', 'CHR_HSCHR6_MHC_APD_CTG1'),  # non-canonical, no swissprot
+    ]
+    df = spark.createDataFrame(data, ENSEMBL_SCHEMA)
+    result = _filter_ensembl(df)
+    ids = {row.id for row in result.collect()}
+    assert 'ENSG00000001' in ids
+    assert 'ENSG00000002' in ids
+    assert 'ENSG00000003' in ids
+    assert 'ENSG00000004' not in ids
+
+
+def test_ensembl_keeps_reviewed_non_canonical(spark):
+    """Genes with uniprot_swissprot on non-canonical chromosomes are kept."""
+    data = [
+        _ensembl_row('ENSG00000005', 'CHR_HSCHR6_MHC_APD_CTG1', swissprot=['P00533']),
+    ]
+    df = spark.createDataFrame(data, ENSEMBL_SCHEMA)
+    result = _filter_ensembl(df)
+    ids = {row.id for row in result.collect()}
+    assert 'ENSG00000005' in ids
+
+
+def test_ensembl_filters_non_ensg(spark):
+    """Non-ENSG IDs are excluded."""
+    data = [
+        _ensembl_row('ENSG00000006', '1'),
+        _ensembl_row('LRG_71', '1'),
+    ]
+    df = spark.createDataFrame(data, ENSEMBL_SCHEMA)
+    result = _filter_ensembl(df)
+    ids = {row.id for row in result.collect()}
+    assert 'ENSG00000006' in ids
+    assert 'LRG_71' not in ids
+
+
+# ---------------------------------------------------------------------------
+# 2. HGNC symbol mapping
+# ---------------------------------------------------------------------------
+
+HGNC_SCHEMA = StructType([
+    StructField('response', StructType([
+        StructField('docs', ArrayType(StructType([
+            StructField('ensembl_gene_id', StringType()),
+            StructField('hgnc_id', StringType()),
+            StructField('symbol', StringType()),
+            StructField('name', StringType()),
+            StructField('uniprot_ids', ArrayType(StringType())),
+            StructField('alias_symbol', ArrayType(StringType())),
+            StructField('alias_name', ArrayType(StringType())),
+            StructField('prev_symbol', ArrayType(StringType())),
+            StructField('prev_name', ArrayType(StringType())),
+        ])))
+    ]))
+])
+
+
+def test_hgnc_symbol_mapping(spark):
+    """HGNC maps ensembl_gene_id to approvedSymbol and approvedName."""
+    data = [{
+        'response': {
+            'docs': [{
+                'ensembl_gene_id': 'ENSG00000141510',
+                'hgnc_id': 'HGNC:11998',
+                'symbol': 'TP53',
+                'name': 'tumor protein p53',
+                'uniprot_ids': ['P04637'],
+                'alias_symbol': None,
+                'alias_name': None,
+                'prev_symbol': None,
+                'prev_name': None,
+            }]
+        }
+    }]
+    df = spark.createDataFrame(data, HGNC_SCHEMA)
+    result = _build_hgnc(df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.ensemblId == 'ENSG00000141510'
+    assert row.approvedSymbol == 'TP53'
+    assert row.approvedName == 'tumor protein p53'
+
+
+# ---------------------------------------------------------------------------
+# 3. GO annotation grouping by aspect (BP, MF, CC)
+# ---------------------------------------------------------------------------
+
+GO_HUMAN_SCHEMA = StructType([
+    StructField('_c0', StringType()),  # database
+    StructField('_c1', StringType()),  # dbObjectId
+    StructField('_c2', StringType()),  # dbObjectSymbol
+    StructField('_c3', StringType()),  # qualifier
+    StructField('_c4', StringType()),  # goId
+    StructField('_c5', StringType()),  # dbReference
+    StructField('_c6', StringType()),  # evidenceCode
+    StructField('_c7', StringType()),  # withOrFrom
+    StructField('_c8', StringType()),  # aspect
+    StructField('_c9', StringType()),  # dbObjectName
+    StructField('_c10', StringType()), # dbObjectSynonym
+    StructField('_c11', StringType()), # dbObjectType
+    StructField('_c12', StringType()), # taxon
+    StructField('_c13', StringType()), # date
+    StructField('_c14', StringType()), # assignedBy
+    StructField('_c15', StringType()), # annotationExtension
+    StructField('_c16', StringType()), # geneProductFormId
+])
+
+
+def _go_row(db_obj_id, go_id, evidence, aspect, db_ref='PMID:1234'):
+    return Row(
+        _c0='UniProtKB',
+        _c1=db_obj_id,
+        _c2='SYMBOL',
+        _c3='enables',
+        _c4=go_id,
+        _c5=db_ref,
+        _c6=evidence,
+        _c7='',
+        _c8=aspect,
+        _c9='Protein name',
+        _c10='',
+        _c11='protein',
+        _c12='taxon:9606',
+        _c13='20230101',
+        _c14='UniProt',
+        _c15='',
+        _c16='',
+    )
+
+
+def test_go_grouping_by_aspect(spark):
+    """GO annotations are grouped per Ensembl ID with aspect preserved."""
+    human_data = [
+        _go_row('P04637', 'GO:0003677', 'IDA', 'F'),  # MF
+        _go_row('P04637', 'GO:0008150', 'TAS', 'P'),  # BP
+        _go_row('P04637', 'GO:0005634', 'IDA', 'C'),  # CC
+    ]
+    human_df = spark.createDataFrame(human_data, GO_HUMAN_SCHEMA)
+    rna_df = spark.createDataFrame([], GO_HUMAN_SCHEMA)
+
+    rna_lookup_schema = StructType([
+        StructField('_c0', StringType()),
+        StructField('_c1', StringType()),
+        StructField('_c2', StringType()),
+        StructField('_c3', StringType()),
+        StructField('_c4', StringType()),
+        StructField('_c5', StringType()),
+    ])
+    rna_lookup_df = spark.createDataFrame([], rna_lookup_schema)
+
+    eco_schema = StructType([
+        StructField('_c1', StringType()),
+        StructField('_c3', StringType()),
+        StructField('_c5', StringType()),
+        StructField('_c11', StringType()),
+    ])
+    eco_df = spark.createDataFrame([], eco_schema)
+
+    # Build a minimal ensembl-like lookup for GO
+    ensembl_go_schema = StructType([
+        StructField('id', StringType()),
+        StructField('approvedSymbol', StringType()),
+        StructField('proteinIds', ArrayType(StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ]))),
+    ])
+    ensembl_go_data = [Row(id='ENSG00000141510', approvedSymbol='TP53',
+                           proteinIds=[Row(id='P04637', source='uniprot_swissprot')])]
+    ensembl_df = spark.createDataFrame(ensembl_go_data, ensembl_go_schema)
+
+    result = _build_gene_ontology(human_df, rna_df, rna_lookup_df, eco_df, ensembl_df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.ensemblId == 'ENSG00000141510'
+    aspects = {g.aspect for g in row.go}
+    assert 'F' in aspects
+    assert 'P' in aspects
+    assert 'C' in aspects
+
+
+# ---------------------------------------------------------------------------
+# 4. Homologue filtering by species whitelist
+# ---------------------------------------------------------------------------
+
+def test_homologue_whitelist_filtering(spark):
+    """Only species in whitelist are included in homologues."""
+    homology_dict_schema = StructType([
+        StructField('#name', StringType()),
+        StructField('species', StringType()),
+        StructField('taxonomy_id', StringType()),
+    ])
+    homology_dict_data = [
+        Row(**{'#name': 'mus_musculus', 'species': 'mus_musculus', 'taxonomy_id': '10090'}),
+        Row(**{'#name': 'rattus_norvegicus', 'species': 'rattus_norvegicus', 'taxonomy_id': '10116'}),
+        Row(**{'#name': 'danio_rerio', 'species': 'danio_rerio', 'taxonomy_id': '7955'}),
+    ]
+    homology_dict_df = spark.createDataFrame(homology_dict_data, homology_dict_schema)
+
+    coding_proteins_schema = StructType([
+        StructField('gene_stable_id', StringType()),
+        StructField('protein_stable_id', StringType()),
+        StructField('species', StringType()),
+        StructField('identity', DoubleType()),
+        StructField('homology_type', StringType()),
+        StructField('homology_gene_stable_id', StringType()),
+        StructField('homology_protein_stable_id', StringType()),
+        StructField('homology_species', StringType()),
+        StructField('homology_identity', DoubleType()),
+        StructField('dn', DoubleType()),
+        StructField('ds', DoubleType()),
+        StructField('goc_score', DoubleType()),
+        StructField('wga_coverage', DoubleType()),
+        StructField('is_high_confidence', StringType()),
+        StructField('homology_id', StringType()),
+    ])
+    coding_proteins_data = [
+        Row(gene_stable_id='ENSG0001', protein_stable_id='P001',
+            species='homo_sapiens', identity=100.0,
+            homology_type='ortholog_one2one',
+            homology_gene_stable_id='ENSMUSG0001',
+            homology_protein_stable_id='P002',
+            homology_species='mus_musculus',
+            homology_identity=88.0, dn=None, ds=None,
+            goc_score=None, wga_coverage=None,
+            is_high_confidence='1', homology_id='h001'),
+        # rat — NOT in whitelist
+        Row(gene_stable_id='ENSG0001', protein_stable_id='P001',
+            species='homo_sapiens', identity=100.0,
+            homology_type='ortholog_one2one',
+            homology_gene_stable_id='ENSRNOG0001',
+            homology_protein_stable_id='P003',
+            homology_species='rattus_norvegicus',
+            homology_identity=85.0, dn=None, ds=None,
+            goc_score=None, wga_coverage=None,
+            is_high_confidence='1', homology_id='h002'),
+    ]
+    coding_proteins_df = spark.createDataFrame(coding_proteins_data, coding_proteins_schema)
+
+    gene_dict_schema = StructType([
+        StructField('id', StringType()),
+        StructField('name', StringType()),
+    ])
+    gene_dict_df = spark.createDataFrame(
+        [Row(id='ENSMUSG0001', name='Trp53')],
+        gene_dict_schema,
+    )
+
+    # Only mouse in whitelist (10090), not rat (10116)
+    whitelist = ['10090-mus_musculus']
+    result = _build_homologues(homology_dict_df, coding_proteins_df, gene_dict_df, whitelist)
+    rows = result.collect()
+    species_ids = {r.speciesId for r in rows}
+    assert '10090' in species_ids
+    assert '10116' not in species_ids
+
+
+# ---------------------------------------------------------------------------
+# 5. Safety evidence aggregation
+# ---------------------------------------------------------------------------
+
+def test_safety_evidence_aggregation(spark):
+    """Safety evidence is grouped by ENSG id into safetyLiabilities."""
+    safety_schema = StructType([
+        StructField('id', StringType()),
+        StructField('targetFromSourceId', StringType()),
+        StructField('event', StringType()),
+        StructField('eventId', StringType()),
+        StructField('effects', ArrayType(StructType([
+            StructField('direction', StringType()),
+            StructField('dosing', StringType()),
+        ]))),
+        StructField('biosamples', ArrayType(StructType([
+            StructField('tissueLabel', StringType()),
+            StructField('tissueId', StringType()),
+            StructField('cellLabel', StringType()),
+            StructField('cellFormat', StringType()),
+        ]))),
+        StructField('datasource', StringType()),
+        StructField('literature', StringType()),
+        StructField('url', StringType()),
+        StructField('studies', ArrayType(StructType([
+            StructField('name', StringType()),
+            StructField('description', StringType()),
+            StructField('type', StringType()),
+        ]))),
+    ])
+    safety_data = [
+        Row(id='ENSG00000141510', targetFromSourceId='TP53',
+            event='heart failure', eventId='EFO_0003777',
+            effects=[Row(direction='Activation/Increase/Upregulation', dosing='general')],
+            biosamples=None, datasource='TestSource',
+            literature='12345678', url=None, studies=None),
+        Row(id='ENSG00000141510', targetFromSourceId='TP53',
+            event='liver toxicity', eventId='EFO_0001234',
+            effects=None, biosamples=None, datasource='TestSource2',
+            literature=None, url=None, studies=None),
+        Row(id='ENSG00000012048', targetFromSourceId='BRCA1',
+            event='breast cancer', eventId='MONDO_0007254',
+            effects=None, biosamples=None, datasource='TestSource',
+            literature=None, url=None, studies=None),
+    ]
+    safety_df = spark.createDataFrame(safety_data, safety_schema)
+
+    # lookup df: ensgId -> name (array)
+    lookup_schema = StructType([
+        StructField('ensgId', StringType()),
+        StructField('name', ArrayType(StringType())),
+        StructField('uniprot', ArrayType(StringType())),
+        StructField('HGNC', ArrayType(StringType())),
+        StructField('symbols', ArrayType(StringType())),
+    ])
+    lookup_data = [
+        Row(ensgId='ENSG00000141510', name=['P04637', 'TP53'],
+            uniprot=['P04637'], HGNC=['TP53'], symbols=['TP53']),
+    ]
+    lookup_df = spark.createDataFrame(lookup_data, lookup_schema)
+
+    # disease df for EFO replacement (empty — no obsolete terms to replace)
+    disease_schema = StructType([
+        StructField('id', StringType()),
+        StructField('obsoleteTerms', ArrayType(StringType())),
+    ])
+    disease_df = spark.createDataFrame([], disease_schema)
+
+    result = _build_safety(safety_df, lookup_df, disease_df)
+    rows = {r.id: r for r in result.collect()}
+
+    # Both ENSG ids should appear
+    assert 'ENSG00000141510' in rows
+    # TP53 has 2 safety liabilities
+    assert len(rows['ENSG00000141510'].safetyLiabilities) == 2
+
+
+# ---------------------------------------------------------------------------
+# 6. Genetic constraints
+# ---------------------------------------------------------------------------
+
+def test_genetic_constraints_structure(spark):
+    """Genetic constraints are grouped as an array with syn/mis/lof entries."""
+    constraint_schema = StructType([
+        StructField('gene_id', StringType()),
+        StructField('canonical', StringType()),
+        StructField('transcript_type', StringType()),
+        StructField('syn.z_score', StringType()),
+        StructField('syn.exp', StringType()),
+        StructField('syn.obs', StringType()),
+        StructField('syn.oe', StringType()),
+        StructField('syn.oe_ci.lower', StringType()),
+        StructField('syn.oe_ci.upper', StringType()),
+        StructField('mis.z_score', StringType()),
+        StructField('mis.exp', StringType()),
+        StructField('mis.obs', StringType()),
+        StructField('mis.oe', StringType()),
+        StructField('mis.oe_ci.lower', StringType()),
+        StructField('mis.oe_ci.upper', StringType()),
+        StructField('lof.pLI', StringType()),
+        StructField('lof.exp', StringType()),
+        StructField('lof.obs', StringType()),
+        StructField('lof.oe', StringType()),
+        StructField('lof.oe_ci.lower', StringType()),
+        StructField('lof.oe_ci.upper', StringType()),
+        StructField('lof.oe_ci.upper_rank', StringType()),
+        StructField('lof.oe_ci.upper_bin_decile', StringType()),
+    ])
+    constraint_data = [{
+        'gene_id': 'ENSG00000141510',
+        'canonical': 'true',
+        'transcript_type': 'protein_coding',
+        'syn.z_score': '1.23',
+        'syn.exp': '100.5',
+        'syn.obs': '95',
+        'syn.oe': '0.95',
+        'syn.oe_ci.lower': '0.8',
+        'syn.oe_ci.upper': '1.1',
+        'mis.z_score': '2.5',
+        'mis.exp': '200.0',
+        'mis.obs': '180',
+        'mis.oe': '0.9',
+        'mis.oe_ci.lower': '0.75',
+        'mis.oe_ci.upper': '1.05',
+        'lof.pLI': '0.99',
+        'lof.exp': '50.0',
+        'lof.obs': '5',
+        'lof.oe': '0.1',
+        'lof.oe_ci.lower': '0.05',
+        'lof.oe_ci.upper': '0.2',
+        'lof.oe_ci.upper_rank': '1000',
+        'lof.oe_ci.upper_bin_decile': '1',
+    }]
+    df = spark.createDataFrame(constraint_data, constraint_schema)
+    result = _build_genetic_constraints(df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == 'ENSG00000141510'
+    constraint_types = {c.constraintType for c in row.constraint}
+    assert constraint_types == {'syn', 'mis', 'lof'}
+
+
+# ---------------------------------------------------------------------------
+# 7. Hallmarks
+# ---------------------------------------------------------------------------
+
+def test_hallmarks_split_cancer_vs_non_cancer(spark):
+    """Hallmarks splits records into cancerHallmarks and attributes."""
+    hallmark_schema = StructType([
+        StructField('GENE_SYMBOL', StringType()),
+        StructField('PUBMED_PMID', StringType()),
+        StructField('HALLMARK', StringType()),
+        StructField('IMPACT', StringType()),
+        StructField('DESCRIPTION', StringType()),
+    ])
+    hallmark_data = [
+        Row(GENE_SYMBOL='TP53', PUBMED_PMID='12345', HALLMARK='angiogenesis',
+            IMPACT='promotes', DESCRIPTION='promotes tumour angiogenesis'),
+        Row(GENE_SYMBOL='TP53', PUBMED_PMID='67890', HALLMARK='apoptosis',
+            IMPACT='suppresses', DESCRIPTION='induces apoptosis'),
+    ]
+    df = spark.createDataFrame(hallmark_data, hallmark_schema)
+    result = _build_hallmarks(df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.approvedSymbol == 'TP53'
+    # angiogenesis is a cancer hallmark
+    cancer_labels = {h.label for h in (row.hallmarks.cancerHallmarks or [])}
+    assert 'angiogenesis' in cancer_labels
+    # apoptosis is NOT a cancer hallmark → attributes
+    attr_names = {a.name for a in (row.hallmarks.attributes or [])}
+    assert 'apoptosis' in attr_names
+
+
+# ---------------------------------------------------------------------------
+# 8. Reactome pathways
+# ---------------------------------------------------------------------------
+
+def test_reactome_pathways(spark):
+    """Reactome groups pathways per Ensembl ID with topLevelTerm."""
+    reactome_pathways_schema = StructType([
+        StructField('_c0', StringType()),  # ensemblId
+        StructField('_c1', StringType()),  # reactomeId
+        StructField('_c2', StringType()),  # url
+        StructField('_c3', StringType()),  # eventName
+        StructField('_c4', StringType()),  # eventCode
+        StructField('_c5', StringType()),  # species
+    ])
+    reactome_pathways_data = [
+        Row(_c0='ENSG00000141510', _c1='R-HSA-69278', _c2='https://reactome.org',
+            _c3='Cell Cycle', _c4='CC', _c5='Homo sapiens'),
+    ]
+    pathways_df = spark.createDataFrame(reactome_pathways_data, reactome_pathways_schema)
+
+    reactome_etl_schema = StructType([
+        StructField('id', StringType()),
+        StructField('label', StringType()),
+        StructField('path', ArrayType(ArrayType(StringType()))),
+    ])
+    reactome_etl_data = [
+        Row(id='R-HSA-69278', label='Cell Cycle', path=[['R-HSA-1', 'R-HSA-69278']]),
+        Row(id='R-HSA-1', label='Cell Cycle Root', path=[[None]]),
+    ]
+    etl_df = spark.createDataFrame(reactome_etl_data, reactome_etl_schema)
+
+    result = _build_reactome(pathways_df, etl_df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == 'ENSG00000141510'
+    pathway_ids = {p.pathwayId for p in row.pathways}
+    assert 'R-HSA-69278' in pathway_ids
+
+
+# ---------------------------------------------------------------------------
+# 9. HGNC + Ensembl merge
+# ---------------------------------------------------------------------------
+
+def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
+    """Merged dataframe uses HGNC approvedName/Symbol when available."""
+    ensembl_schema = StructType([
+        StructField('id', StringType()),
+        StructField('biotype', StringType()),
+        StructField('approvedName', StringType()),
+        StructField('approvedSymbol', StringType()),
+        StructField('genomicLocation', StructType([
+            StructField('chromosome', StringType()),
+            StructField('start', LongType()),
+            StructField('end', LongType()),
+            StructField('strand', IntegerType()),
+        ])),
+    ])
+    ensembl_data = [
+        Row(id='ENSG00000141510', biotype='protein_coding',
+            approvedName='Ensembl approved name',
+            approvedSymbol='TP53_ensembl',
+            genomicLocation=Row(chromosome='17', start=7661779, end=7687538, strand=-1)),
+    ]
+    ensembl_df = spark.createDataFrame(ensembl_data, ensembl_schema)
+
+    hgnc_schema = StructType([
+        StructField('ensemblId', StringType()),
+        StructField('approvedSymbol', StringType()),
+        StructField('approvedName', StringType()),
+        StructField('hgncId', ArrayType(StructType([
+            StructField('id', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('hgncSynonyms', ArrayType(StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('hgncSymbolSynonyms', ArrayType(StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('hgncNameSynonyms', ArrayType(StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('hgncObsoleteSymbols', ArrayType(StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('hgncObsoleteNames', ArrayType(StructType([
+            StructField('label', StringType()),
+            StructField('source', StringType()),
+        ]))),
+        StructField('uniprotIds', ArrayType(StringType())),
+    ])
+    hgnc_data = [
+        Row(ensemblId='ENSG00000141510',
+            approvedSymbol='TP53',
+            approvedName='tumor protein p53',
+            hgncId=[Row(id='11998', source='HGNC')],
+            hgncSynonyms=None,
+            hgncSymbolSynonyms=None,
+            hgncNameSynonyms=None,
+            hgncObsoleteSymbols=None,
+            hgncObsoleteNames=None,
+            uniprotIds=['P04637']),
+    ]
+    hgnc_df = spark.createDataFrame(hgnc_data, hgnc_schema)
+
+    result = _merge_hgnc_ensembl(hgnc_df, ensembl_df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    # HGNC values take precedence
+    assert row.approvedSymbol == 'TP53'
+    assert row.approvedName == 'tumor protein p53'
+
+
+# ---------------------------------------------------------------------------
+# 10. Output schema validation
+# ---------------------------------------------------------------------------
+
+REQUIRED_OUTPUT_COLUMNS = {
+    'id',
+    'approvedSymbol',
+    'approvedName',
+    'biotype',
+    'transcripts',
+    'genomicLocation',
+    'pathways',
+    'geneOntology',
+    'constraint',
+    'safety',
+    'tractability',
+    'homologues',
+    'subcellularLocations',
+    'targetClass',
+    'hallmarks',
+    'chemicalProbes',
+    'tep',
+}
+
+
+def test_output_schema_has_required_columns(spark):
+    """The target module exposes the required_output_columns constant."""
+    from pts.pyspark.target import REQUIRED_OUTPUT_COLUMNS as ROC
+    assert REQUIRED_OUTPUT_COLUMNS.issubset(ROC)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -3,14 +3,10 @@
 Ported from platform-etl-backend target step.
 """
 
-import pytest
 from pyspark.sql import Row
-from pyspark.sql import functions as f
 from pyspark.sql.types import (
     ArrayType,
-    BooleanType,
     DoubleType,
-    FloatType,
     IntegerType,
     LongType,
     StringType,
@@ -29,7 +25,6 @@ from pts.pyspark.target import (
     _filter_ensembl,
     _merge_hgnc_ensembl,
 )
-
 
 # ---------------------------------------------------------------------------
 # Helper builders
@@ -55,10 +50,15 @@ ENSEMBL_SCHEMA = StructType([
     StructField('strand', IntegerType()),
     StructField('description', StringType()),
     StructField('approvedSymbol', StringType()),
-    StructField('transcripts', ArrayType(StructType([
-        StructField('id', StringType()),
-        StructField('biotype', StringType()),
-    ]))),
+    StructField(
+        'transcripts',
+        ArrayType(
+            StructType([
+                StructField('id', StringType()),
+                StructField('biotype', StringType()),
+            ])
+        ),
+    ),
     StructField('uniprot_swissprot', ArrayType(StringType())),
     StructField('uniprot_trembl', ArrayType(StringType())),
     StructField('translations', ArrayType(StructType([StructField('id', StringType())]))),
@@ -130,39 +130,51 @@ def test_ensembl_filters_non_ensg(spark):
 # ---------------------------------------------------------------------------
 
 HGNC_SCHEMA = StructType([
-    StructField('response', StructType([
-        StructField('docs', ArrayType(StructType([
-            StructField('ensembl_gene_id', StringType()),
-            StructField('hgnc_id', StringType()),
-            StructField('symbol', StringType()),
-            StructField('name', StringType()),
-            StructField('uniprot_ids', ArrayType(StringType())),
-            StructField('alias_symbol', ArrayType(StringType())),
-            StructField('alias_name', ArrayType(StringType())),
-            StructField('prev_symbol', ArrayType(StringType())),
-            StructField('prev_name', ArrayType(StringType())),
-        ])))
-    ]))
+    StructField(
+        'response',
+        StructType([
+            StructField(
+                'docs',
+                ArrayType(
+                    StructType([
+                        StructField('ensembl_gene_id', StringType()),
+                        StructField('hgnc_id', StringType()),
+                        StructField('symbol', StringType()),
+                        StructField('name', StringType()),
+                        StructField('uniprot_ids', ArrayType(StringType())),
+                        StructField('alias_symbol', ArrayType(StringType())),
+                        StructField('alias_name', ArrayType(StringType())),
+                        StructField('prev_symbol', ArrayType(StringType())),
+                        StructField('prev_name', ArrayType(StringType())),
+                    ])
+                ),
+            )
+        ]),
+    )
 ])
 
 
 def test_hgnc_symbol_mapping(spark):
     """HGNC maps ensembl_gene_id to approvedSymbol and approvedName."""
-    data = [{
-        'response': {
-            'docs': [{
-                'ensembl_gene_id': 'ENSG00000141510',
-                'hgnc_id': 'HGNC:11998',
-                'symbol': 'TP53',
-                'name': 'tumor protein p53',
-                'uniprot_ids': ['P04637'],
-                'alias_symbol': None,
-                'alias_name': None,
-                'prev_symbol': None,
-                'prev_name': None,
-            }]
+    data = [
+        {
+            'response': {
+                'docs': [
+                    {
+                        'ensembl_gene_id': 'ENSG00000141510',
+                        'hgnc_id': 'HGNC:11998',
+                        'symbol': 'TP53',
+                        'name': 'tumor protein p53',
+                        'uniprot_ids': ['P04637'],
+                        'alias_symbol': None,
+                        'alias_name': None,
+                        'prev_symbol': None,
+                        'prev_name': None,
+                    }
+                ]
+            }
         }
-    }]
+    ]
     df = spark.createDataFrame(data, HGNC_SCHEMA)
     result = _build_hgnc(df)
     rows = result.collect()
@@ -188,13 +200,13 @@ GO_HUMAN_SCHEMA = StructType([
     StructField('_c7', StringType()),  # withOrFrom
     StructField('_c8', StringType()),  # aspect
     StructField('_c9', StringType()),  # dbObjectName
-    StructField('_c10', StringType()), # dbObjectSynonym
-    StructField('_c11', StringType()), # dbObjectType
-    StructField('_c12', StringType()), # taxon
-    StructField('_c13', StringType()), # date
-    StructField('_c14', StringType()), # assignedBy
-    StructField('_c15', StringType()), # annotationExtension
-    StructField('_c16', StringType()), # geneProductFormId
+    StructField('_c10', StringType()),  # dbObjectSynonym
+    StructField('_c11', StringType()),  # dbObjectType
+    StructField('_c12', StringType()),  # taxon
+    StructField('_c13', StringType()),  # date
+    StructField('_c14', StringType()),  # assignedBy
+    StructField('_c15', StringType()),  # annotationExtension
+    StructField('_c16', StringType()),  # geneProductFormId
 ])
 
 
@@ -252,13 +264,19 @@ def test_go_grouping_by_aspect(spark):
     ensembl_go_schema = StructType([
         StructField('id', StringType()),
         StructField('approvedSymbol', StringType()),
-        StructField('proteinIds', ArrayType(StructType([
-            StructField('id', StringType()),
-            StructField('source', StringType()),
-        ]))),
+        StructField(
+            'proteinIds',
+            ArrayType(
+                StructType([
+                    StructField('id', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
     ])
-    ensembl_go_data = [Row(id='ENSG00000141510', approvedSymbol='TP53',
-                           proteinIds=[Row(id='P04637', source='uniprot_swissprot')])]
+    ensembl_go_data = [
+        Row(id='ENSG00000141510', approvedSymbol='TP53', proteinIds=[Row(id='P04637', source='uniprot_swissprot')])
+    ]
     ensembl_df = spark.createDataFrame(ensembl_go_data, ensembl_go_schema)
 
     result = _build_gene_ontology(human_df, rna_df, rna_lookup_df, eco_df, ensembl_df)
@@ -275,6 +293,7 @@ def test_go_grouping_by_aspect(spark):
 # ---------------------------------------------------------------------------
 # 4. Homologue filtering by species whitelist
 # ---------------------------------------------------------------------------
+
 
 def test_homologue_whitelist_filtering(spark):
     """Only species in whitelist are included in homologues."""
@@ -308,25 +327,41 @@ def test_homologue_whitelist_filtering(spark):
         StructField('homology_id', StringType()),
     ])
     coding_proteins_data = [
-        Row(gene_stable_id='ENSG0001', protein_stable_id='P001',
-            species='homo_sapiens', identity=100.0,
+        Row(
+            gene_stable_id='ENSG0001',
+            protein_stable_id='P001',
+            species='homo_sapiens',
+            identity=100.0,
             homology_type='ortholog_one2one',
             homology_gene_stable_id='ENSMUSG0001',
             homology_protein_stable_id='P002',
             homology_species='mus_musculus',
-            homology_identity=88.0, dn=None, ds=None,
-            goc_score=None, wga_coverage=None,
-            is_high_confidence='1', homology_id='h001'),
+            homology_identity=88.0,
+            dn=None,
+            ds=None,
+            goc_score=None,
+            wga_coverage=None,
+            is_high_confidence='1',
+            homology_id='h001',
+        ),
         # rat — NOT in whitelist
-        Row(gene_stable_id='ENSG0001', protein_stable_id='P001',
-            species='homo_sapiens', identity=100.0,
+        Row(
+            gene_stable_id='ENSG0001',
+            protein_stable_id='P001',
+            species='homo_sapiens',
+            identity=100.0,
             homology_type='ortholog_one2one',
             homology_gene_stable_id='ENSRNOG0001',
             homology_protein_stable_id='P003',
             homology_species='rattus_norvegicus',
-            homology_identity=85.0, dn=None, ds=None,
-            goc_score=None, wga_coverage=None,
-            is_high_confidence='1', homology_id='h002'),
+            homology_identity=85.0,
+            dn=None,
+            ds=None,
+            goc_score=None,
+            wga_coverage=None,
+            is_high_confidence='1',
+            homology_id='h002',
+        ),
     ]
     coding_proteins_df = spark.createDataFrame(coding_proteins_data, coding_proteins_schema)
 
@@ -352,6 +387,7 @@ def test_homologue_whitelist_filtering(spark):
 # 5. Safety evidence aggregation
 # ---------------------------------------------------------------------------
 
+
 def test_safety_evidence_aggregation(spark):
     """Safety evidence is grouped by ENSG id into safetyLiabilities."""
     safety_schema = StructType([
@@ -359,39 +395,77 @@ def test_safety_evidence_aggregation(spark):
         StructField('targetFromSourceId', StringType()),
         StructField('event', StringType()),
         StructField('eventId', StringType()),
-        StructField('effects', ArrayType(StructType([
-            StructField('direction', StringType()),
-            StructField('dosing', StringType()),
-        ]))),
-        StructField('biosamples', ArrayType(StructType([
-            StructField('tissueLabel', StringType()),
-            StructField('tissueId', StringType()),
-            StructField('cellLabel', StringType()),
-            StructField('cellFormat', StringType()),
-        ]))),
+        StructField(
+            'effects',
+            ArrayType(
+                StructType([
+                    StructField('direction', StringType()),
+                    StructField('dosing', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'biosamples',
+            ArrayType(
+                StructType([
+                    StructField('tissueLabel', StringType()),
+                    StructField('tissueId', StringType()),
+                    StructField('cellLabel', StringType()),
+                    StructField('cellFormat', StringType()),
+                ])
+            ),
+        ),
         StructField('datasource', StringType()),
         StructField('literature', StringType()),
         StructField('url', StringType()),
-        StructField('studies', ArrayType(StructType([
-            StructField('name', StringType()),
-            StructField('description', StringType()),
-            StructField('type', StringType()),
-        ]))),
+        StructField(
+            'studies',
+            ArrayType(
+                StructType([
+                    StructField('name', StringType()),
+                    StructField('description', StringType()),
+                    StructField('type', StringType()),
+                ])
+            ),
+        ),
     ])
     safety_data = [
-        Row(id='ENSG00000141510', targetFromSourceId='TP53',
-            event='heart failure', eventId='EFO_0003777',
+        Row(
+            id='ENSG00000141510',
+            targetFromSourceId='TP53',
+            event='heart failure',
+            eventId='EFO_0003777',
             effects=[Row(direction='Activation/Increase/Upregulation', dosing='general')],
-            biosamples=None, datasource='TestSource',
-            literature='12345678', url=None, studies=None),
-        Row(id='ENSG00000141510', targetFromSourceId='TP53',
-            event='liver toxicity', eventId='EFO_0001234',
-            effects=None, biosamples=None, datasource='TestSource2',
-            literature=None, url=None, studies=None),
-        Row(id='ENSG00000012048', targetFromSourceId='BRCA1',
-            event='breast cancer', eventId='MONDO_0007254',
-            effects=None, biosamples=None, datasource='TestSource',
-            literature=None, url=None, studies=None),
+            biosamples=None,
+            datasource='TestSource',
+            literature='12345678',
+            url=None,
+            studies=None,
+        ),
+        Row(
+            id='ENSG00000141510',
+            targetFromSourceId='TP53',
+            event='liver toxicity',
+            eventId='EFO_0001234',
+            effects=None,
+            biosamples=None,
+            datasource='TestSource2',
+            literature=None,
+            url=None,
+            studies=None,
+        ),
+        Row(
+            id='ENSG00000012048',
+            targetFromSourceId='BRCA1',
+            event='breast cancer',
+            eventId='MONDO_0007254',
+            effects=None,
+            biosamples=None,
+            datasource='TestSource',
+            literature=None,
+            url=None,
+            studies=None,
+        ),
     ]
     safety_df = spark.createDataFrame(safety_data, safety_schema)
 
@@ -404,8 +478,7 @@ def test_safety_evidence_aggregation(spark):
         StructField('symbols', ArrayType(StringType())),
     ])
     lookup_data = [
-        Row(ensgId='ENSG00000141510', name=['P04637', 'TP53'],
-            uniprot=['P04637'], HGNC=['TP53'], symbols=['TP53']),
+        Row(ensgId='ENSG00000141510', name=['P04637', 'TP53'], uniprot=['P04637'], HGNC=['TP53'], symbols=['TP53']),
     ]
     lookup_df = spark.createDataFrame(lookup_data, lookup_schema)
 
@@ -428,6 +501,7 @@ def test_safety_evidence_aggregation(spark):
 # ---------------------------------------------------------------------------
 # 6. Genetic constraints
 # ---------------------------------------------------------------------------
+
 
 def test_genetic_constraints_structure(spark):
     """Genetic constraints are grouped as an array with syn/mis/lof entries."""
@@ -456,31 +530,33 @@ def test_genetic_constraints_structure(spark):
         StructField('lof.oe_ci.upper_rank', StringType()),
         StructField('lof.oe_ci.upper_bin_decile', StringType()),
     ])
-    constraint_data = [{
-        'gene_id': 'ENSG00000141510',
-        'canonical': 'true',
-        'transcript_type': 'protein_coding',
-        'syn.z_score': '1.23',
-        'syn.exp': '100.5',
-        'syn.obs': '95',
-        'syn.oe': '0.95',
-        'syn.oe_ci.lower': '0.8',
-        'syn.oe_ci.upper': '1.1',
-        'mis.z_score': '2.5',
-        'mis.exp': '200.0',
-        'mis.obs': '180',
-        'mis.oe': '0.9',
-        'mis.oe_ci.lower': '0.75',
-        'mis.oe_ci.upper': '1.05',
-        'lof.pLI': '0.99',
-        'lof.exp': '50.0',
-        'lof.obs': '5',
-        'lof.oe': '0.1',
-        'lof.oe_ci.lower': '0.05',
-        'lof.oe_ci.upper': '0.2',
-        'lof.oe_ci.upper_rank': '1000',
-        'lof.oe_ci.upper_bin_decile': '1',
-    }]
+    constraint_data = [
+        {
+            'gene_id': 'ENSG00000141510',
+            'canonical': 'true',
+            'transcript_type': 'protein_coding',
+            'syn.z_score': '1.23',
+            'syn.exp': '100.5',
+            'syn.obs': '95',
+            'syn.oe': '0.95',
+            'syn.oe_ci.lower': '0.8',
+            'syn.oe_ci.upper': '1.1',
+            'mis.z_score': '2.5',
+            'mis.exp': '200.0',
+            'mis.obs': '180',
+            'mis.oe': '0.9',
+            'mis.oe_ci.lower': '0.75',
+            'mis.oe_ci.upper': '1.05',
+            'lof.pLI': '0.99',
+            'lof.exp': '50.0',
+            'lof.obs': '5',
+            'lof.oe': '0.1',
+            'lof.oe_ci.lower': '0.05',
+            'lof.oe_ci.upper': '0.2',
+            'lof.oe_ci.upper_rank': '1000',
+            'lof.oe_ci.upper_bin_decile': '1',
+        }
+    ]
     df = spark.createDataFrame(constraint_data, constraint_schema)
     result = _build_genetic_constraints(df)
     rows = result.collect()
@@ -495,6 +571,7 @@ def test_genetic_constraints_structure(spark):
 # 7. Hallmarks
 # ---------------------------------------------------------------------------
 
+
 def test_hallmarks_split_cancer_vs_non_cancer(spark):
     """Hallmarks splits records into cancerHallmarks and attributes."""
     hallmark_schema = StructType([
@@ -505,10 +582,20 @@ def test_hallmarks_split_cancer_vs_non_cancer(spark):
         StructField('DESCRIPTION', StringType()),
     ])
     hallmark_data = [
-        Row(GENE_SYMBOL='TP53', PUBMED_PMID='12345', HALLMARK='angiogenesis',
-            IMPACT='promotes', DESCRIPTION='promotes tumour angiogenesis'),
-        Row(GENE_SYMBOL='TP53', PUBMED_PMID='67890', HALLMARK='apoptosis',
-            IMPACT='suppresses', DESCRIPTION='induces apoptosis'),
+        Row(
+            GENE_SYMBOL='TP53',
+            PUBMED_PMID='12345',
+            HALLMARK='angiogenesis',
+            IMPACT='promotes',
+            DESCRIPTION='promotes tumour angiogenesis',
+        ),
+        Row(
+            GENE_SYMBOL='TP53',
+            PUBMED_PMID='67890',
+            HALLMARK='apoptosis',
+            IMPACT='suppresses',
+            DESCRIPTION='induces apoptosis',
+        ),
     ]
     df = spark.createDataFrame(hallmark_data, hallmark_schema)
     result = _build_hallmarks(df)
@@ -528,6 +615,7 @@ def test_hallmarks_split_cancer_vs_non_cancer(spark):
 # 8. Reactome pathways
 # ---------------------------------------------------------------------------
 
+
 def test_reactome_pathways(spark):
     """Reactome groups pathways per Ensembl ID with topLevelTerm."""
     reactome_pathways_schema = StructType([
@@ -539,8 +627,14 @@ def test_reactome_pathways(spark):
         StructField('_c5', StringType()),  # species
     ])
     reactome_pathways_data = [
-        Row(_c0='ENSG00000141510', _c1='R-HSA-69278', _c2='https://reactome.org',
-            _c3='Cell Cycle', _c4='CC', _c5='Homo sapiens'),
+        Row(
+            _c0='ENSG00000141510',
+            _c1='R-HSA-69278',
+            _c2='https://reactome.org',
+            _c3='Cell Cycle',
+            _c4='CC',
+            _c5='Homo sapiens',
+        ),
     ]
     pathways_df = spark.createDataFrame(reactome_pathways_data, reactome_pathways_schema)
 
@@ -568,6 +662,7 @@ def test_reactome_pathways(spark):
 # 9. HGNC + Ensembl merge
 # ---------------------------------------------------------------------------
 
+
 def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
     """Merged dataframe uses HGNC approvedName/Symbol when available."""
     ensembl_schema = StructType([
@@ -575,18 +670,24 @@ def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
         StructField('biotype', StringType()),
         StructField('approvedName', StringType()),
         StructField('approvedSymbol', StringType()),
-        StructField('genomicLocation', StructType([
-            StructField('chromosome', StringType()),
-            StructField('start', LongType()),
-            StructField('end', LongType()),
-            StructField('strand', IntegerType()),
-        ])),
+        StructField(
+            'genomicLocation',
+            StructType([
+                StructField('chromosome', StringType()),
+                StructField('start', LongType()),
+                StructField('end', LongType()),
+                StructField('strand', IntegerType()),
+            ]),
+        ),
     ])
     ensembl_data = [
-        Row(id='ENSG00000141510', biotype='protein_coding',
+        Row(
+            id='ENSG00000141510',
+            biotype='protein_coding',
             approvedName='Ensembl approved name',
             approvedSymbol='TP53_ensembl',
-            genomicLocation=Row(chromosome='17', start=7661779, end=7687538, strand=-1)),
+            genomicLocation=Row(chromosome='17', start=7661779, end=7687538, strand=-1),
+        ),
     ]
     ensembl_df = spark.createDataFrame(ensembl_data, ensembl_schema)
 
@@ -594,34 +695,65 @@ def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
         StructField('ensemblId', StringType()),
         StructField('approvedSymbol', StringType()),
         StructField('approvedName', StringType()),
-        StructField('hgncId', ArrayType(StructType([
-            StructField('id', StringType()),
-            StructField('source', StringType()),
-        ]))),
-        StructField('hgncSynonyms', ArrayType(StructType([
-            StructField('label', StringType()),
-            StructField('source', StringType()),
-        ]))),
-        StructField('hgncSymbolSynonyms', ArrayType(StructType([
-            StructField('label', StringType()),
-            StructField('source', StringType()),
-        ]))),
-        StructField('hgncNameSynonyms', ArrayType(StructType([
-            StructField('label', StringType()),
-            StructField('source', StringType()),
-        ]))),
-        StructField('hgncObsoleteSymbols', ArrayType(StructType([
-            StructField('label', StringType()),
-            StructField('source', StringType()),
-        ]))),
-        StructField('hgncObsoleteNames', ArrayType(StructType([
-            StructField('label', StringType()),
-            StructField('source', StringType()),
-        ]))),
+        StructField(
+            'hgncId',
+            ArrayType(
+                StructType([
+                    StructField('id', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'hgncSynonyms',
+            ArrayType(
+                StructType([
+                    StructField('label', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'hgncSymbolSynonyms',
+            ArrayType(
+                StructType([
+                    StructField('label', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'hgncNameSynonyms',
+            ArrayType(
+                StructType([
+                    StructField('label', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'hgncObsoleteSymbols',
+            ArrayType(
+                StructType([
+                    StructField('label', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
+        StructField(
+            'hgncObsoleteNames',
+            ArrayType(
+                StructType([
+                    StructField('label', StringType()),
+                    StructField('source', StringType()),
+                ])
+            ),
+        ),
         StructField('uniprotIds', ArrayType(StringType())),
     ])
     hgnc_data = [
-        Row(ensemblId='ENSG00000141510',
+        Row(
+            ensemblId='ENSG00000141510',
             approvedSymbol='TP53',
             approvedName='tumor protein p53',
             hgncId=[Row(id='11998', source='HGNC')],
@@ -630,7 +762,8 @@ def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
             hgncNameSynonyms=None,
             hgncObsoleteSymbols=None,
             hgncObsoleteNames=None,
-            uniprotIds=['P04637']),
+            uniprotIds=['P04637'],
+        ),
     ]
     hgnc_df = spark.createDataFrame(hgnc_data, hgnc_schema)
 
@@ -671,4 +804,5 @@ REQUIRED_OUTPUT_COLUMNS = {
 def test_output_schema_has_required_columns(spark):
     """The target module exposes the required_output_columns constant."""
     from pts.pyspark.target import REQUIRED_OUTPUT_COLUMNS as ROC
+
     assert REQUIRED_OUTPUT_COLUMNS.issubset(ROC)

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -788,7 +788,7 @@ REQUIRED_OUTPUT_COLUMNS = {
     'transcripts',
     'genomicLocation',
     'pathways',
-    'geneOntology',
+    'go',
     'constraint',
     'safety',
     'tractability',

--- a/test/test_uniprot.py
+++ b/test/test_uniprot.py
@@ -1,0 +1,66 @@
+"""Tests for the uniprot transformer."""
+
+from __future__ import annotations
+
+from pts.transformers.uniprot import _parse_record
+
+MINIMAL_ENTRY = """\
+ID   PROT_HUMAN           Reviewed;         100 AA.
+AC   P12345; Q99999;
+DE   RecName: Full=Test protein;
+DE   AltName: Full=Alt protein;
+GN   Name=GENE1; Synonyms=SYN1;
+DR   ChEMBL; CHEMBL123; -.
+DR   Ensembl; ENST00001; ENSP00001; ENSG00001.
+DR   PDB; 1ABC; X-ray; -.
+CC   -!- FUNCTION: Catalyzes the reaction.
+CC   -!- SUBCELLULAR LOCATION: Nucleus. Cytoplasm.\
+"""
+
+
+def _lines(entry: str) -> list[str]:
+    return entry.splitlines()
+
+
+def test_parse_record_id():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert rec['id'] == 'PROT_HUMAN'
+
+
+def test_parse_record_accessions():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert rec['accessions'] == ['P12345', 'Q99999']
+
+
+def test_parse_record_names():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert 'Test protein' in rec['names']
+
+
+def test_parse_record_synonyms():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert 'Alt protein' in rec['synonyms']
+
+
+def test_parse_record_symbol_synonyms():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert 'GENE1' in rec['symbolSynonyms']
+    assert 'SYN1' in rec['symbolSynonyms']
+
+
+def test_parse_record_db_xrefs():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert 'CHEMBL123 ChEMBL' in rec['dbXrefs']
+    assert 'ENST00001 Ensembl' in rec['dbXrefs']
+    assert '1ABC PDB' in rec['dbXrefs']
+
+
+def test_parse_record_functions():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert any('Catalyzes the reaction' in f for f in rec['functions'])
+
+
+def test_parse_record_locations():
+    rec = _parse_record(_lines(MINIMAL_ENTRY))
+    assert 'Nucleus' in rec['locations']
+    assert 'Cytoplasm' in rec['locations']


### PR DESCRIPTION
## Summary

- Port all 18 Scala target step files to `src/pts/pyspark/target.py` (~700 lines)
- Rename existing `target:` preprocessing step in `config.yaml` to `pre_target:` (unzip/gzip tasks)
- Add new `target:` pyspark step in `config.yaml` integrating ~15 data sources

## What's included

- `src/pts/pyspark/target.py`: Complete PySpark port of Ensembl, HGNC, GeneOntology, GeneticConstraints, GeneWithLocation, Hallmarks, NCBI, Ortholog, ProjectScores, ProteinClassification, Reactome, Safety, Tep, Tractability, Uniprot, Target assembly
- `test/test_target.py`: 12 unit tests covering key internal functions
- `config.yaml`: `target:` → `pre_target:` rename + new `target:` pyspark block

## Test plan

- [x] 12/12 unit tests pass (`uv run pytest test/test_target.py -v`)
- [x] Integration test against gs://open-targets-pre-data-releases/26.03/output/target

Tracking issue: https://github.com/opentargets/issues/issues/4347