### PR TITLE
chore: remove qc flags from drug index

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -36,7 +36,7 @@ steps:
       source: input/go/go.obo
       destination: output/go/go.parquet
   ##################################################################################################
-  
+
   #: OTAR STEP :####################################################################################
   otar:
     - name: pyspark otar
@@ -535,11 +535,6 @@ steps:
       destination:
         output: output/drug_molecule
         excluded: excluded/drug_molecule_failed_report
-      settings:
-        invalid_clinical_report_qc:
-          - PHASE_IV_NOT_APPROVED
-          - UNVALIDATED_INDICATION
-          - INDIRECT_PRIMARY_PURPOSE
   ##################################################################################################
 
   #: CLINICAL_REPORT STEP :#######################################################################
@@ -1703,7 +1698,7 @@ steps:
         interactions_unmatched: excluded/interaction
       settings:
         scorethreshold: 0
-        string_version: "12.0"
+        string_version: '12.0'
   ##################################################################################################
 
   #: RELEASE METRICS STEP :##########################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.4"
+version = "26.06.5"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"


### PR DESCRIPTION
I believe QC flags in the clinical reports reporting concerns about the validity of drug/indication relationships shouldn't be taken into account to calculate a drug's max stage.

This calculation is made from clinical reports across all indications. IMO, if we have a phase III trial for a drug studying a condition not supported by any other trial, it is fair to disregard it as a drug indication, but it doesn't hinder the fact that there is a phase III for the drug.

This change is of **low impact**, affecting the max phase assignment to **863 drugs (3.8% of the drug index**). This table represents how drugs are being promoted (columns represent new assignments, rows are previous assignments)
```
┌───────────────┬─────────┬─────────┬──────────┬───────────┬───────────────┬─────────┬───────────┐
│ stage_w_flags ┆ PHASE_2 ┆ PHASE_3 ┆ APPROVAL ┆ PHASE_1_2 ┆ EARLY_PHASE_1 ┆ PHASE_1 ┆ PHASE_2_3 │
│ ---           ┆ ---     ┆ ---     ┆ ---      ┆ ---       ┆ ---           ┆ ---     ┆ ---       │
│ str           ┆ u32     ┆ u32     ┆ u32      ┆ u32       ┆ u32           ┆ u32     ┆ u32       │
╞═══════════════╪═════════╪═════════╪══════════╪═══════════╪═══════════════╪═════════╪═══════════╡
│ EARLY_PHASE_1 ┆ 2       ┆ 4       ┆ 1        ┆ 0         ┆ 0             ┆ 4       ┆ 0         │
│ IND           ┆ 3       ┆ 1       ┆ 1        ┆ 1         ┆ 0             ┆ 5       ┆ 1         │
│ PHASE_1       ┆ 92      ┆ 25      ┆ 18       ┆ 51        ┆ 0             ┆ 0       ┆ 8         │
│ PHASE_1_2     ┆ 38      ┆ 16      ┆ 3        ┆ 0         ┆ 0             ┆ 0       ┆ 8         │
│ PHASE_2       ┆ 0       ┆ 70      ┆ 39       ┆ 0         ┆ 0             ┆ 0       ┆ 24        │
│ PHASE_2_3     ┆ 0       ┆ 20      ┆ 16       ┆ 0         ┆ 0             ┆ 0       ┆ 0         │
│ PHASE_3       ┆ 0       ┆ 0       ┆ 150      ┆ 0         ┆ 0             ┆ 0       ┆ 0         │
│ PRECLINICAL   ┆ 1       ┆ 1       ┆ 1        ┆ 0         ┆ 0             ┆ 0       ┆ 0         │
│ UNKNOWN       ┆ 64      ┆ 33      ┆ 46       ┆ 38        ┆ 10            ┆ 59      ┆ 9         │
│ TOTAL         ┆ 200     ┆170      ┆ 275      ┆ 65        ┆ 10            ┆ 68      ┆ 50        │
└───────────────┴─────────┴─────────┴──────────┴───────────┴───────────────┴─────────┴───────────┘
```
The category with the biggest gain is **approvals** (+200). I checked Unknown -> Approval transitions specifically to check they are legit.
    - [AMITRIPTYLINOXIDE](https://platform.opentargets.org/drug/CHEMBL627) is now approved thanks to this [Phase IV study](https://clinicaltrials.gov/study/nct02237937). 
    - [FLUOROCHOLINE](https://platform.opentargets.org/drug/CHEMBL5314939) is an approved diagnostic agent thanks to [this Phase IV trial](https://clinicaltrials.gov/study/nct01956409)
    - [LOXOPROFEN SODIUM](https://platform.opentargets.org/drug/CHEMBL66552) is now approved thanks to this [phase IV trial](https://clinicaltrials.gov/study/nct03800797). It is a salt of an approved drug
    - [THYROXINE](https://platform.opentargets.org/drug/CHEMBL42115) used to be in Phase III and now is approved thanks to this [phase IV trial ](https://clinicaltrials.gov/study/nct00111735). Levothyroxine is obv approved

#### Side notes (useful for https://github.com/opentargets/issues/issues/4339)
- FLUOROCHOLINE is incorrectly misassigned to prostate cancer and adenoma