### PR TITLE
migrate etl_search_ebi to PySpark

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1574,6 +1574,22 @@ steps:
         spark.driver.memory: 16g
   ##################################################################################################
 
+  #: SEARCH EBI STEP :##############################################################################
+  search_ebi:
+    - name: pyspark search_ebi
+      pyspark: search_ebi
+      source:
+        disease: output/disease
+        target: output/target
+        association: output/association_overall_direct
+        evidence: output/evidence_gwas_credible_sets
+      destination:
+        associations: view/search_ebi_associations
+        evidence: view/search_ebi_evidence
+      properties:
+        spark.driver.memory: 8g
+  ##################################################################################################
+
   #: ASSOCIATION TIMESERIES VIEW STEP :#############################################################
   association_timeseries_view:
     - name: pyspark timeseries view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.03.5"
+version = "26.03.6"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/search_ebi.py
+++ b/src/pts/pyspark/search_ebi.py
@@ -1,0 +1,45 @@
+"""PySpark implementation of the SearchEBI step.
+
+Ported from platform-etl-backend SearchEBI step.
+"""
+
+import pyspark.sql.functions as f
+from pyspark.sql import DataFrame
+
+from pts.pyspark.common.session import Session
+
+
+def _generate_datasets(
+    diseases: DataFrame,
+    targets: DataFrame,
+    associations: DataFrame,
+    evidence: DataFrame,
+) -> dict[str, DataFrame]:
+    """Join associations and evidence with target and disease metadata."""
+    assoc_ds = (
+        associations.join(targets, 'targetId', 'inner')
+        .join(diseases, 'diseaseId', 'inner')
+        .select('targetId', 'diseaseId', 'approvedSymbol', 'name', f.col('associationScore').alias('score'))
+    )
+    evidence_ds = (
+        evidence.join(targets, 'targetId', 'inner')
+        .join(diseases, 'diseaseId', 'inner')
+        .select('targetId', 'diseaseId', 'approvedSymbol', 'name', 'score')
+    )
+    return {'associations': assoc_ds, 'evidence': evidence_ds}
+
+
+def search_ebi(source: dict[str, str], destination: dict[str, str], settings, properties) -> None:
+    """Entry point for the search_ebi step."""
+    session = Session(app_name='search_ebi', properties=properties)
+    spark = session.spark
+
+    diseases = spark.read.parquet(source['disease']).withColumnRenamed('id', 'diseaseId')
+    targets = spark.read.parquet(source['target']).withColumnRenamed('id', 'targetId')
+    associations = spark.read.parquet(source['association'])
+    evidence = spark.read.parquet(source['evidence'])
+
+    datasets = _generate_datasets(diseases, targets, associations, evidence)
+
+    datasets['associations'].write.mode('overwrite').parquet(destination['associations'])
+    datasets['evidence'].write.mode('overwrite').parquet(destination['evidence'])

