### PR TITLE
build(deps): add ot-literature as a git dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,10 +19,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-# TODO: flip `branch` to "vh-restructure-datasets" once
-# https://github.com/opentargets/ot-literature/pull/7 is merged. The temporary
-# branch holds the same content plus a pyspark==3.5.7 bump so uv can resolve.
-ot-literature = { git = "https://github.com/opentargets/ot-literature", branch = "do/bump-pyspark-3.5.7" }
+ot-literature = { git = "https://github.com/opentargets/ot-literature", branch = "dev" }
 
 [dependency-groups]
 dev = ["deptry==0.23.0", "pre-commit>=4.3.0", "pytest>=8.4.1", "ruff==0.12.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,14 @@ dependencies = [
   "defusedxml>=0.7.1",
   "openpyxl>=3.1.5",
   "setuptools>=80.9.0",
+  "ot-literature",
 ]
+
+[tool.uv.sources]
+# TODO: flip `branch` to "vh-restructure-datasets" once
+# https://github.com/opentargets/ot-literature/pull/7 is merged. The temporary
+# branch holds the same content plus a pyspark==3.5.7 bump so uv can resolve.
+ot-literature = { git = "https://github.com/opentargets/ot-literature", branch = "do/bump-pyspark-3.5.7" }
 
 [dependency-groups]
 dev = ["deptry==0.23.0", "pre-commit>=4.3.0", "pytest>=8.4.1", "ruff==0.12.2"]
@@ -39,6 +46,7 @@ exclude = ["src/test/**", "src/conftest.py"]
 
 [tool.deptry.package_module_name_map]
 opentargets-otter = 'otter'
+ot-literature = 'literature'
 
 [tool.deptry.per_rule_ignores]
 DEP002 = ['openpyxl', 'coverage', 'setuptools']

--- a/uv.lock
+++ b/uv.lock
@@ -871,6 +871,18 @@ wheels = [
 ]
 
 [[package]]
+name = "ot-literature"
+version = "0.1.0"
+source = { git = "https://github.com/opentargets/ot-literature?branch=do%2Fbump-pyspark-3.5.7#ed714cad2b5e23e68b76c0bb65006a232ae09a6a" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "numpy" },
+    { name = "pyspark" },
+    { name = "pytest" },
+    { name = "spark-nlp" },
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1050,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "25.3.1.dev19"
+version = "26.0.0.dev4"
 source = { editable = "." }
 dependencies = [
     { name = "defusedxml" },
@@ -1059,6 +1071,7 @@ dependencies = [
     { name = "openai" },
     { name = "openpyxl" },
     { name = "opentargets-otter" },
+    { name = "ot-literature" },
     { name = "pandas" },
     { name = "polars" },
     { name = "pyspark" },
@@ -1088,6 +1101,7 @@ requires-dist = [
     { name = "openai", specifier = ">=2.7.2" },
     { name = "openpyxl", specifier = ">=3.1.5" },
     { name = "opentargets-otter", specifier = "==25.0.16" },
+    { name = "ot-literature", git = "https://github.com/opentargets/ot-literature?branch=do%2Fbump-pyspark-3.5.7" },
     { name = "pandas", specifier = ">=2.3.2" },
     { name = "polars", specifier = "==1.31.0" },
     { name = "pyspark", specifier = "==3.5.7" },


### PR DESCRIPTION
## Summary

The new `literature_*` pyspark steps in #113 import from the `literature` package (e.g. `from literature.dataset.match_mapped import MatchMapped`), but no such dependency is declared. Without this, the steps fail at import time with `ModuleNotFoundError`. This PR adds `ot-literature` as a git dependency, mirroring the pattern used for `clinical-mining`.

## Changes

- `pyproject.toml`:
  - Add `ot-literature` to `[project].dependencies`
  - Add `[tool.uv.sources]` block pointing at `opentargets/ot-literature`, `branch = "dev"`
  - Map the distribution name `ot-literature` to the import name `literature` for `deptry`
- `uv.lock`: a `uv lock` against `dev` is currently not possible (see below). The lockfile in this PR was generated against a temporary branch that has the same content as `dev` plus the pyspark fix; it will need to be regenerated against `dev` once the upstream blockers below are resolved.

## Blockers on ot-literature `dev`

`uv lock` against `branch = "dev"` fails today:

```
× No solution found ...
  ot-literature==0.1.0 depends on pyspark==3.3.4
  pts depends on pyspark==3.5.7
  → unsatisfiable
```

In addition, even after the pyspark conflict is resolved, runtime imports will still fail because `dev` does not yet contain `match_mapped.py` (used by `literature_cooccurrence`). Both are tracked upstream:

- pyspark conflict — [ot-literature#7](https://github.com/opentargets/ot-literature/pull/7), targeting `dev`. Merging it removes the resolver conflict.
- `match_mapped` etc. — currently only on the `vh-restructure-datasets` branch in ot-literature; needs to merge into `dev` for runtime imports to succeed.

Once both have landed on `dev`, run `uv lock` from this branch and force-push to refresh the lockfile.

## Heads-up: transitive dev deps

`ot-literature` declares `pytest` and `ipykernel` in its top-level `dependencies` (rather than under a dev/optional group), so they will end up in pts's runtime closure. Pre-existing issue in `ot-literature`; out of scope here.

## Test plan

- [ ] Once ot-literature `dev` has both fixes, `uv lock` resolves cleanly and `uv sync` succeeds.
- [ ] `uv run pts -h` succeeds.
- [ ] `uv run pts --step literature_publication` (or similar) imports without `ModuleNotFoundError`.
