### PR TITLE
Migrate evidence_epmc step from Scala

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1780,4 +1780,10 @@ steps:
         model: etc/model/w2v_model
       destination:
         vectors: output/literature_vector
+    - name: pyspark evidence_epmc
+      pyspark: evidence_epmc
+      source:
+        cooccurrences: intermediate/literature_cooccurrence
+      destination:
+        evidence: intermediate/evidence/literature_epmc
   ##################################################################################################

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.3"
+version = "26.06.4"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/evidence_epmc.py
+++ b/src/pts/pyspark/evidence_epmc.py
@@ -1,0 +1,133 @@
+"""EPMC literature evidence generation.
+
+Ported from Epmc.scala in platform-etl-backend (evidence portion only,
+EPMCCooccurrences is not migrated). Aggregates cooccurrence data into
+disease-target evidence entries with text mining sentences.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from loguru import logger
+from pyspark.sql import DataFrame
+from pyspark.sql import functions as f
+from pyspark.sql.types import StringType
+
+from pts.pyspark.common.session import Session
+
+_EXCLUDED_TARGET_TERMS = [
+    'TEC',
+    'TECS',
+    'Tec',
+    'tec',
+    "'",
+    '(',
+    ')',
+    '-',
+    '-S',
+    'S',
+    'S-',
+    'SS',
+    'SSS',
+    'Ss',
+    'Ss-',
+    's',
+    's-',
+    'ss',
+    'U3',
+    'U6',
+    'u6',
+    'SNORA70',
+    'U2',
+    'U8',
+]
+
+_SECTIONS_OF_INTEREST = [
+    'title',
+    'abstract',
+    'intro',
+    'case',
+    'figure',
+    'table',
+    'discuss',
+    'concl',
+    'results',
+    'appendix',
+    'other',
+]
+
+
+def _compute_evidence(cooccurrences: DataFrame) -> DataFrame:
+    """Aggregate cooccurrence data into scored disease-target evidence.
+
+    Args:
+        cooccurrences: Raw cooccurrence DataFrame.
+
+    Returns:
+        DataFrame with evidence columns including textMiningSentences.
+    """
+    return (
+        cooccurrences
+        .filter(f.col('section').isin(_SECTIONS_OF_INTEREST))
+        .withColumn('pmid', f.trim(f.col('pmid').cast(StringType())))
+        .withColumn('publicationIdentifier', f.coalesce(f.col('pmid'), f.col('pmcid')))
+        .filter(
+            (f.col('type') == 'GP-DS')
+            & f.col('isMapped')
+            & f.col('publicationIdentifier').isNotNull()
+            & (f.length(f.col('text')) < 600)
+            & ~f.col('label1').isin(_EXCLUDED_TARGET_TERMS)
+        )
+        .withColumnRenamed('keywordId1', 'targetFromSourceId')
+        .withColumnRenamed('keywordId2', 'diseaseFromSourceMappedId')
+        .groupBy('publicationIdentifier', 'targetFromSourceId', 'diseaseFromSourceMappedId', 'year')
+        .agg(
+            f.collect_set(f.col('pmcid')).alias('pmcIds'),
+            f.collect_set(f.col('pmid')).alias('literature'),
+            f.collect_set(
+                f.struct(
+                    f.col('text'),
+                    f.col('start1').alias('tStart'),
+                    f.col('end1').alias('tEnd'),
+                    f.col('start2').alias('dStart'),
+                    f.col('end2').alias('dEnd'),
+                    f.col('section'),
+                )
+            ).alias('textMiningSentences'),
+            f.sum(f.col('evidence_score')).alias('resourceScore'),
+        )
+        .withColumn('pmcIds', f.when(f.size(f.col('pmcIds')) != 0, f.col('pmcIds')))
+        .filter(f.col('resourceScore') > 1)
+        .select(
+            f.lit('europepmc').alias('datasourceId'),
+            f.lit('literature').alias('datatypeId'),
+            f.col('targetFromSourceId'),
+            f.col('diseaseFromSourceMappedId'),
+            f.col('resourceScore'),
+            f.col('literature'),
+            f.col('textMiningSentences'),
+            f.col('pmcIds'),
+            f.col('year').alias('publicationYear'),
+        )
+    )
+
+
+def evidence_epmc(
+    source: dict[str, str] | str,
+    destination: dict[str, str] | str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate EPMC disease-target evidence from cooccurrence data."""
+    spark = Session(app_name='evidence_epmc', properties=properties).spark
+
+    logger.info('Reading literature cooccurrences')
+    cooccurrences = spark.read.parquet(source['cooccurrences'])
+
+    logger.info('Computing EPMC evidence')
+    evidence = _compute_evidence(cooccurrences)
+
+    dest = destination['evidence'] if isinstance(destination, dict) else destination
+    logger.info(f'Writing EPMC evidence to {dest}')
+    evidence.write.mode('overwrite').parquet(dest)