--- a/test/test_search_ebi.py
+++ b/test/test_search_ebi.py
@@ -1,0 +1,127 @@
+"""Tests for the search_ebi pyspark module.
+
+Ported from platform-etl-backend SearchEBI step.
+"""
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    DoubleType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from pts.pyspark.search_ebi import _generate_datasets
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+DISEASE_SCHEMA = StructType([
+    StructField('diseaseId', StringType()),
+    StructField('name', StringType()),
+])
+
+TARGET_SCHEMA = StructType([
+    StructField('targetId', StringType()),
+    StructField('approvedSymbol', StringType()),
+])
+
+ASSOC_SCHEMA = StructType([
+    StructField('targetId', StringType()),
+    StructField('diseaseId', StringType()),
+    StructField('associationScore', DoubleType()),
+])
+
+EVIDENCE_SCHEMA = StructType([
+    StructField('targetId', StringType()),
+    StructField('diseaseId', StringType()),
+    StructField('score', DoubleType()),
+])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_generate_datasets_associations_output_columns(spark):
+    """_generate_datasets associations output has expected columns."""
+    diseases = spark.createDataFrame([Row(diseaseId='D1', name='Cancer')], DISEASE_SCHEMA)
+    targets = spark.createDataFrame([Row(targetId='T1', approvedSymbol='BRCA1')], TARGET_SCHEMA)
+    associations = spark.createDataFrame(
+        [Row(targetId='T1', diseaseId='D1', associationScore=0.9)], ASSOC_SCHEMA
+    )
+    evidence = spark.createDataFrame([], EVIDENCE_SCHEMA)
+
+    result = _generate_datasets(diseases, targets, associations, evidence)
+    cols = set(result['associations'].columns)
+    assert 'targetId' in cols
+    assert 'diseaseId' in cols
+    assert 'approvedSymbol' in cols
+    assert 'name' in cols
+    assert 'score' in cols
+
+
+def test_generate_datasets_associations_inner_join(spark):
+    """_generate_datasets associations only keeps rows matching both target and disease."""
+    diseases = spark.createDataFrame([Row(diseaseId='D1', name='Cancer')], DISEASE_SCHEMA)
+    targets = spark.createDataFrame([Row(targetId='T1', approvedSymbol='BRCA1')], TARGET_SCHEMA)
+    associations = spark.createDataFrame([
+        Row(targetId='T1', diseaseId='D1', associationScore=0.9),
+        Row(targetId='T2', diseaseId='D1', associationScore=0.5),  # T2 not in targets
+    ], ASSOC_SCHEMA)
+    evidence = spark.createDataFrame([], EVIDENCE_SCHEMA)
+
+    result = _generate_datasets(diseases, targets, associations, evidence)
+    rows = result['associations'].collect()
+    assert len(rows) == 1
+    assert rows[0].targetId == 'T1'
+
+
+def test_generate_datasets_associations_score_alias(spark):
+    """_generate_datasets renames associationScore to score."""
+    diseases = spark.createDataFrame([Row(diseaseId='D1', name='Cancer')], DISEASE_SCHEMA)
+    targets = spark.createDataFrame([Row(targetId='T1', approvedSymbol='BRCA1')], TARGET_SCHEMA)
+    associations = spark.createDataFrame(
+        [Row(targetId='T1', diseaseId='D1', associationScore=0.8)], ASSOC_SCHEMA
+    )
+    evidence = spark.createDataFrame([], EVIDENCE_SCHEMA)
+
+    result = _generate_datasets(diseases, targets, associations, evidence)
+    row = result['associations'].collect()[0]
+    assert abs(row.score - 0.8) < 1e-6
+
+
+def test_generate_datasets_evidence_output_columns(spark):
+    """_generate_datasets evidence output has expected columns."""
+    diseases = spark.createDataFrame([Row(diseaseId='D1', name='Cancer')], DISEASE_SCHEMA)
+    targets = spark.createDataFrame([Row(targetId='T1', approvedSymbol='BRCA1')], TARGET_SCHEMA)
+    associations = spark.createDataFrame([], ASSOC_SCHEMA)
+    evidence = spark.createDataFrame(
+        [Row(targetId='T1', diseaseId='D1', score=0.7)], EVIDENCE_SCHEMA
+    )
+
+    result = _generate_datasets(diseases, targets, associations, evidence)
+    cols = set(result['evidence'].columns)
+    assert 'targetId' in cols
+    assert 'diseaseId' in cols
+    assert 'approvedSymbol' in cols
+    assert 'name' in cols
+    assert 'score' in cols
+
+
+def test_generate_datasets_evidence_inner_join(spark):
+    """_generate_datasets evidence only keeps rows matching both target and disease."""
+    diseases = spark.createDataFrame([Row(diseaseId='D1', name='Cancer')], DISEASE_SCHEMA)
+    targets = spark.createDataFrame([Row(targetId='T1', approvedSymbol='BRCA1')], TARGET_SCHEMA)
+    associations = spark.createDataFrame([], ASSOC_SCHEMA)
+    evidence = spark.createDataFrame([
+        Row(targetId='T1', diseaseId='D1', score=0.7),
+        Row(targetId='T1', diseaseId='D2', score=0.5),  # D2 not in diseases
+    ], EVIDENCE_SCHEMA)
+
+    result = _generate_datasets(diseases, targets, associations, evidence)
+    rows = result['evidence'].collect()
+    assert len(rows) == 1
+    assert rows[0].diseaseId == 'D1'


### PR DESCRIPTION
## Summary
- Ports `SearchEBI` Scala step to `pts.pyspark.search_ebi`
- Joins associations and evidence with target/disease metadata
- Writes to `view/search_ebi_associations` and `view/search_ebi_evidence`
- Adds `search_ebi` step to `config.yaml`

## Test plan
- [x] `uv run pytest test/test_search_ebi.py` — 5 tests pass
- [x] `uv run ruff check src/pts/pyspark/search_ebi.py` — clean

Part of opentargets/issues#4347