### PR TITLE
feat: add literature_ingestion pyspark step placeholder

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1706,6 +1706,20 @@ steps:
         string_version: "12.0"
   ##################################################################################################
 
+  #: LITERATURE INGESTION STEP :####################################################################
+  literature_ingestion:
+    - name: pyspark literature_ingestion
+      pyspark: literature_ingestion
+      source: gs://otar025-epmc/ml02  # format: json
+      destination:
+        match: intermediate/literature/match
+        cooccurrence: intermediate/literature/cooccurrence
+        excluded: excluded/literature_match
+      settings:
+        target: output/target
+        disease: output/disease
+  ##################################################################################################
+
   #: RELEASE METRICS STEP :##########################################################################
   search:
     - name: pyspark search

--- a/src/pts/pyspark/literature_ingestion.py
+++ b/src/pts/pyspark/literature_ingestion.py
@@ -1,0 +1,13 @@
+"""Placeholder for the literature ingestion pipeline step."""
+
+from typing import Any
+
+
+def literature_ingestion(
+    source: str,
+    destination: dict[str, str],
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Process EPMC literature data into match and co-occurrence outputs."""
+    raise NotImplementedError


### PR DESCRIPTION
## Summary

- Adds `src/pts/pyspark/literature_ingestion.py` as a placeholder for the upcoming literature ingestion pipeline step
- The `literature_ingestion` function currently raises `NotImplementedError`
- Adds the corresponding `literature_ingestion` step to `config.yaml` with EPMC source (`gs://otar025-epmc/ml02`), three output destinations (`match`, `cooccurrence`, `excluded`), and `target`/`disease` settings

## Test plan

- [ ] Verify the step is recognised by the framework (`uv run pts -s literature_ingestion` should fail with `NotImplementedError`, not a config or import error)
- [ ] Implement the step logic and update this PR