### PR TITLE
Migrate literature_vector step from Scala

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1774,8 +1774,8 @@ steps:
         model: etc/model/w2v_model
       properties:
         spark.sql.shuffle.partitions: '800'
-    - name: pyspark vectors
-      pyspark: vectors
+    - name: pyspark literature_vector
+      pyspark: literature_vector
       source:
         model: etc/model/w2v_model
       destination:

--- a/config.yaml
+++ b/config.yaml
@@ -1774,4 +1774,10 @@ steps:
         model: etc/model/w2v_model
       properties:
         spark.sql.shuffle.partitions: '800'
+    - name: pyspark vectors
+      pyspark: vectors
+      source:
+        model: etc/model/w2v_model
+      destination:
+        vectors: output/literature_vector
   ##################################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.2"
+version = "26.06.3"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/literature_vector.py
+++ b/src/pts/pyspark/literature_vector.py
@@ -48,14 +48,14 @@ def _compute_vectors(vectors: DataFrame) -> DataFrame:
     )
 
 
-def vectors(
+def literature_vector(
     source: dict[str, str] | str,
     destination: dict[str, str] | str,
     settings: dict[str, Any],
     properties: dict[str, str],
 ) -> None:
     """Generate vector index from trained Word2Vec model."""
-    _spark = Session(app_name='vectors', properties=properties).spark
+    _spark = Session(app_name='literature_vector', properties=properties).spark
 
     model_path = source['model'] if isinstance(source, dict) else source
     logger.info(f'Loading Word2Vec model from {model_path}')

--- a/src/pts/pyspark/vectors.py
+++ b/src/pts/pyspark/vectors.py
@@ -1,0 +1,70 @@
+"""Literature word vector index generation.
+
+Ported from Vectors.scala in platform-etl-backend.
+Loads a trained Word2Vec model, extracts word vectors, computes L2 norms,
+assigns entity categories, and writes the result as a single-partition parquet.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from pyspark.ml.feature import Word2VecModel
+from pyspark.ml.functions import vector_to_array
+from pyspark.ml.linalg import Vectors
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as f
+from pyspark.sql.types import DoubleType
+
+from pts.pyspark.common.session import Session
+
+_OUTPUT_COLUMNS = ['category', 'word', 'norm', 'vector']
+
+
+def _compute_vectors(vectors: DataFrame) -> DataFrame:
+    """Transform raw Word2Vec vectors: assign category, compute norm, serialize.
+
+    Args:
+        vectors: DataFrame with columns [word, vector] from Word2VecModel.getVectors().
+
+    Returns:
+        DataFrame with columns [category, word, norm, vector].
+    """
+    norm_udf = f.udf(lambda v: float(Vectors.norm(v, 2.0)), DoubleType())
+
+    return (
+        vectors
+        .withColumn(
+            'category',
+            f
+            .when(f.col('word').startswith('ENSG'), f.lit('target'))
+            .when(f.col('word').startswith('CHEMBL'), f.lit('drug'))
+            .otherwise(f.lit('disease')),
+        )
+        .withColumn('norm', norm_udf(f.col('vector')))
+        .withColumn('vector', vector_to_array(f.col('vector')))
+        .select(*_OUTPUT_COLUMNS)
+    )
+
+
+def vectors(
+    source: dict[str, str] | str,
+    destination: dict[str, str] | str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate vector index from trained Word2Vec model."""
+    _spark = Session(app_name='vectors', properties=properties).spark
+
+    model_path = source['model'] if isinstance(source, dict) else source
+    logger.info(f'Loading Word2Vec model from {model_path}')
+    model = Word2VecModel.load(model_path)
+    raw_vectors = model.getVectors()
+
+    logger.info('Computing vector index')
+    result = _compute_vectors(raw_vectors).coalesce(1)
+
+    dest = destination['vectors'] if isinstance(destination, dict) else destination
+    logger.info(f'Writing vector index to {dest}')
+    result.write.mode('overwrite').parquet(dest)

--- a/test/test_vectors.py
+++ b/test/test_vectors.py
@@ -1,0 +1,87 @@
+"""Tests for vectors step."""
+
+import pytest
+from pyspark.ml.linalg import Vectors as MLVectors
+from pyspark.sql import Row
+
+
+class TestCategoryAssignment:
+    """Test _compute_vectors category logic."""
+
+    def test_target_category(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='ENSG00000139618', vector=MLVectors.dense([1.0, 0.0, 0.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert row['category'] == 'target'
+
+    def test_drug_category(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='CHEMBL25', vector=MLVectors.dense([0.0, 1.0, 0.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert row['category'] == 'drug'
+
+    def test_disease_category(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='EFO_0000311', vector=MLVectors.dense([0.0, 0.0, 1.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert row['category'] == 'disease'
+
+
+class TestNormComputation:
+    """Test L2 norm calculation."""
+
+    def test_unit_vector_norm(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='ENSG001', vector=MLVectors.dense([1.0, 0.0, 0.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert row['norm'] == pytest.approx(1.0)
+
+    def test_known_norm(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='ENSG001', vector=MLVectors.dense([3.0, 4.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert row['norm'] == pytest.approx(5.0)
+
+
+class TestOutputSchema:
+    """Test output column structure."""
+
+    def test_output_columns(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='ENSG001', vector=MLVectors.dense([1.0, 2.0]))],
+        )
+        result = _compute_vectors(df)
+        assert result.columns == ['category', 'word', 'norm', 'vector']
+
+    def test_vector_is_array(self, spark):
+        from pts.pyspark.vectors import _compute_vectors
+
+        df = spark.createDataFrame(
+            [Row(word='ENSG001', vector=MLVectors.dense([1.0, 2.0]))],
+        )
+        result = _compute_vectors(df)
+        row = result.collect()[0]
+        assert isinstance(row['vector'], list)
+        assert len(row['vector']) == 2

--- a/test/test_vectors.py
+++ b/test/test_vectors.py
@@ -1,4 +1,4 @@
-"""Tests for vectors step."""
+"""Tests for literature_vector step."""
 
 import pytest
 from pyspark.ml.linalg import Vectors as MLVectors
@@ -9,7 +9,7 @@ class TestCategoryAssignment:
     """Test _compute_vectors category logic."""
 
     def test_target_category(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='ENSG00000139618', vector=MLVectors.dense([1.0, 0.0, 0.0]))],
@@ -19,7 +19,7 @@ class TestCategoryAssignment:
         assert row['category'] == 'target'
 
     def test_drug_category(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='CHEMBL25', vector=MLVectors.dense([0.0, 1.0, 0.0]))],
@@ -29,7 +29,7 @@ class TestCategoryAssignment:
         assert row['category'] == 'drug'
 
     def test_disease_category(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='EFO_0000311', vector=MLVectors.dense([0.0, 0.0, 1.0]))],
@@ -43,7 +43,7 @@ class TestNormComputation:
     """Test L2 norm calculation."""
 
     def test_unit_vector_norm(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='ENSG001', vector=MLVectors.dense([1.0, 0.0, 0.0]))],
@@ -53,7 +53,7 @@ class TestNormComputation:
         assert row['norm'] == pytest.approx(1.0)
 
     def test_known_norm(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='ENSG001', vector=MLVectors.dense([3.0, 4.0]))],
@@ -67,7 +67,7 @@ class TestOutputSchema:
     """Test output column structure."""
 
     def test_output_columns(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='ENSG001', vector=MLVectors.dense([1.0, 2.0]))],
@@ -76,7 +76,7 @@ class TestOutputSchema:
         assert result.columns == ['category', 'word', 'norm', 'vector']
 
     def test_vector_is_array(self, spark):
-        from pts.pyspark.vectors import _compute_vectors
+        from pts.pyspark.literature_vector import _compute_vectors
 
         df = spark.createDataFrame(
             [Row(word='ENSG001', vector=MLVectors.dense([1.0, 2.0]))],


### PR DESCRIPTION
## Summary

- Port `Vectors.scala` from `platform-etl-backend` as a standalone PTS step
- Loads Word2Vec model, extracts vectors, assigns entity category (target/drug/disease)
- Computes L2 norm and writes single-partition parquet
- Depends on embedding step output

## Changes

- `src/pts/pyspark/vectors.py` — step implementation (70 LOC)
- `test/test_vectors.py` — 7 unit tests
- `config.yaml` — step entry

## Ref

- opentargets/issues#4374

🤖 Generated with [Claude Code](https://claude.com/claude-code)