### PR TITLE
perf(tests): improving test performance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.7"
+version = "26.06.8"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/test/test_association_otf.py
+++ b/test/test_association_otf.py
@@ -56,8 +56,13 @@ class TestComputeFacetClasses:
 
     @pytest.fixture(autouse=True)
     def _setup(self: TestComputeFacetClasses, spark: SparkSession) -> None:
-        self.df = spark.createDataFrame(self.DATASET, schema=self.TARGET_CLASS_SCHEMA)
-        self.result = _compute_facet_classes(self.df)
+        if '_cached_result' not in TestComputeFacetClasses.__dict__:
+            df = spark.createDataFrame(self.DATASET, schema=self.TARGET_CLASS_SCHEMA)
+            result = _compute_facet_classes(df)
+            result.cache()
+            result.count()  # materialize
+            TestComputeFacetClasses._cached_result = result
+        self.result = TestComputeFacetClasses._cached_result
 
     def test_target_class_column_dropped(self: TestComputeFacetClasses) -> None:
         """TargetClass column should be replaced by facetClasses."""
@@ -112,11 +117,16 @@ class TestComputeFacetTherapeuticAreas:
 
     @pytest.fixture(autouse=True)
     def _setup(self: TestComputeFacetTherapeuticAreas, spark: SparkSession) -> None:
-        self.df = spark.createDataFrame(
-            self.DATASET,
-            'diseaseId STRING, diseaseData STRING, therapeuticAreas ARRAY<STRING>, name STRING',
-        )
-        self.result = _compute_facet_therapeutic_areas(self.df, 'diseaseId', 'name', 'therapeuticAreas')
+        if '_cached_result' not in TestComputeFacetTherapeuticAreas.__dict__:
+            df = spark.createDataFrame(
+                self.DATASET,
+                'diseaseId STRING, diseaseData STRING, therapeuticAreas ARRAY<STRING>, name STRING',
+            )
+            result = _compute_facet_therapeutic_areas(df, 'diseaseId', 'name', 'therapeuticAreas')
+            result.cache()
+            result.count()  # materialize
+            TestComputeFacetTherapeuticAreas._cached_result = result
+        self.result = TestComputeFacetTherapeuticAreas._cached_result
 
     def test_output_columns(self: TestComputeFacetTherapeuticAreas) -> None:
         """Output should contain the key column and the vec column."""
@@ -177,8 +187,13 @@ class TestComputeFacetTractability:
 
     @pytest.fixture(autouse=True)
     def _setup(self: TestComputeFacetTractability, spark: SparkSession) -> None:
-        self.df = spark.createDataFrame(self.DATASET, schema=self.TRACTABILITY_SCHEMA)
-        self.result = _compute_facet_tractability(self.df)
+        if '_cached_result' not in TestComputeFacetTractability.__dict__:
+            df = spark.createDataFrame(self.DATASET, schema=self.TRACTABILITY_SCHEMA)
+            result = _compute_facet_tractability(df)
+            result.cache()
+            result.count()  # materialize
+            TestComputeFacetTractability._cached_result = result
+        self.result = TestComputeFacetTractability._cached_result
 
     def test_facet_columns_added(self: TestComputeFacetTractability) -> None:
         """All four modality facet columns should be present."""

