### PR TITLE
feat: add interaction pyspark step (migrated from ETL)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1643,6 +1643,26 @@ steps:
         diseases: view/search_facet_disease
   ##################################################################################################
 
+  #: INTERACTION STEP :############################################################################
+  interaction:
+    - name: pyspark interaction
+      pyspark: interaction
+      source:
+        targets: output/target
+        rnacentral: input/interaction/rna_central_ensembl.tsv
+        humanmapping: input/interaction/HUMAN_9606_idmapping.dat.gz
+        ensproteins: input/interaction/Homo_sapiens.GRCh38.chr.gtf.gz
+        intact: input/interaction/intact-interactors.json
+        strings: input/interaction/string-interactions.txt.gz
+      destination:
+        interactions: output/interaction
+        interactions_evidence: output/interaction_evidence
+        interactions_unmatched: excluded/interaction
+      settings:
+        scorethreshold: 0
+        string_version: "12.0"
+  ##################################################################################################
+
   #: RELEASE METRICS STEP :##########################################################################
   search:
     - name: pyspark search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.10"
+version = "26.03.11"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/common/utils.py
+++ b/src/pts/pyspark/common/utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import pyspark.sql.functions as f
 from pyspark.sql import Column, DataFrame
-from pyspark.sql.types import StructType
+from pyspark.sql.types import StructField, StructType
 
 from pts import schemas
 
@@ -236,3 +236,50 @@ def parse_spark_schema(schema_json: str) -> StructType:
         core_schema = json.load(schema)
 
     return StructType.fromJson(core_schema)
+
+
+def snake_to_lower_camel(name: str) -> str:
+    """Convert a snake_case string to lowerCamelCase.
+
+    >>> snake_to_lower_camel('evidence_score')
+    'evidenceScore'
+    >>> snake_to_lower_camel('already')
+    'already'
+    """
+    parts = name.split('_')
+    return parts[0] + ''.join(p.capitalize() for p in parts[1:])
+
+
+def rename_columns_to_camel_case(df: DataFrame) -> DataFrame:
+    """Recursively rename all columns and nested struct fields from snake_case to lowerCamelCase.
+
+    Handles:
+    - Top-level columns
+    - Nested struct fields (any depth)
+    - Array<struct> element fields
+
+    Args:
+        df: DataFrame with snake_case column/field names.
+
+    Returns:
+        DataFrame with all names converted to lowerCamelCase.
+    """
+    from pyspark.sql.types import ArrayType as SparkArrayType
+
+    def _transform_schema(schema: StructType) -> StructType:
+        new_fields = []
+        for field in schema.fields:
+            new_name = snake_to_lower_camel(field.name)
+            new_type = _transform_type(field.dataType)
+            new_fields.append(StructField(new_name, new_type, field.nullable, field.metadata))
+        return StructType(new_fields)
+
+    def _transform_type(dtype):
+        if isinstance(dtype, StructType):
+            return _transform_schema(dtype)
+        if isinstance(dtype, SparkArrayType):
+            return SparkArrayType(_transform_type(dtype.elementType), dtype.containsNull)
+        return dtype
+
+    new_schema = _transform_schema(df.schema)
+    return df.sparkSession.createDataFrame(df.rdd, new_schema)