--- a/test/test_evidence_epmc.py
+++ b/test/test_evidence_epmc.py
@@ -1,0 +1,163 @@
+"""Tests for evidence_epmc step."""
+
+import pytest
+from pyspark.sql import Row
+
+
+def _make_cooc_row(
+    pmid='12345',
+    pmcid='PMC001',
+    section='abstract',
+    type='GP-DS',
+    isMapped=True,  # noqa: N803
+    text='short text',
+    label1='BRCA1',
+    keywordId1='ENSG001',  # noqa: N803
+    keywordId2='EFO_0000311',  # noqa: N803
+    start1=0,
+    end1=5,
+    start2=10,
+    end2=15,
+    evidence_score=0.8,
+    year=2020,
+):
+    return Row(
+        pmid=pmid,
+        pmcid=pmcid,
+        section=section,
+        type=type,
+        isMapped=isMapped,
+        text=text,
+        label1=label1,
+        keywordId1=keywordId1,
+        keywordId2=keywordId2,
+        start1=start1,
+        end1=end1,
+        start2=start2,
+        end2=end2,
+        evidence_score=evidence_score,
+        year=year,
+    )
+
+
+class TestEpmcFiltering:
+    """Test the filtering logic of _compute_evidence."""
+
+    def test_filters_non_gp_ds_type(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(type='GP-DS', evidence_score=1.5),
+            _make_cooc_row(type='GP-DS', pmid='99999', keywordId1='ENSG002', evidence_score=1.5),
+            _make_cooc_row(type='DS-CD'),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        types = {r['targetFromSourceId'] for r in result.collect()}
+        assert 'ENSG001' in types
+
+    def test_filters_excluded_terms(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(label1='TEC', evidence_score=1.5),
+            _make_cooc_row(label1='BRCA1', pmid='99999', keywordId1='ENSG002', evidence_score=1.5),
+            _make_cooc_row(label1='BRCA1', pmid='99998', keywordId1='ENSG003', evidence_score=1.5),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        targets = {r['targetFromSourceId'] for r in result.collect()}
+        assert 'ENSG001' not in targets
+
+    def test_filters_long_text(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        long_text = 'x' * 600
+        data = [
+            _make_cooc_row(text=long_text, evidence_score=1.5),
+            _make_cooc_row(text='short', pmid='99999', keywordId1='ENSG002', evidence_score=1.5),
+            _make_cooc_row(text='short2', pmid='99998', keywordId1='ENSG003', evidence_score=1.5),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        assert result.count() == 2
+
+    def test_filters_unmapped(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(isMapped=False, evidence_score=1.5),
+            _make_cooc_row(isMapped=True, pmid='99999', keywordId1='ENSG002', evidence_score=1.5),
+            _make_cooc_row(isMapped=True, pmid='99998', keywordId1='ENSG003', evidence_score=1.5),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        assert result.count() == 2
+
+    def test_resource_score_threshold(self, spark):
+        """Only rows with resourceScore > 1 should pass."""
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(evidence_score=0.5),
+            _make_cooc_row(evidence_score=0.3, text='other'),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        assert result.count() == 0
+
+
+class TestEpmcAggregation:
+    """Test aggregation and output schema."""
+
+    def test_aggregates_by_publication(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(section='title', evidence_score=1.0, text='sentence 1'),
+            _make_cooc_row(section='abstract', evidence_score=1.0, text='sentence 2'),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        assert result.count() == 1
+        row = result.collect()[0]
+        assert row['resourceScore'] == pytest.approx(2.0)
+
+    def test_output_has_required_columns(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(evidence_score=1.5),
+            _make_cooc_row(evidence_score=1.0, text='another'),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        expected = {
+            'datasourceId',
+            'datatypeId',
+            'targetFromSourceId',
+            'diseaseFromSourceMappedId',
+            'resourceScore',
+            'literature',
+            'textMiningSentences',
+            'pmcIds',
+            'publicationYear',
+        }
+        assert expected.issubset(set(result.columns))
+
+    def test_text_mining_sentences_struct(self, spark):
+        from pts.pyspark.evidence_epmc import _compute_evidence
+
+        data = [
+            _make_cooc_row(evidence_score=1.5, start1=0, end1=5, start2=10, end2=15),
+            _make_cooc_row(evidence_score=1.0, start1=20, end1=25, start2=30, end2=35, text='s2'),
+        ]
+        df = spark.createDataFrame(data)
+        result = _compute_evidence(df)
+        row = result.collect()[0]
+        sentences = row['textMiningSentences']
+        assert len(sentences) == 2
+        s = sentences[0]
+        assert 'text' in s.asDict()
+        assert 'tStart' in s.asDict()
+        assert 'dEnd' in s.asDict()


### PR DESCRIPTION
## Summary

- Port `Epmc.scala` evidence logic from `platform-etl-backend` (without EPMCCooccurrences)
- Filters GP-DS cooccurrences, aggregates text mining sentences
- Outputs scored disease-target evidence as parquet (changed from JSON+gzip)

## Changes

- `src/pts/pyspark/evidence_epmc.py` — step implementation (133 LOC)
- `test/test_evidence_epmc.py` — 8 unit tests
- `config.yaml` — step entry

## Ref

- opentargets/issues#4374

🤖 Generated with [Claude Code](https://claude.com/claude-code)