### PR TITLE
feat: add search_facet pyspark step (migrated from ETL)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1604,6 +1604,19 @@ steps:
         spark.driver.memory: 12g
   ##################################################################################################
 
+  #: SEARCH FACET STEP :###########################################################################
+  search_facet:
+    - name: pyspark search_facet
+      pyspark: search_facet
+      source:
+        diseases: output/disease
+        targets: output/target
+        go: output/go
+      destination:
+        targets: view/search_facet_target
+        diseases: view/search_facet_disease
+  ##################################################################################################
+
   #: RELEASE METRICS STEP :##########################################################################
   search:
     - name: pyspark search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.7"
+version = "26.03.8"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/search_facet.py
+++ b/src/pts/pyspark/search_facet.py
@@ -1,0 +1,380 @@
+"""Search facet dataset generation.
+
+Ported from platform-etl-backend searchFacet step. Computes facets for
+targets and diseases used by the Open Targets Platform search.
+
+Scala sources ported:
+    - SearchFacet.scala (main assembly)
+    - TargetFacets.scala
+    - DiseaseFacets.scala
+    - Helpers.scala
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame
+
+from pts.pyspark.common.session import Session
+
+# ---------------------------------------------------------------------------
+# Category label defaults (mirrors reference.conf categories block)
+# ---------------------------------------------------------------------------
+
+DEFAULT_CATEGORIES: dict[str, str] = {
+    'disease_name': 'Disease',
+    'therapeutic_area': 'Therapeutic Area',
+    'sm': 'Tractability Small Molecule',
+    'ab': 'Tractability Antibody',
+    'pr': 'Tractability PROTAC',
+    'oc': 'Tractability Other Modalities',
+    'target_id': 'Target ID',
+    'approved_symbol': 'Approved Symbol',
+    'approved_name': 'Approved Name',
+    'subcellular_location': 'Subcellular Location',
+    'target_class': 'ChEMBL Target Class',
+    'pathways': 'Reactome',
+    'go_f': 'GO:MF',
+    'go_p': 'GO:BP',
+    'go_c': 'GO:CC',
+}
+
+
+# ---------------------------------------------------------------------------
+# Disease facets
+# ---------------------------------------------------------------------------
+
+
+def _compute_disease_name_facets(disease_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute disease name facets.
+
+    Each disease produces one row with label=name, category='Disease',
+    datasourceId=disease id, entityIds=[id].
+
+    Args:
+        disease_df: DataFrame with columns id, name.
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, datasourceId, entityIds.
+    """
+    logger.info('Computing disease name facets')
+    return (
+        disease_df
+        .select(f.col('id'), f.col('name').alias('label'))
+        .withColumn('category', f.lit(categories['disease_name']))
+        .withColumn('datasourceId', f.col('id'))
+        .groupBy('label', 'category', 'datasourceId')
+        .agg(f.collect_set('id').alias('entityIds'))
+    )
+
+
+def _compute_therapeutic_areas_facets(disease_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute therapeutic area facets.
+
+    Explodes the therapeuticAreas array, joins back to disease names, then groups
+    diseases by the therapeutic area they belong to.
+
+    Args:
+        disease_df: DataFrame with columns id, name, therapeuticAreas.
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, datasourceId, entityIds.
+    """
+    logger.info('Computing therapeutic areas facets')
+    disease_names = disease_df.select(f.col('id'), f.col('name'))
+    return (
+        disease_df
+        .where(f.col('therapeuticAreas').isNotNull())
+        .select(f.col('id').alias('diseaseId'), f.explode('therapeuticAreas').alias('tId'))
+        .join(disease_names, f.col('tId') == f.col('id'))
+        .select(
+            f.col('name').alias('label'),
+            f.lit(categories['therapeutic_area']).alias('category'),
+            f.col('diseaseId'),
+            f.col('tId').alias('datasourceId'),
+        )
+        .groupBy('label', 'category', 'datasourceId')
+        .agg(f.collect_set('diseaseId').alias('entityIds'))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Target facets
+# ---------------------------------------------------------------------------
+
+
+def _compute_tractability_facets(target_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute tractability facets.
+
+    Explodes the tractability array, filters to value=True, maps modality codes
+    to human-readable category labels (SM→'Tractability Small Molecule', etc.).
+
+    Args:
+        target_df: DataFrame with columns id, tractability (array of structs with
+            modality, id, value).
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId (null).
+    """
+    logger.info('Computing tractability facets')
+    modality_map = f.create_map(
+        f.lit('SM'),
+        f.lit(categories['sm']),
+        f.lit('AB'),
+        f.lit(categories['ab']),
+        f.lit('PR'),
+        f.lit(categories['pr']),
+        f.lit('OC'),
+        f.lit(categories['oc']),
+    )
+    return (
+        target_df
+        .where(f.col('tractability').isNotNull())
+        .select(f.col('id'), f.explode('tractability').alias('t'))
+        .select(
+            f.col('id').alias('ensemblGeneId'),
+            f.col('t.modality').alias('category'),
+            f.col('t.id').alias('label'),
+            f.col('t.value').alias('value'),
+        )
+        .where(f.col('value'))
+        .groupBy('category', 'label')
+        .agg(f.collect_set('ensemblGeneId').alias('entityIds'))
+        .withColumn(
+            'category',
+            f.when(modality_map[f.col('category')].isNotNull(), modality_map[f.col('category')]).otherwise(
+                f.col('category')
+            ),
+        )
+        .withColumn('datasourceId', f.lit(None).cast('string'))
+    )
+
+
+def _compute_go_facets(target_df: DataFrame, go_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute Gene Ontology facets.
+
+    Explodes the go array, joins with the GO reference DataFrame to get labels,
+    maps aspect codes (F/P/C) to category labels (GO:MF/GO:BP/GO:CC).
+
+    Args:
+        target_df: DataFrame with columns id, go (array of structs with id, aspect).
+        go_df: Reference GO DataFrame with columns id, label.
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId (GO id).
+    """
+    logger.info('Computing GO facets')
+    aspect_map = f.create_map(
+        f.lit('F'),
+        f.lit(categories['go_f']),
+        f.lit('P'),
+        f.lit(categories['go_p']),
+        f.lit('C'),
+        f.lit(categories['go_c']),
+    )
+    return (
+        target_df
+        .where(f.col('go').isNotNull())
+        .select(f.col('id').alias('ensemblGeneId'), f.explode('go').alias('g'))
+        .select(
+            f.col('ensemblGeneId'),
+            f.col('g.id').alias('id'),
+            f.col('g.aspect').alias('aspect'),
+        )
+        .join(go_df, 'id', 'left')
+        .where(f.col('label').isNotNull())
+        .withColumn('datasourceId', f.col('id'))
+        .groupBy('label', 'aspect', 'datasourceId')
+        .agg(f.collect_set('ensemblGeneId').alias('entityIds'))
+        .withColumn(
+            'category',
+            f.when(aspect_map[f.col('aspect')].isNotNull(), aspect_map[f.col('aspect')]).otherwise(f.col('aspect')),
+        )
+        .drop('aspect')
+    )
+
+
+def _compute_subcellular_location_facets(target_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute subcellular location facets.
+
+    Explodes the subcellularLocations array, using location as label and termSl
+    as datasourceId.
+
+    Args:
+        target_df: DataFrame with columns id, subcellularLocations (array of structs
+            with location, termSl).
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId.
+    """
+    logger.info('Computing subcellular location facets')
+    return (
+        target_df
+        .where(f.col('subcellularLocations').isNotNull())
+        .select(f.col('id'), f.explode('subcellularLocations').alias('s'))
+        .select(
+            f.col('id'),
+            f.col('s.location').alias('label'),
+            f.lit(categories['subcellular_location']).alias('category'),
+            f.col('s.termSl').alias('datasourceId'),
+        )
+        .groupBy('label', 'category', 'datasourceId')
+        .agg(f.collect_set('id').alias('entityIds'))
+    )
+
+
+def _compute_target_class_facets(target_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute target class facets.
+
+    Explodes the targetClass array, using the class label as facet label.
+
+    Args:
+        target_df: DataFrame with columns id, targetClass (array of structs with
+            id, label, level).
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId (null).
+    """
+    logger.info('Computing target class facets')
+    return (
+        target_df
+        .where(f.col('targetClass').isNotNull())
+        .select(f.col('id').alias('ensemblGeneId'), f.explode('targetClass').alias('tc'))
+        .select(
+            f.col('ensemblGeneId'),
+            f.col('tc.label').alias('label'),
+            f.lit(categories['target_class']).alias('category'),
+        )
+        .groupBy('label', 'category')
+        .agg(f.collect_set('ensemblGeneId').alias('entityIds'))
+        .withColumn('datasourceId', f.lit(None).cast('string'))
+    )
+
+
+def _compute_pathway_facets(target_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+    """Compute Reactome pathway facets.
+
+    Explodes the pathways array, using pathway name as label and pathwayId as
+    datasourceId.
+
+    Args:
+        target_df: DataFrame with columns id, pathways (array of structs with
+            pathwayId, pathway, topLevelTerm).
+        categories: category label mapping.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId.
+    """
+    logger.info('Computing pathway facets')
+    return (
+        target_df
+        .where(f.col('pathways').isNotNull())
+        .select(f.col('id').alias('ensemblGeneId'), f.explode('pathways').alias('p'))
+        .select(
+            f.col('ensemblGeneId'),
+            f.col('p.pathway').alias('label'),
+            f.lit(categories['pathways']).alias('category'),
+            f.col('p.pathwayId').alias('datasourceId'),
+        )
+        .groupBy('label', 'category', 'datasourceId')
+        .agg(f.collect_set('ensemblGeneId').alias('entityIds'))
+    )
+
+
+def _compute_simple_facet(
+    df: DataFrame,
+    label_field: str,
+    category_value: str,
+    entity_id_field: str,
+) -> DataFrame:
+    """Compute a simple facet from a flat column.
+
+    Args:
+        df: Source DataFrame.
+        label_field: Column to use as facet label.
+        category_value: Literal string for the category column.
+        entity_id_field: Column to collect as entity IDs.
+
+    Returns:
+        DataFrame with columns label, category, entityIds, datasourceId (null).
+    """
+    return (
+        df
+        .select(
+            f.col(label_field).alias('label'),
+            f.lit(category_value).alias('category'),
+            f.col(entity_id_field).alias('_eid'),
+        )
+        .groupBy('label', 'category')
+        .agg(f.collect_set('_eid').alias('entityIds'))
+        .withColumn('datasourceId', f.lit(None).cast('string'))
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def search_facet(
+    source: dict[str, str],
+    destination: dict[str, str],
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Compute search facets for targets and diseases.
+
+    Reads disease, target, and GO datasets, computes facets for each, and writes
+    results to the configured destination paths.
+
+    Args:
+        source: Input paths keyed by 'diseases', 'targets', 'go'.
+        destination: Output paths keyed by 'targets', 'diseases'.
+        settings: Step settings; may contain a 'categories' sub-dict to override
+            the default category labels.
+        properties: Spark/GCS properties forwarded to Session.
+    """
+    spark = Session(app_name='search_facet', properties=properties).spark
+
+    categories = {**DEFAULT_CATEGORIES, **(settings.get('categories') or {})}
+
+    logger.info('Loading disease data from %s', source['diseases'])
+    disease_df = spark.read.parquet(source['diseases'])
+
+    logger.info('Loading target data from %s', source['targets'])
+    target_df = spark.read.parquet(source['targets'])
+
+    logger.info('Loading GO data from %s', source['go'])
+    go_df = spark.read.parquet(source['go'])
+
+    # ---- disease facets ----
+    disease_facets = _compute_disease_name_facets(disease_df, categories).unionByName(
+        _compute_therapeutic_areas_facets(disease_df, categories)
+    )
+
+    # ---- target facets ----
+    target_facets = (
+        _compute_simple_facet(target_df, 'id', categories['target_id'], 'id')
+        .unionByName(_compute_simple_facet(target_df, 'approvedSymbol', categories['approved_symbol'], 'id'))
+        .unionByName(_compute_simple_facet(target_df, 'approvedName', categories['approved_name'], 'id'))
+        .unionByName(_compute_go_facets(target_df, go_df, categories))
+        .unionByName(_compute_subcellular_location_facets(target_df, categories))
+        .unionByName(_compute_target_class_facets(target_df, categories))
+        .unionByName(_compute_pathway_facets(target_df, categories))
+        .unionByName(_compute_tractability_facets(target_df, categories))
+    )
+
+    logger.info('Writing target facets to %s', destination['targets'])
+    target_facets.coalesce(200).write.mode('overwrite').parquet(destination['targets'])
+
+    logger.info('Writing disease facets to %s', destination['diseases'])
+    disease_facets.coalesce(200).write.mode('overwrite').parquet(destination['diseases'])

--- a/test/test_search_facet.py
+++ b/test/test_search_facet.py
@@ -1,0 +1,492 @@
+"""Tests for the search_facet pyspark module.
+
+Ported from platform-etl-backend searchFacet step.
+"""
+
+from pyspark.sql import Row
+from pyspark.sql.types import ArrayType, BooleanType, LongType, StringType, StructField, StructType
+
+from pts.pyspark.search_facet import (
+    _compute_disease_name_facets,
+    _compute_go_facets,
+    _compute_pathway_facets,
+    _compute_simple_facet,
+    _compute_subcellular_location_facets,
+    _compute_target_class_facets,
+    _compute_therapeutic_areas_facets,
+    _compute_tractability_facets,
+)
+
+# ---------------------------------------------------------------------------
+# Category label constants (mirrors reference.conf categories)
+# ---------------------------------------------------------------------------
+
+CATEGORIES = {
+    'disease_name': 'Disease',
+    'therapeutic_area': 'Therapeutic Area',
+    'sm': 'Tractability Small Molecule',
+    'ab': 'Tractability Antibody',
+    'pr': 'Tractability PROTAC',
+    'oc': 'Tractability Other Modalities',
+    'target_id': 'Target ID',
+    'approved_symbol': 'Approved Symbol',
+    'approved_name': 'Approved Name',
+    'subcellular_location': 'Subcellular Location',
+    'target_class': 'ChEMBL Target Class',
+    'pathways': 'Reactome',
+    'go_f': 'GO:MF',
+    'go_p': 'GO:BP',
+    'go_c': 'GO:CC',
+}
+
+# ---------------------------------------------------------------------------
+# Disease schemas
+# ---------------------------------------------------------------------------
+
+DISEASE_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('name', StringType()),
+    StructField('therapeuticAreas', ArrayType(StringType())),
+])
+
+
+# ---------------------------------------------------------------------------
+# 1. Disease name facet
+# ---------------------------------------------------------------------------
+
+
+def test_disease_name_facet_produces_name_category(spark):
+    """Disease name facet produces rows with 'Disease' category."""
+    data = [
+        Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=['EFO_0010285']),
+        Row(id='EFO_0000002', name='lung cancer', therapeuticAreas=[]),
+    ]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_disease_name_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'Disease' in categories
+    labels = {r.label for r in rows}
+    assert 'breast cancer' in labels
+    assert 'lung cancer' in labels
+
+
+def test_disease_name_facet_entry_structure(spark):
+    """Disease name facet entries have label, category, entityIds, datasourceId."""
+    data = [Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=[])]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_disease_name_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+    assert row.category == 'Disease'
+    assert 'EFO_0000001' in row.entityIds
+
+
+def test_disease_name_facet_datasource_id_is_disease_id(spark):
+    """Disease name facet datasourceId equals the disease id."""
+    data = [Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=[])]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_disease_name_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert row.datasourceId == 'EFO_0000001'
+
+
+# ---------------------------------------------------------------------------
+# 2. Therapeutic area facet
+# ---------------------------------------------------------------------------
+
+
+def test_therapeutic_area_facet_produces_therapeutic_area_category(spark):
+    """Therapeutic areas facet produces rows with 'Therapeutic Area' category."""
+    data = [
+        Row(id='EFO_0000010', name='cancer', therapeuticAreas=[]),
+        Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=['EFO_0000010']),
+    ]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_therapeutic_areas_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'Therapeutic Area' in categories
+
+
+def test_therapeutic_area_facet_entry_structure(spark):
+    """Therapeutic area facet entries have label, category, entityIds, datasourceId."""
+    data = [
+        Row(id='EFO_0000010', name='neoplasm', therapeuticAreas=[]),
+        Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=['EFO_0000010']),
+    ]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_therapeutic_areas_facets(df, CATEGORIES)
+    rows = result.collect()
+    assert len(rows) >= 1
+    row = rows[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+
+
+def test_therapeutic_area_label_is_area_name(spark):
+    """Therapeutic area facet label is the name of the therapeutic area disease."""
+    data = [
+        Row(id='EFO_0000010', name='neoplasm', therapeuticAreas=[]),
+        Row(id='EFO_0000001', name='breast cancer', therapeuticAreas=['EFO_0000010']),
+    ]
+    df = spark.createDataFrame(data, DISEASE_SCHEMA)
+    result = _compute_therapeutic_areas_facets(df, CATEGORIES)
+    rows = result.collect()
+    labels = {r.label for r in rows}
+    assert 'neoplasm' in labels
+
+
+# ---------------------------------------------------------------------------
+# 3. Tractability facets
+# ---------------------------------------------------------------------------
+
+TRACTABILITY_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'tractability',
+        ArrayType(
+            StructType([
+                StructField('modality', StringType()),
+                StructField('id', StringType()),
+                StructField('value', BooleanType()),
+            ])
+        ),
+    ),
+])
+
+
+def test_tractability_facet_produces_modality_categories(spark):
+    """Tractability facet produces SM/AB/PR/OC modality categories."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            tractability=[
+                Row(modality='SM', id='Clinical Precedence', value=True),
+                Row(modality='AB', id='Predicted Tractable High', value=True),
+            ],
+        ),
+    ]
+    df = spark.createDataFrame(data, TRACTABILITY_SCHEMA)
+    result = _compute_tractability_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'Tractability Small Molecule' in categories
+    assert 'Tractability Antibody' in categories
+
+
+def test_tractability_facet_only_true_values(spark):
+    """Tractability facet only includes entries where value=True."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            tractability=[
+                Row(modality='SM', id='Clinical Precedence', value=True),
+                Row(modality='SM', id='Discovery Precedence', value=False),
+            ],
+        ),
+    ]
+    df = spark.createDataFrame(data, TRACTABILITY_SCHEMA)
+    result = _compute_tractability_facets(df, CATEGORIES)
+    rows = result.collect()
+    labels = {r.label for r in rows}
+    assert 'Clinical Precedence' in labels
+    assert 'Discovery Precedence' not in labels
+
+
+def test_tractability_facet_entry_structure(spark):
+    """Tractability facet entries have label, category, entityIds, datasourceId."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            tractability=[Row(modality='SM', id='Clinical Precedence', value=True)],
+        ),
+    ]
+    df = spark.createDataFrame(data, TRACTABILITY_SCHEMA)
+    result = _compute_tractability_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+
+
+# ---------------------------------------------------------------------------
+# 4. GO facets
+# ---------------------------------------------------------------------------
+
+TARGET_GO_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'go',
+        ArrayType(
+            StructType([
+                StructField('id', StringType()),
+                StructField('aspect', StringType()),
+            ])
+        ),
+    ),
+])
+
+GO_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('label', StringType()),
+])
+
+
+def test_go_facet_produces_f_p_c_categories(spark):
+    """GO facet maps F/P/C aspects to GO:MF / GO:BP / GO:CC categories."""
+    target_data = [
+        Row(
+            id='ENSG00000001',
+            go=[
+                Row(id='GO:0003677', aspect='F'),
+                Row(id='GO:0008150', aspect='P'),
+                Row(id='GO:0005634', aspect='C'),
+            ],
+        ),
+    ]
+    go_data = [
+        Row(id='GO:0003677', label='DNA binding'),
+        Row(id='GO:0008150', label='biological_process'),
+        Row(id='GO:0005634', label='nucleus'),
+    ]
+    target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
+    go_df = spark.createDataFrame(go_data, GO_SCHEMA)
+    result = _compute_go_facets(target_df, go_df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'GO:MF' in categories
+    assert 'GO:BP' in categories
+    assert 'GO:CC' in categories
+
+
+def test_go_facet_entry_structure(spark):
+    """GO facet entries have label, category, entityIds, datasourceId."""
+    target_data = [Row(id='ENSG00000001', go=[Row(id='GO:0003677', aspect='F')])]
+    go_data = [Row(id='GO:0003677', label='DNA binding')]
+    target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
+    go_df = spark.createDataFrame(go_data, GO_SCHEMA)
+    result = _compute_go_facets(target_df, go_df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+    assert row.datasourceId == 'GO:0003677'
+
+
+# ---------------------------------------------------------------------------
+# 5. Subcellular location facets
+# ---------------------------------------------------------------------------
+
+SUBCELLULAR_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'subcellularLocations',
+        ArrayType(
+            StructType([
+                StructField('location', StringType()),
+                StructField('termSl', StringType()),
+            ])
+        ),
+    ),
+])
+
+
+def test_subcellular_location_facet_category(spark):
+    """Subcellular location facet produces 'Subcellular Location' category."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            subcellularLocations=[Row(location='nucleus', termSl='SL-0191')],
+        ),
+    ]
+    df = spark.createDataFrame(data, SUBCELLULAR_SCHEMA)
+    result = _compute_subcellular_location_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'Subcellular Location' in categories
+
+
+def test_subcellular_location_facet_entry_structure(spark):
+    """Subcellular location facet entries have label, category, entityIds, datasourceId."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            subcellularLocations=[Row(location='nucleus', termSl='SL-0191')],
+        ),
+    ]
+    df = spark.createDataFrame(data, SUBCELLULAR_SCHEMA)
+    result = _compute_subcellular_location_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+    assert row.label == 'nucleus'
+    assert row.datasourceId == 'SL-0191'
+
+
+# ---------------------------------------------------------------------------
+# 6. Target class facets
+# ---------------------------------------------------------------------------
+
+TARGET_CLASS_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'targetClass',
+        ArrayType(
+            StructType([
+                StructField('id', LongType()),
+                StructField('label', StringType()),
+                StructField('level', StringType()),
+            ])
+        ),
+    ),
+])
+
+
+def test_target_class_facet_category(spark):
+    """Target class facet produces 'ChEMBL Target Class' category."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            targetClass=[Row(id=1, label='Kinase', level='l1')],
+        ),
+    ]
+    df = spark.createDataFrame(data, TARGET_CLASS_SCHEMA)
+    result = _compute_target_class_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'ChEMBL Target Class' in categories
+
+
+def test_target_class_facet_entry_structure(spark):
+    """Target class facet entries have label, category, entityIds, datasourceId (null)."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            targetClass=[Row(id=1, label='Kinase', level='l1')],
+        ),
+    ]
+    df = spark.createDataFrame(data, TARGET_CLASS_SCHEMA)
+    result = _compute_target_class_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+    assert row.label == 'Kinase'
+    assert row.datasourceId is None
+
+
+# ---------------------------------------------------------------------------
+# 7. Pathway facets
+# ---------------------------------------------------------------------------
+
+PATHWAY_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'pathways',
+        ArrayType(
+            StructType([
+                StructField('pathwayId', StringType()),
+                StructField('pathway', StringType()),
+                StructField('topLevelTerm', StringType()),
+            ])
+        ),
+    ),
+])
+
+
+def test_pathway_facet_category(spark):
+    """Pathway facet produces 'Reactome' category."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            pathways=[Row(pathwayId='R-HSA-1', pathway='Cell Cycle', topLevelTerm='Cell Cycle')],
+        ),
+    ]
+    df = spark.createDataFrame(data, PATHWAY_SCHEMA)
+    result = _compute_pathway_facets(df, CATEGORIES)
+    rows = result.collect()
+    categories = {r.category for r in rows}
+    assert 'Reactome' in categories
+
+
+def test_pathway_facet_entry_structure(spark):
+    """Pathway facet entries have label, category, entityIds, datasourceId."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            pathways=[Row(pathwayId='R-HSA-1', pathway='Cell Cycle', topLevelTerm='Cell Cycle')],
+        ),
+    ]
+    df = spark.createDataFrame(data, PATHWAY_SCHEMA)
+    result = _compute_pathway_facets(df, CATEGORIES)
+    row = result.collect()[0]
+    assert hasattr(row, 'label')
+    assert hasattr(row, 'category')
+    assert hasattr(row, 'entityIds')
+    assert hasattr(row, 'datasourceId')
+    assert row.label == 'Cell Cycle'
+    assert row.datasourceId == 'R-HSA-1'
+
+
+# ---------------------------------------------------------------------------
+# 8. Simple facet
+# ---------------------------------------------------------------------------
+
+SIMPLE_FACET_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('approvedSymbol', StringType()),
+])
+
+
+class TestComputeSimpleFacet:
+    """Tests for _compute_simple_facet."""
+
+    def test_simple_facet_produces_expected_columns(self, spark):
+        """Simple facet output has label, category, entityIds, datasourceId."""
+        data = [
+            Row(id='ENSG00000001', approvedSymbol='BRCA1'),
+            Row(id='ENSG00000002', approvedSymbol='TP53'),
+        ]
+        df = spark.createDataFrame(data, SIMPLE_FACET_SCHEMA)
+        result = _compute_simple_facet(df, 'approvedSymbol', 'Approved Symbol', 'id')
+        row_dict = {r.label: r for r in result.collect()}
+        assert 'BRCA1' in row_dict
+        assert 'TP53' in row_dict
+
+    def test_simple_facet_category_value(self, spark):
+        """Simple facet uses the provided category string."""
+        data = [Row(id='ENSG00000001', approvedSymbol='BRCA1')]
+        df = spark.createDataFrame(data, SIMPLE_FACET_SCHEMA)
+        result = _compute_simple_facet(df, 'approvedSymbol', 'Target ID', 'id')
+        row = result.collect()[0]
+        assert row.category == 'Target ID'
+
+    def test_simple_facet_entity_ids_collected(self, spark):
+        """Simple facet collects entity IDs for the same label."""
+        data = [
+            Row(id='ENSG00000001', approvedSymbol='BRCA1'),
+        ]
+        df = spark.createDataFrame(data, SIMPLE_FACET_SCHEMA)
+        result = _compute_simple_facet(df, 'approvedSymbol', 'Approved Symbol', 'id')
+        row = result.collect()[0]
+        assert row.label == 'BRCA1'
+        assert 'ENSG00000001' in row.entityIds
+
+    def test_simple_facet_datasource_id_is_null(self, spark):
+        """Simple facet datasourceId is null."""
+        data = [Row(id='ENSG00000001', approvedSymbol='BRCA1')]
+        df = spark.createDataFrame(data, SIMPLE_FACET_SCHEMA)
+        result = _compute_simple_facet(df, 'approvedSymbol', 'Approved Symbol', 'id')
+        row = result.collect()[0]
+        assert row.datasourceId is None


### PR DESCRIPTION
## Summary

- Ports the `searchFacet` step from `platform-etl-backend` to PySpark in PTS
- Implements disease facets (name, therapeutic area) and target facets (tractability, GO, subcellular location, target class, pathways, plus simple id/symbol/name facets)
- Adds 17 unit tests covering all facet types

## References

Closes https://github.com/opentargets/issues/issues/4347

## Test plan

- [x] All 17 pytest tests pass (`uv run pytest test/test_search_facet.py -v`)
- [x] Ruff lint and format checks pass
- [x] `config.yaml` updated with `search_facet:` step block