--- a/test/test_drug_molecule.py
+++ b/test/test_drug_molecule.py
@@ -86,7 +86,7 @@ MECHANISM_SCHEMA = StructType([
 # --- Fixtures ---
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def clinical_report_df(spark):
     """A clinical report with multiple drugs, diseases, and stages."""
     data = [
@@ -140,7 +140,7 @@ def clinical_report_df(spark):
     return spark.createDataFrame(data, schema=CLINICAL_REPORT_SCHEMA)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def disease_df(spark):
     """Disease reference data."""
     data = [
@@ -151,7 +151,7 @@ def disease_df(spark):
     return spark.createDataFrame(data, schema=DISEASE_SCHEMA)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def molecule_df(spark):
     """Molecule data with various cross-references."""
     data = [
@@ -226,7 +226,7 @@ def molecule_df(spark):
     return spark.createDataFrame(data, schema=MOLECULE_SCHEMA)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def chemical_probes_df(spark):
     """Chemical probes data."""
     data = [
@@ -236,7 +236,7 @@ def chemical_probes_df(spark):
     return spark.createDataFrame(data, schema=CHEMICAL_PROBES_SCHEMA)
 
 
-@pytest.fixture
+@pytest.fixture(scope='module')
 def mechanism_df(spark):
     """Mechanism of action data."""
     data = [
@@ -465,262 +465,93 @@ class TestJoinSemantic:
         assert _join_semantic(['a', 'b', 'c']) == 'a, b and c'
 
 
+# --- Shared fixture for process_drug_index ---
+
+
+@pytest.fixture(scope='module')
+def drug_index_result(spark, molecule_df, chemical_probes_df, mechanism_df, clinical_report_df, disease_df):
+    """Pre-computed drug index result shared across all TestProcessDrugIndex tests."""
+    result = process_drug_index(molecule_df, chemical_probes_df, mechanism_df, clinical_report_df, disease_df)
+    result.cache()
+    result.count()  # materialize the cache
+    return result
+
+
 # --- Tests for process_drug_index ---
 
 
 class TestProcessDrugIndex:
     @pytest.mark.slow
-    def test_non_drug_molecules_excluded(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_non_drug_molecules_excluded(self, drug_index_result):
         """CHEMBL999 has no drugbank ref, no clinical reports, no mechanism, no probe -> excluded."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        ids = [r['id'] for r in result.collect()]
+        ids = [r['id'] for r in drug_index_result.collect()]
         assert 'CHEMBL999' not in ids
 
     @pytest.mark.slow
-    def test_drug_with_drugbank_included(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_drug_with_drugbank_included(self, drug_index_result):
         """CHEMBL1 has a drugbank cross-reference -> included."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        ids = [r['id'] for r in result.collect()]
+        ids = [r['id'] for r in drug_index_result.collect()]
         assert 'CHEMBL1' in ids
 
     @pytest.mark.slow
-    def test_drug_in_clinical_reports_included(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_drug_in_clinical_reports_included(self, drug_index_result):
         """CHEMBL2 appears in clinical reports -> included."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        ids = [r['id'] for r in result.collect()]
+        ids = [r['id'] for r in drug_index_result.collect()]
         assert 'CHEMBL2' in ids
 
     @pytest.mark.slow
-    def test_chemical_probe_included(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_chemical_probe_included(self, drug_index_result):
         """CHEMBL3 is a chemical probe -> included."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        ids = [r['id'] for r in result.collect()]
+        ids = [r['id'] for r in drug_index_result.collect()]
         assert 'CHEMBL3' in ids
 
     @pytest.mark.slow
-    def test_chemical_probe_gets_probes_drugs_xref(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_chemical_probe_gets_probes_drugs_xref(self, drug_index_result):
         """CHEMBL3 is a chemical probe -> should have probes&drugs cross-reference with probe ID."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        chembl3 = result.filter(f.col('id') == 'CHEMBL3').collect()[0]
+        chembl3 = drug_index_result.filter(f.col('id') == 'CHEMBL3').collect()[0]
         xrefs = {xref['source']: xref['ids'] for xref in chembl3['crossReferences']}
         assert 'Probes&Drugs' in xrefs
 
     @pytest.mark.slow
-    def test_non_probe_has_no_probes_drugs_xref(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_non_probe_has_no_probes_drugs_xref(self, drug_index_result):
         """CHEMBL1 is not a chemical probe -> should not have probes&drugs cross-reference."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        chembl1 = result.filter(f.col('id') == 'CHEMBL1').collect()[0]
+        chembl1 = drug_index_result.filter(f.col('id') == 'CHEMBL1').collect()[0]
         xref_sources = [xref['source'] for xref in chembl1['crossReferences']]
         assert 'probes&drugs' not in xref_sources
 
-    def test_max_phase_is_string(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_max_phase_is_string(self, drug_index_result):
         """MaximumClinicalTrialPhase should be a string, not a double."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        phase_field = result.schema['maximumClinicalStage']
+        phase_field = drug_index_result.schema['maximumClinicalStage']
         assert phase_field.dataType == StringType()
 
     @pytest.mark.slow
-    def test_drugs_without_clinical_reports_get_unknown_phase(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_drugs_without_clinical_reports_get_unknown_phase(self, drug_index_result):
         """Drugs not in clinical reports should have maximumClinicalStage='UNKNOWN'."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        null_phases = result.filter(f.col('maximumClinicalStage').isNull()).count()
+        null_phases = drug_index_result.filter(f.col('maximumClinicalStage').isNull()).count()
         assert null_phases == 0
-        # CHEMBL888 has drugbank xref but no clinical reports -> unknown
-        chembl888 = result.filter(f.col('id') == 'CHEMBL888').collect()[0]
+        chembl888 = drug_index_result.filter(f.col('id') == 'CHEMBL888').collect()[0]
         assert chembl888['maximumClinicalStage'] == 'UNKNOWN'
 
-    def test_no_blackbox_or_withdrawal_columns(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_no_blackbox_or_withdrawal_columns(self, drug_index_result):
         """Output should not contain blackBoxWarning or hasBeenWithdrawn columns."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        assert 'blackBoxWarning' not in result.columns
-        assert 'hasBeenWithdrawn' not in result.columns
+        assert 'blackBoxWarning' not in drug_index_result.columns
+        assert 'hasBeenWithdrawn' not in drug_index_result.columns
 
-    def test_no_intermediate_columns(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_no_intermediate_columns(self, drug_index_result):
         """Intermediate columns should be dropped from final output."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        assert 'chemicalProbeDrugId' not in result.columns
-        assert 'hasMechanismOfAction' not in result.columns
-        assert 'indications' not in result.columns
+        assert 'chemicalProbeDrugId' not in drug_index_result.columns
+        assert 'hasMechanismOfAction' not in drug_index_result.columns
+        assert 'indications' not in drug_index_result.columns
 
     @pytest.mark.slow
-    def test_description_is_populated(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_description_is_populated(self, drug_index_result):
         """All drugs in the output should have a non-null description."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        null_descriptions = result.filter(f.col('description').isNull()).count()
+        null_descriptions = drug_index_result.filter(f.col('description').isNull()).count()
         assert null_descriptions == 0
 
     @pytest.mark.slow
-    def test_no_duplicate_ids(
-        self,
-        spark,
-        molecule_df,
-        chemical_probes_df,
-        mechanism_df,
-        clinical_report_df,
-        disease_df,
-    ):
+    def test_no_duplicate_ids(self, drug_index_result):
         """Output should have no duplicate drug IDs."""
-        result = process_drug_index(
-            molecule_df,
-            chemical_probes_df,
-            mechanism_df,
-            clinical_report_df,
-            disease_df,
-        )
-        total = result.count()
-        distinct = result.select('id').distinct().count()
+        total = drug_index_result.count()
+        distinct = drug_index_result.select('id').distinct().count()
         assert total == distinct

--- a/uv.lock
+++ b/uv.lock
@@ -2109,7 +2109,7 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "26.6.7"
+version = "26.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "clinical-mining" },


### PR DESCRIPTION
## Context

Tests were slow. Upon investigating the test runtimes, it was apparent that 

#### TestProcessDrugIndex** — ~140s → ~25s

**Problem**: 8 test methods each called `process_drug_index(...)` independently using function-scoped fixtures. Since Spark is lazy, each call built a new query plan, and each .collect() triggered the full pipeline (multiple joins, explodes, group-bys, a Python UDF for descriptions) from scratch — 8 times on identical data.

**Fix**: Changed input fixtures to scope='module' and added a module-scoped `drug_index_result` fixture that runs `process_drug_index` once, calls `.cache()` + `.count()` to materialize the result in Spark's memory, and returns the cached DataFrame. All 11  tests in the class now share one computation.

#### TestComputeFacetClasses/TherapeuticAreas/Tractability** —  ~10s → ~2s

**Problem**: Each class used a function-scoped autouse _setup fixture that built a new Spark DataFrame and a new (lazy) query plan for every test. The actual Spark computation fired again in each test's .filter().first() or .count() call.

**Fix**: Added a class-variable cache (TestComputeFacetClasses._cached_result) inside each _setup fixture. The first test in the class computes the result and materializes it with .cache() + .count(); subsequent tests reuse the same Spark DataFrame from the in-memory cache.

## Overall

The full suite went from 251s → 103s — a 2.4× speedup (saving ~148 seconds)