--- a/src/pts/pyspark/interaction.py
+++ b/src/pts/pyspark/interaction.py
@@ -1,0 +1,709 @@
+"""Interaction dataset generation.
+
+Ported from platform-etl-backend Interaction step. Computes protein-protein
+and RNA interactions from IntAct and STRING databases, producing aggregated
+interaction records and per-evidence records.
+
+Scala sources ported:
+    - Interaction.scala (main assembly)
+    - stringProtein/StringProtein.scala (STRING protein transformation)
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame, SparkSession
+from pyspark.sql.types import BooleanType, IntegerType, LongType
+
+from pts.pyspark.common.session import Session
+from pts.pyspark.common.utils import rename_columns_to_camel_case
+
+# ---------------------------------------------------------------------------
+# Column name mappings for A/B swap (intact/reactome/signor are bidirectional)
+# ---------------------------------------------------------------------------
+
+_SWAP_MAP: dict[str, str] = {
+    'targetA': 'targetB',
+    'intA': 'intB',
+    'intA_source': 'intB_source',
+    'speciesA': 'speciesB',
+    'intABiologicalRole': 'intBBiologicalRole',
+    'targetB': 'targetA',
+    'intB': 'intA',
+    'intB_source': 'intA_source',
+    'speciesB': 'speciesA',
+    'intBBiologicalRole': 'intABiologicalRole',
+}
+
+_BIDIRECTIONAL_SOURCES = ('reactome', 'intact', 'signor')
+
+# UDF: truncate a string at the first '_' or '-' character.
+# E.g. 'URS123-2_992' → 'URS123'.
+_GET_CODE = f.udf(lambda s: re.split(r'[_\-]', s.strip())[0] if s else s)
+
+# Evidence channel definitions for STRING data
+_STRING_EVIDENCE_CHANNELS = [
+    ('coexpression', 'MI:2231'),
+    ('cooccurence', 'MI:2231'),
+    ('neighborhood', 'MI:0057'),
+    ('fusion', 'MI:0036'),
+    ('homology', 'MI:2163'),
+    ('experimental', 'MI:0591'),
+    ('database', ''),
+    ('textmining', 'MI:0110'),
+]
+
+
+# ---------------------------------------------------------------------------
+# Mapping helpers (RNACentral / Human mapping)
+# ---------------------------------------------------------------------------
+
+
+def _transform_rnacentral(df: DataFrame) -> DataFrame:
+    """Transform the RNACentral file to (gene_id, mapped_id) pairs.
+
+    Maps column ``_c0`` to ``mapped_id`` and ``_c5`` to ``gene_id``.
+
+    Args:
+        df: Raw RNACentral TSV DataFrame with columns _c0 … _c5.
+
+    Returns:
+        DataFrame with columns gene_id and mapped_id.
+
+    Examples:
+        >>> from pyspark.sql import Row
+        >>> from pyspark.sql.types import StringType, StructField, StructType
+        >>> schema = StructType([
+        ...     StructField('_c0', StringType()),
+        ...     StructField('_c1', StringType()),
+        ...     StructField('_c2', StringType()),
+        ...     StructField('_c3', StringType()),
+        ...     StructField('_c4', StringType()),
+        ...     StructField('_c5', StringType()),
+        ... ])
+        >>> df = spark.createDataFrame(
+        ...     [Row(_c0='URS001', _c1='9606', _c2='x', _c3='y', _c4='z', _c5='ENSG001')],
+        ...     schema,
+        ... )
+        >>> result = _transform_rnacentral(df)
+        >>> row = result.collect()[0]
+        >>> row.mapped_id
+        'URS001'
+        >>> row.gene_id
+        'ENSG001'
+    """
+    return df.withColumnRenamed('_c0', 'mapped_id').withColumnRenamed('_c5', 'gene_id').select('gene_id', 'mapped_id')
+
+
+def _transform_human_mapping(df: DataFrame) -> DataFrame:
+    """Transform the Human Mapping file to (id, mapping_list) pairs.
+
+    Filters to rows where ``_c1 == 'Ensembl'``, groups by ``_c2``, and
+    collects the ``_c0`` values into a list.
+
+    Args:
+        df: Raw human-mapping TSV DataFrame with columns _c0, _c1, _c2.
+
+    Returns:
+        DataFrame with columns id (Ensembl gene id) and mapping_list (array of
+        mapped ids).
+
+    Examples:
+        >>> from pyspark.sql import Row
+        >>> from pyspark.sql.types import StringType, StructField, StructType
+        >>> schema = StructType([
+        ...     StructField('_c0', StringType()),
+        ...     StructField('_c1', StringType()),
+        ...     StructField('_c2', StringType()),
+        ... ])
+        >>> df = spark.createDataFrame(
+        ...     [
+        ...         Row(_c0='P12345', _c1='Ensembl', _c2='ENSG001'),
+        ...         Row(_c0='BRCA1',  _c1='Gene_Name', _c2='ENSG001'),
+        ...     ],
+        ...     schema,
+        ... )
+        >>> result = _transform_human_mapping(df)
+        >>> row = result.collect()[0]
+        >>> row.id
+        'ENSG001'
+        >>> sorted(row.mapping_list)
+        ['P12345']
+    """
+    return (
+        df
+        .filter(f.col('_c1') == 'Ensembl')
+        .groupBy('_c2')
+        .agg(f.collect_list('_c0').alias('mapping_list'))
+        .withColumnRenamed('_c2', 'id')
+        .withColumn('mapping_list', f.coalesce(f.col('mapping_list'), f.array()))
+        .select('id', 'mapping_list')
+    )
+
+
+def _transform_gene_ids(df: DataFrame, human_mapping: DataFrame) -> DataFrame:
+    """Extract gene_name → gene_id links from Human Mapping.
+
+    Uses Gene_Name entries to find rows whose mapped_id matches entries in
+    ``df`` (which already contains gene_id, mapped_id pairs). Returns the
+    combined (gene_id, mapped_id) rows for names that did not directly resolve
+    via Ensembl.
+
+    Args:
+        df: DataFrame with columns gene_id and mapped_id (from Ensembl mapping).
+        human_mapping: Raw human-mapping TSV DataFrame with _c0, _c1, _c2.
+
+    Returns:
+        DataFrame with columns gene_id and mapped_id.
+    """
+    genes = (
+        human_mapping
+        .filter(f.col('_c1') == 'Gene_Name')
+        .groupBy('_c2')
+        .agg(f.collect_list('_c0').alias('mapping_list'))
+    )
+
+    gene_ids = genes.withColumn('mapped_id', f.explode(f.col('mapping_list'))).drop('mapping_list')
+
+    combination_info = gene_ids.join(df, 'mapped_id', 'left')
+    mapped = combination_info.filter(f.col('gene_id').isNotNull()).drop('mapped_id').distinct()
+    mapped_not = combination_info.filter(f.col('gene_id').isNull()).drop('gene_id')
+    return mapped_not.join(mapped, '_c2').select('gene_id', 'mapped_id').distinct()
+
+
+def _generate_mapping(
+    target_df: DataFrame,
+    rnacentral_df: DataFrame,
+    human_mapping_df: DataFrame,
+) -> DataFrame:
+    """Generate the full gene_id ↔ mapped_id lookup table.
+
+    Combines protein IDs, HGNC IDs, Ensembl cross-references from
+    Human Mapping, RNACentral mappings, and gene-name derived mappings.
+
+    Args:
+        target_df: Target DataFrame with columns id, proteinIds, dbXRefs.
+        rnacentral_df: Raw RNACentral TSV DataFrame.
+        human_mapping_df: Raw Human Mapping TSV DataFrame.
+
+    Returns:
+        Distinct DataFrame with columns gene_id and mapped_id.
+    """
+    targets_proteins = target_df.withColumn('proteins', f.coalesce(f.col('proteinIds.id'), f.array())).select(
+        'id', 'proteins'
+    )
+
+    target_hgnc = (
+        target_df
+        .select(
+            f.col('id'),
+            f.filter(f.col('dbXRefs'), lambda c: c.getField('source') == 'HGNC').alias('h'),
+        )
+        .withColumn('mapped_id', f.explode(f.col('h.id')))
+        .select(
+            f.col('id').alias('gene_id'),
+            f.concat(f.lit('HGNC:'), f.col('mapped_id')).alias('mapped_id'),
+        )
+    )
+
+    human_mapping_result = _transform_human_mapping(human_mapping_df)
+    rna_mapping = _transform_rnacentral(rnacentral_df)
+
+    mapping_human = (
+        targets_proteins
+        .join(human_mapping_result, 'id', 'left')
+        .withColumn(
+            'mapped_id_list',
+            f.when(f.col('mapping_list').isNull(), f.col('proteins')).otherwise(
+                f.array_union(f.col('proteins'), f.col('mapping_list'))
+            ),
+        )
+        .select('id', 'mapped_id_list')
+        .distinct()
+        .withColumnRenamed('id', 'gene_id')
+    )
+
+    mapping_explode = mapping_human.withColumn('mapped_id', f.explode(f.col('mapped_id_list'))).drop('mapped_id_list')
+
+    map_gene_ids = _transform_gene_ids(mapping_explode, human_mapping_df)
+
+    mapping = mapping_explode.union(rna_mapping).union(target_hgnc).union(map_gene_ids)
+
+    return mapping.distinct()
+
+
+# ---------------------------------------------------------------------------
+# STRING protein transformation
+# ---------------------------------------------------------------------------
+
+
+def _transform_string_proteins(df: DataFrame, score_threshold: int, string_version: str = '12') -> DataFrame:
+    """Transform the STRING protein interaction file into the common schema.
+
+    Filters interactions below ``score_threshold``, constructs interactorA /
+    interactorB / interaction / source_info nested columns in the same schema
+    used by IntAct data.
+
+    Args:
+        df: Raw STRING CSV DataFrame with columns protein1, protein2,
+            combined_score, and evidence channel columns.
+        score_threshold: Minimum combined_score (inclusive) to keep.
+        string_version: STRING database version string for source_info.
+
+    Returns:
+        DataFrame with nested columns interactorA, interactorB, interaction,
+        source_info.
+    """
+    logger.info('Transforming STRING proteins with score_threshold=%d', score_threshold)
+
+    filtered = df.withColumn('interaction_score', f.ltrim(f.col('combined_score')).cast(IntegerType())).filter(
+        f.col('interaction_score') >= score_threshold
+    )
+
+    # Build per-channel evidence structs
+    for channel_name, mi_id in _STRING_EVIDENCE_CHANNELS:
+        filtered = filtered.withColumn(
+            'e_' + channel_name,
+            f.struct(
+                f.lit(channel_name).alias('interaction_detection_method_short_name'),
+                f.lit(mi_id).alias('interaction_detection_method_mi_identifier'),
+                f.col(channel_name).cast(LongType()).alias('evidence_score'),
+                f.lit(None).cast('string').alias('interaction_identifier'),
+                f.lit(None).cast('string').alias('pubmed_id'),
+            ),
+        )
+
+    return (
+        filtered
+        .filter(f.col('protein1').contains('9606.'))
+        .filter(f.col('protein2').contains('9606.'))
+        .withColumn('id_source_p1', f.regexp_replace(f.col('protein1'), '9606\\.', ''))
+        .withColumn('id_source_p2', f.regexp_replace(f.col('protein2'), '9606\\.', ''))
+        .withColumn('biological_role', f.lit('unspecified role'))
+        .withColumn('id_source', f.lit('ensembl_protein'))
+        .withColumn(
+            'organism',
+            f.struct(
+                f.lit('human').alias('mnemonic'),
+                f.lit('Homo sapiens').alias('scientific_name'),
+                f.lit(9606).cast('bigint').alias('taxon_id'),
+            ),
+        )
+        .withColumn(
+            'interactorA',
+            f.struct(
+                f.col('id_source'),
+                f.col('biological_role'),
+                f.col('id_source_p1').alias('id'),
+                f.col('organism'),
+            ),
+        )
+        .withColumn(
+            'interactorB',
+            f.struct(
+                f.col('id_source'),
+                f.col('biological_role'),
+                f.col('id_source_p2').alias('id'),
+                f.col('organism'),
+            ),
+        )
+        .withColumn(
+            'source_info',
+            f.struct(
+                f.lit(string_version).alias('database_version'),
+                f.lit('string').alias('source_database'),
+            ),
+        )
+        .withColumn('causal_interaction', f.lit(False).cast(BooleanType()))
+        .drop(
+            'protein1',
+            'protein2',
+            'id_source_p1',
+            'id_source_p2',
+            'biological_role',
+            'id_source',
+        )
+        .withColumn(
+            'all_evidence',
+            f.array(
+                f.col('e_textmining'),
+                f.col('e_database'),
+                f.col('e_experimental'),
+                f.col('e_fusion'),
+                f.col('e_neighborhood'),
+                f.col('e_cooccurence'),
+                f.col('e_coexpression'),
+                f.col('e_homology'),
+            ),
+        )
+        .withColumn(
+            'interaction',
+            f.struct(
+                f.col('interaction_score'),
+                f.col('causal_interaction'),
+                f.col('all_evidence').alias('evidence'),
+            ),
+        )
+        .drop(
+            'combined_score',
+            'textmining',
+            'database',
+            'experimental',
+            'fusion',
+            'neighborhood',
+            'cooccurence',
+            'coexpression',
+            'homology',
+            'e_textmining',
+            'e_database',
+            'e_experimental',
+            'e_fusion',
+            'e_neighborhood',
+            'e_cooccurence',
+            'e_coexpression',
+            'e_homology',
+            'all_evidence',
+            'interaction_score',
+            'causal_interaction',
+            'organism',
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Core interaction computation
+# ---------------------------------------------------------------------------
+
+
+def _generate_interactions(df: DataFrame, mapping_info: DataFrame) -> DataFrame:
+    """Map raw interaction records to (targetA, targetB) via the lookup table.
+
+    Handles the self-interaction case where interactorB is null by falling
+    back to interactorA values. For bidirectional sources (intact, reactome,
+    signor) the swapped (B→A) direction is also included via union.
+
+    Args:
+        df: Raw interaction DataFrame with interactorA, interactorB, interaction,
+            source_info nested columns.
+        mapping_info: DataFrame with columns gene_id and mapped_id.
+
+    Returns:
+        DataFrame of interaction evidence records (one row per evidence entry,
+        after exploding the evidences array).
+    """
+    interactions = (
+        df
+        .withColumn(
+            'intB',
+            f.when(f.col('interactorB.id').isNull(), f.col('interactorA.id')).otherwise(f.col('interactorB.id')),
+        )
+        .withColumn(
+            'intB_source',
+            f.when(f.col('interactorB.id_source').isNull(), f.col('interactorA.id_source')).otherwise(
+                f.col('interactorB.id_source')
+            ),
+        )
+        .withColumn(
+            'speciesB',
+            f.when(f.col('interactorB.organism').isNull(), f.col('interactorA.organism')).otherwise(
+                f.col('interactorB.organism')
+            ),
+        )
+        .withColumn(
+            'intBBiologicalRole',
+            f.when(
+                f.col('interactorB.biological_role').isNull(),
+                f.col('interactorA.biological_role'),
+            ).otherwise(f.col('interactorB.biological_role')),
+        )
+        .withColumn(
+            'interactionScore',
+            f.when(
+                f.col('interaction.interaction_score') > 1,
+                f.col('interaction.interaction_score') / 1000,
+            ).otherwise(f.col('interaction.interaction_score')),
+        )
+        .selectExpr(
+            'interactorA.id as intA',
+            'interactorA.id_source as intA_source',
+            'interactorA.organism as speciesA',
+            'interactorA.biological_role as intABiologicalRole',
+            'intB',
+            'intB_source',
+            'speciesB',
+            'intBBiologicalRole',
+            'source_info.source_database as sourceDatabase',
+            'source_info as interactionResources',
+            'interaction.evidence as evidencesList',
+            'interactionScore',
+        )
+        .withColumn(
+            'speciesA',
+            f.struct(
+                f.col('speciesA.mnemonic'),
+                f.col('speciesA.scientific_name').alias('scientificName'),
+                f.col('speciesA.taxon_id').alias('taxonId'),
+            ),
+        )
+        .withColumn(
+            'speciesB',
+            f.struct(
+                f.col('speciesB.mnemonic'),
+                f.col('speciesB.scientific_name').alias('scientificName'),
+                f.col('speciesB.taxon_id').alias('taxonId'),
+            ),
+        )
+    )
+
+    interaction_map_left = (
+        interactions
+        .join(
+            mapping_info,
+            _GET_CODE(f.col('intA')) == f.col('mapped_id'),
+            'left',
+        )
+        .withColumn(
+            'targetA',
+            f.when(f.col('gene_id').isNull(), f.lit(None)).otherwise(f.col('gene_id')),
+        )
+        .drop('gene_id', 'mapped_id')
+    )
+
+    interaction_mapped = (
+        interaction_map_left
+        .join(
+            mapping_info.alias('mapping'),
+            _GET_CODE(f.col('intB')) == f.col('mapping.mapped_id'),
+            'left',
+        )
+        .withColumn(
+            'targetB',
+            f.when(f.col('gene_id').isNull(), f.lit(None)).otherwise(f.col('gene_id')),
+        )
+        .drop('gene_id', 'mapping.mapped_id')
+    )
+
+    # Swap A/B for bidirectional sources and union.
+    # Exclude rows where intA == intB — swapping a self-interaction produces
+    # an identical row, which would create duplicates (fixes opentargets/issues#3853).
+    reverse_interactions = (
+        interaction_mapped
+        .filter(f.col('sourceDatabase').isin(*_BIDIRECTIONAL_SOURCES))
+        .filter(f.col('intA') != f.col('intB'))
+        .select([f.col(c).alias(_SWAP_MAP.get(c, c)) for c in interaction_mapped.columns])
+    )
+
+    full_interactions = interaction_mapped.unionByName(reverse_interactions)
+
+    return full_interactions.withColumn('evidences', f.explode(f.col('evidencesList'))).drop(
+        'evidencesList', 'sourceDatabase'
+    )
+
+
+def _select_fields(df: DataFrame) -> DataFrame:
+    """Select and flatten fields for the interaction_evidences index.
+
+    Args:
+        df: Interaction evidence DataFrame.
+
+    Returns:
+        DataFrame with flattened evidence fields.
+    """
+    return df.selectExpr(
+        'targetA',
+        'intA',
+        'intA_source',
+        'speciesA',
+        'targetB',
+        'intB',
+        'intB_source',
+        'speciesB',
+        'interactionResources',
+        'interactionScore',
+        'evidences.*',
+        'intABiologicalRole',
+        'intBBiologicalRole',
+    )
+
+
+def _generate_interactions_agg(df: DataFrame) -> DataFrame:
+    """Aggregate interaction evidence rows into per-pair summary records.
+
+    Groups by source database, targetA/B, intA/B, biological roles and species,
+    and produces a count of evidence rows and the first interaction score.
+
+    Args:
+        df: Interaction evidence DataFrame (from _select_fields).
+
+    Returns:
+        DataFrame with aggregated interaction records and sourceDatabase column.
+    """
+    return (
+        df
+        .groupBy(
+            'interactionResources.source_database',
+            'targetA',
+            'intA',
+            'intABiologicalRole',
+            'targetB',
+            'intB',
+            'intBBiologicalRole',
+            'speciesA',
+            'speciesB',
+        )
+        .agg(
+            f.count('*').alias('count'),
+            f.first(f.col('interactionScore')).alias('scoring'),
+        )
+        .withColumnRenamed('source_database', 'sourceDatabase')
+    )
+
+
+def _transform_ensembl_protein(df: DataFrame) -> DataFrame:
+    """Extract gene_id, protein_id pairs from the Ensembl GTF file.
+
+    Filters to CDS feature rows and extracts ENSG/ENSP identifiers from
+    column _c8 via regex.
+
+    Args:
+        df: Raw GTF TSV DataFrame (comment lines already excluded by reader).
+
+    Returns:
+        DataFrame with columns gene_id and protein_id.
+    """
+    return (
+        df
+        .filter(f.col('_c2') == 'CDS')
+        .withColumn('gene_id', f.regexp_extract(f.col('_c8'), r'ENSG\w{11}', 0))
+        .withColumn('protein_id', f.regexp_extract(f.col('_c8'), r'ENSP\w{11}', 0))
+        .select('gene_id', 'protein_id')
+    )
+
+
+def _get_unmatched(intact_df: DataFrame, string_df: DataFrame) -> DataFrame:
+    """Collect unmatched interactorB IDs (human, no targetB resolved).
+
+    Args:
+        intact_df: IntAct interaction evidence DataFrame.
+        string_df: STRING interaction evidence DataFrame.
+
+    Returns:
+        Distinct DataFrame with column intB.
+    """
+    intact_missing = intact_df.filter(f.col('targetB').isNull() & (f.col('speciesB.taxonId') == 9606)).select('intB')
+
+    string_missing = string_df.filter(f.col('targetB').isNull() & (f.col('speciesB.taxonId') == 9606)).select('intB')
+
+    return intact_missing.unionByName(string_missing).select('intB').distinct()
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def interaction(
+    source: dict[str, str],
+    destination: dict[str, str],
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Compute interaction datasets from IntAct and STRING.
+
+    Reads target, RNACentral, Human Mapping, Ensembl protein, IntAct, and
+    STRING inputs. Produces aggregated interaction records, per-evidence
+    records, and a list of unmatched interactor IDs.
+
+    Args:
+        source: Input paths keyed by 'targets', 'rnacentral', 'humanmapping',
+            'ensproteins', 'intact', 'strings'.
+        destination: Output paths keyed by 'interactions',
+            'interactions_evidence', 'interactions_unmatched'.
+        settings: Step settings; may contain 'scorethreshold' (int, default 0)
+            and 'string_version' (str, default '12').
+        properties: Spark/GCS properties forwarded to Session.
+    """
+    spark: SparkSession = Session(app_name='interaction', properties=properties).spark
+
+    score_threshold: int = int(settings.get('scorethreshold', 0))
+    string_version: str = str(settings.get('string_version', '12'))
+
+    logger.info('Loading target data from %s', source['targets'])
+    target_df = spark.read.parquet(source['targets'])
+
+    logger.info('Loading RNACentral data from %s', source['rnacentral'])
+    rnacentral_df = spark.read.option('sep', '\t').option('header', 'false').csv(source['rnacentral'])
+
+    logger.info('Loading Human Mapping data from %s', source['humanmapping'])
+    human_mapping_df = spark.read.option('sep', '\t').option('header', 'false').csv(source['humanmapping'])
+
+    logger.info('Loading Ensembl protein data from %s', source['ensproteins'])
+    ensproteins_raw = (
+        spark.read.option('sep', '\t').option('header', 'false').option('comment', '#').csv(source['ensproteins'])
+    )
+    ensproteins_df = _transform_ensembl_protein(ensproteins_raw)
+
+    logger.info('Loading IntAct data from %s', source['intact'])
+    intact_raw = spark.read.json(source['intact'])
+
+    logger.info('Loading STRING data from %s', source['strings'])
+    strings_raw = spark.read.option('sep', ' ').option('header', 'true').csv(source['strings'])
+
+    # Build mapping lookup
+    logger.info('Generating ID mapping table')
+    mapping_df = _generate_mapping(target_df, rnacentral_df, human_mapping_df)
+
+    # STRING interactions
+    logger.info('Transforming STRING proteins (score_threshold=%d)', score_threshold)
+    string_proteins = _transform_string_proteins(strings_raw, score_threshold, string_version)
+    string_mapping = ensproteins_df.withColumnRenamed('protein_id', 'mapped_id').distinct()
+    string_interactions_df = _generate_interactions(string_proteins, string_mapping).filter(
+        f.col('evidences.evidence_score') > 0
+    )
+
+    # IntAct interactions
+    logger.info('Transforming IntAct interactions')
+    intact_interactions_df = _generate_interactions(intact_raw, mapping_df)
+
+    # Filter: remove null targetA (keep for unmatched output)
+    intact_valid = intact_interactions_df.filter(f.col('targetA').isNotNull())
+    string_valid = string_interactions_df.filter(f.col('targetA').isNotNull())
+
+    # Aggregated interactions
+    logger.info('Aggregating interaction pairs')
+    intact_agg = _generate_interactions_agg(_select_fields(intact_valid))
+    string_agg = _generate_interactions_agg(_select_fields(string_valid))
+    aggregated = rename_columns_to_camel_case(intact_agg.unionByName(string_agg)).coalesce(200)
+
+    # Evidences
+    logger.info('Generating interaction evidences')
+    intact_evidences = _select_fields(intact_valid)
+    string_evidences = _select_fields(string_valid).withColumn('evidence_score', f.col('evidence_score') / 1000)
+
+    # Union evidences (string first, then intact — match Scala unionDataframeDifferentSchema order)
+    all_columns = list(dict.fromkeys(string_evidences.columns + intact_evidences.columns))
+    for col_name in all_columns:
+        if col_name not in string_evidences.columns:
+            string_evidences = string_evidences.withColumn(col_name, f.lit(None))
+        if col_name not in intact_evidences.columns:
+            intact_evidences = intact_evidences.withColumn(col_name, f.lit(None))
+
+    evidences_raw = string_evidences.select(all_columns).unionByName(intact_evidences.select(all_columns))
+    evidences = rename_columns_to_camel_case(evidences_raw).repartition(200)
+
+    # Unmatched
+    logger.info('Collecting unmatched interactors')
+    unmatched = _get_unmatched(intact_interactions_df, string_interactions_df)
+
+    logger.info('Writing interactions to %s', destination['interactions'])
+    aggregated.write.mode('overwrite').parquet(destination['interactions'])
+
+    logger.info('Writing interactions_evidence to %s', destination['interactions_evidence'])
+    evidences.write.mode('overwrite').parquet(destination['interactions_evidence'])
+
+    logger.info('Writing interactions_unmatched to %s', destination['interactions_unmatched'])
+    unmatched.write.mode('overwrite').parquet(destination['interactions_unmatched'])

--- a/test/test_common_utils.py
+++ b/test/test_common_utils.py
@@ -1,0 +1,167 @@
+"""Tests for pts.pyspark.common.utils camelCase conversion utilities."""
+
+import pytest
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    ArrayType,
+    BooleanType,
+    IntegerType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from pts.pyspark.common.utils import rename_columns_to_camel_case, snake_to_lower_camel
+
+# ---------------------------------------------------------------------------
+# snake_to_lower_camel
+# ---------------------------------------------------------------------------
+
+
+def test_snake_to_lower_camel_single_word():
+    assert snake_to_lower_camel('score') == 'score'
+
+
+def test_snake_to_lower_camel_two_words():
+    assert snake_to_lower_camel('evidence_score') == 'evidenceScore'
+
+
+def test_snake_to_lower_camel_three_words():
+    assert snake_to_lower_camel('interaction_mi_identifier') == 'interactionMiIdentifier'
+
+
+def test_snake_to_lower_camel_already_camel():
+    assert snake_to_lower_camel('evidenceScore') == 'evidenceScore'
+
+
+# ---------------------------------------------------------------------------
+# rename_columns_to_camel_case — top-level columns
+# ---------------------------------------------------------------------------
+
+
+def test_rename_top_level_columns(spark):
+    df = spark.createDataFrame([Row(evidence_score=1.0, source_database='intact')])
+    result = rename_columns_to_camel_case(df)
+    assert 'evidenceScore' in result.columns
+    assert 'sourceDatabase' in result.columns
+    assert result.collect()[0]['evidenceScore'] == 1
+
+
+def test_rename_preserves_values(spark):
+    df = spark.createDataFrame([Row(target_a='ENSG1', target_b='ENSG2', score=0.5)])
+    result = rename_columns_to_camel_case(df)
+    row = result.collect()[0]
+    assert row['targetA'] == 'ENSG1'
+    assert row['targetB'] == 'ENSG2'
+    assert row['score'] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# rename_columns_to_camel_case — nested structs
+# ---------------------------------------------------------------------------
+
+
+def test_rename_nested_struct_fields(spark):
+    schema = StructType([
+        StructField(
+            'info',
+            StructType([
+                StructField('database_version', StringType()),
+                StructField('source_database', StringType()),
+            ]),
+        ),
+    ])
+    df = spark.createDataFrame([Row(info=Row(database_version='v1', source_database='intact'))], schema)
+    result = rename_columns_to_camel_case(df)
+    row = result.collect()[0]
+    assert row['info']['databaseVersion'] == 'v1'
+    assert row['info']['sourceDatabase'] == 'intact'
+
+
+def test_rename_deeply_nested_struct(spark):
+    schema = StructType([
+        StructField(
+            'outer_field',
+            StructType([
+                StructField(
+                    'inner_field',
+                    StructType([
+                        StructField('deep_value', StringType()),
+                    ]),
+                ),
+            ]),
+        ),
+    ])
+    df = spark.createDataFrame([Row(outer_field=Row(inner_field=Row(deep_value='hello')))], schema)
+    result = rename_columns_to_camel_case(df)
+    row = result.collect()[0]
+    assert row['outerField']['innerField']['deepValue'] == 'hello'
+
+
+# ---------------------------------------------------------------------------
+# rename_columns_to_camel_case — array<struct>
+# ---------------------------------------------------------------------------
+
+
+def test_rename_array_struct_fields(spark):
+    schema = StructType([
+        StructField(
+            'methods',
+            ArrayType(
+                StructType([
+                    StructField('mi_identifier', StringType()),
+                    StructField('short_name', StringType()),
+                ])
+            ),
+        ),
+    ])
+    df = spark.createDataFrame([Row(methods=[Row(mi_identifier='MI:0001', short_name='test')])], schema)
+    result = rename_columns_to_camel_case(df)
+    row = result.collect()[0]
+    assert row['methods'][0]['miIdentifier'] == 'MI:0001'
+    assert row['methods'][0]['shortName'] == 'test'
+
+
+# ---------------------------------------------------------------------------
+# rename_columns_to_camel_case — mixed schema
+# ---------------------------------------------------------------------------
+
+
+def test_rename_mixed_schema_preserves_all_data(spark):
+    schema = StructType([
+        StructField('target_id', StringType()),
+        StructField('interaction_score', IntegerType()),
+        StructField(
+            'source_info',
+            StructType([
+                StructField('database_version', StringType()),
+            ]),
+        ),
+        StructField(
+            'detection_methods',
+            ArrayType(
+                StructType([
+                    StructField('method_name', StringType()),
+                    StructField('is_valid', BooleanType()),
+                ])
+            ),
+        ),
+    ])
+    df = spark.createDataFrame(
+        [
+            Row(
+                target_id='ENSG1',
+                interaction_score=42,
+                source_info=Row(database_version='v2'),
+                detection_methods=[Row(method_name='pull-down', is_valid=True)],
+            )
+        ],
+        schema,
+    )
+    result = rename_columns_to_camel_case(df)
+    row = result.collect()[0]
+    assert row['targetId'] == 'ENSG1'
+    assert row['interactionScore'] == 42
+    assert row['sourceInfo']['databaseVersion'] == 'v2'
+    assert row['detectionMethods'][0]['methodName'] == 'pull-down'
+    assert row['detectionMethods'][0]['isValid'] is True

--- a/test/test_interaction.py
+++ b/test/test_interaction.py
@@ -1,0 +1,254 @@
+"""Tests for the interaction pyspark module.
+
+Ported from platform-etl-backend Interaction step.
+"""
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    ArrayType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from pts.pyspark.interaction import (
+    _transform_human_mapping,
+    _transform_rnacentral,
+    _transform_string_proteins,
+)
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+RNACENTRAL_SCHEMA = StructType([
+    StructField('_c0', StringType()),
+    StructField('_c1', StringType()),
+    StructField('_c2', StringType()),
+    StructField('_c3', StringType()),
+    StructField('_c4', StringType()),
+    StructField('_c5', StringType()),
+])
+
+HUMAN_MAPPING_SCHEMA = StructType([
+    StructField('_c0', StringType()),
+    StructField('_c1', StringType()),
+    StructField('_c2', StringType()),
+])
+
+STRINGS_SCHEMA = StructType([
+    StructField('protein1', StringType()),
+    StructField('protein2', StringType()),
+    StructField('combined_score', StringType()),
+    StructField('coexpression', StringType()),
+    StructField('cooccurence', StringType()),
+    StructField('neighborhood', StringType()),
+    StructField('fusion', StringType()),
+    StructField('homology', StringType()),
+    StructField('experimental', StringType()),
+    StructField('database', StringType()),
+    StructField('textmining', StringType()),
+])
+
+
+# ---------------------------------------------------------------------------
+# 1. _transform_rnacentral
+# ---------------------------------------------------------------------------
+
+
+def test_transform_rnacentral_maps_c0_to_mapped_id(spark):
+    """_transform_rnacentral maps _c0 to mapped_id."""
+    data = [Row(_c0='URS0000001', _c1='9606', _c2='x', _c3='y', _c4='z', _c5='ENSG00000001')]
+    df = spark.createDataFrame(data, RNACENTRAL_SCHEMA)
+    result = _transform_rnacentral(df)
+    row = result.collect()[0]
+    assert row.mapped_id == 'URS0000001'
+
+
+def test_transform_rnacentral_maps_c5_to_gene_id(spark):
+    """_transform_rnacentral maps _c5 to gene_id."""
+    data = [Row(_c0='URS0000001', _c1='9606', _c2='x', _c3='y', _c4='z', _c5='ENSG00000001')]
+    df = spark.createDataFrame(data, RNACENTRAL_SCHEMA)
+    result = _transform_rnacentral(df)
+    row = result.collect()[0]
+    assert row.gene_id == 'ENSG00000001'
+
+
+def test_transform_rnacentral_output_columns(spark):
+    """_transform_rnacentral output has exactly gene_id and mapped_id columns."""
+    data = [Row(_c0='URS0000001', _c1='9606', _c2='x', _c3='y', _c4='z', _c5='ENSG00000002')]
+    df = spark.createDataFrame(data, RNACENTRAL_SCHEMA)
+    result = _transform_rnacentral(df)
+    assert set(result.columns) == {'gene_id', 'mapped_id'}
+
+
+# ---------------------------------------------------------------------------
+# 2. _transform_human_mapping
+# ---------------------------------------------------------------------------
+
+
+def test_transform_human_mapping_filters_ensembl(spark):
+    """_transform_human_mapping keeps only rows where _c1 == 'Ensembl'."""
+    data = [
+        Row(_c0='P12345', _c1='Ensembl', _c2='ENSG00000001'),
+        Row(_c0='Q98765', _c1='Gene_Name', _c2='ENSG00000001'),
+        Row(_c0='BRCA1', _c1='Ensembl', _c2='ENSG00000002'),
+    ]
+    df = spark.createDataFrame(data, HUMAN_MAPPING_SCHEMA)
+    result = _transform_human_mapping(df)
+    rows = result.collect()
+    ids = {r.id for r in rows}
+    # only Ensembl rows contribute, but Gene_Name row is excluded
+    assert 'ENSG00000001' in ids
+    assert 'ENSG00000002' in ids
+
+
+def test_transform_human_mapping_groups_by_c2(spark):
+    """_transform_human_mapping groups by _c2 to produce mapping_list."""
+    data = [
+        Row(_c0='P12345', _c1='Ensembl', _c2='ENSG00000001'),
+        Row(_c0='Q11111', _c1='Ensembl', _c2='ENSG00000001'),
+    ]
+    df = spark.createDataFrame(data, HUMAN_MAPPING_SCHEMA)
+    result = _transform_human_mapping(df)
+    rows = result.collect()
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == 'ENSG00000001'
+    assert set(row.mapping_list) == {'P12345', 'Q11111'}
+
+
+def test_transform_human_mapping_output_columns(spark):
+    """_transform_human_mapping output has id and mapping_list columns."""
+    data = [Row(_c0='P12345', _c1='Ensembl', _c2='ENSG00000001')]
+    df = spark.createDataFrame(data, HUMAN_MAPPING_SCHEMA)
+    result = _transform_human_mapping(df)
+    assert set(result.columns) == {'id', 'mapping_list'}
+
+
+def test_transform_human_mapping_mapping_list_is_array(spark):
+    """_transform_human_mapping produces mapping_list as an array type."""
+    data = [Row(_c0='P12345', _c1='Ensembl', _c2='ENSG00000001')]
+    df = spark.createDataFrame(data, HUMAN_MAPPING_SCHEMA)
+    result = _transform_human_mapping(df)
+    field = [f for f in result.schema.fields if f.name == 'mapping_list'][0]
+    assert isinstance(field.dataType, ArrayType)
+
+
+# ---------------------------------------------------------------------------
+# 3. STRING score threshold filtering
+# ---------------------------------------------------------------------------
+
+
+def test_strings_score_threshold_filters_low_scores(spark):
+    """STRING interactions below the score threshold are excluded."""
+    data = [
+        Row(
+            protein1='9606.ENSP00000001',
+            protein2='9606.ENSP00000002',
+            combined_score='500',
+            coexpression='100',
+            cooccurence='0',
+            neighborhood='0',
+            fusion='0',
+            homology='0',
+            experimental='200',
+            database='0',
+            textmining='100',
+        ),
+        Row(
+            protein1='9606.ENSP00000003',
+            protein2='9606.ENSP00000004',
+            combined_score='200',
+            coexpression='50',
+            cooccurence='0',
+            neighborhood='0',
+            fusion='0',
+            homology='0',
+            experimental='100',
+            database='0',
+            textmining='50',
+        ),
+    ]
+    df = spark.createDataFrame(data, STRINGS_SCHEMA)
+    result = _transform_string_proteins(df, score_threshold=400)
+    rows = result.collect()
+    # only the row with combined_score=500 should survive
+    assert len(rows) == 1
+
+
+def test_strings_score_threshold_zero_keeps_all(spark):
+    """STRING interactions all pass when threshold is 0."""
+    data = [
+        Row(
+            protein1='9606.ENSP00000001',
+            protein2='9606.ENSP00000002',
+            combined_score='1',
+            coexpression='0',
+            cooccurence='0',
+            neighborhood='0',
+            fusion='0',
+            homology='0',
+            experimental='0',
+            database='0',
+            textmining='0',
+        ),
+    ]
+    df = spark.createDataFrame(data, STRINGS_SCHEMA)
+    result = _transform_string_proteins(df, score_threshold=0)
+    rows = result.collect()
+    assert len(rows) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. STRING output schema fields
+# ---------------------------------------------------------------------------
+
+
+def test_string_proteins_output_schema_fields(spark):
+    """_transform_string_proteins output has expected nested schema fields."""
+    data = [
+        Row(
+            protein1='9606.ENSP00000001',
+            protein2='9606.ENSP00000002',
+            combined_score='500',
+            coexpression='100',
+            cooccurence='0',
+            neighborhood='0',
+            fusion='0',
+            homology='0',
+            experimental='200',
+            database='0',
+            textmining='100',
+        ),
+    ]
+    df = spark.createDataFrame(data, STRINGS_SCHEMA)
+    result = _transform_string_proteins(df, score_threshold=0)
+    col_names = set(result.columns)
+    assert 'interactorA' in col_names
+    assert 'interactorB' in col_names
+    assert 'interaction' in col_names
+    assert 'source_info' in col_names
+
+
+def test_string_proteins_source_database_is_string(spark):
+    """_transform_string_proteins sets source_database to 'string'."""
+    data = [
+        Row(
+            protein1='9606.ENSP00000001',
+            protein2='9606.ENSP00000002',
+            combined_score='500',
+            coexpression='100',
+            cooccurence='0',
+            neighborhood='0',
+            fusion='0',
+            homology='0',
+            experimental='200',
+            database='0',
+            textmining='100',
+        ),
+    ]
+    df = spark.createDataFrame(data, STRINGS_SCHEMA)
+    result = _transform_string_proteins(df, score_threshold=0)
+    row = result.collect()[0]
+    assert row.source_info.source_database == 'string'


### PR DESCRIPTION
## Summary

- Ports `Interaction.scala` and `StringProtein.scala` from `platform-etl-backend` to PySpark (`src/pts/pyspark/interaction.py`)
- Adds 11 unit tests covering `_transform_rnacentral`, `_transform_human_mapping`, STRING score threshold filtering, and output schema validation
- Adds `interaction:` step to `config.yaml`

## Details

Key functions:
- `_transform_rnacentral(df)` → `(gene_id, mapped_id)` from RNACentral TSV
- `_transform_human_mapping(df)` → `(id, mapping_list)` filtered to Ensembl entries
- `_transform_string_proteins(df, score_threshold)` → structured STRING interaction DataFrame
- `interaction(source, destination, settings, properties)` — main entry point

Closes https://github.com/opentargets/issues/issues/4347

## Test plan

- [x] `uv run pytest test/test_interaction.py -v` — 11 tests pass
- [x] `uv run ruff check src/pts/pyspark/interaction.py test/test_interaction.py` — no errors
- [x] `uv run ruff format` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)