### PR TITLE
fix: avoid reused-quote f-strings for Python 3.11 compatibility

### DIFF
--- a/src/pts/pyspark/literature_cooccurrence.py
+++ b/src/pts/pyspark/literature_cooccurrence.py
@@ -16,10 +16,10 @@ def literature_cooccurrence(
 ) -> None:
     spark = Session(app_name='literature', properties=properties)
 
-    logger.info(f'load matches from: {source['match']}')
+    logger.info(f'load matches from: {source["match"]}')
     match = spark.load_data(path=source['match'])
 
-    logger.info(f'write cooccurrences to {destination['cooccurrence']}')
+    logger.info(f'write cooccurrences to {destination["cooccurrence"]}')
     (
         MatchMapped(match)
         .generate_target_disease_cooccurrences()

--- a/src/pts/pyspark/literature_match.py
+++ b/src/pts/pyspark/literature_match.py
@@ -17,7 +17,7 @@ def literature_match(
 ) -> None:
     spark = Session(app_name='literature', properties=properties)
 
-    logger.info(f'load publications from: {source['publication']}')
+    logger.info(f'load publications from: {source["publication"]}')
     publication = spark.load_data(path=source['publication'])
 
     logger.info('extract matches and map labels')
@@ -61,14 +61,14 @@ def literature_match(
         )
     )
 
-    logger.info(f'write valid matches to {destination['match_valid']}')
+    logger.info(f'write valid matches to {destination["match_valid"]}')
     (
         match_valid
         .write.mode('overwrite')
         .parquet(destination['match_valid'])
     )
 
-    logger.info(f'write failed matches to {destination['match_failed']}')
+    logger.info(f'write failed matches to {destination["match_failed"]}')
     (
         match_failed
         .write.mode('overwrite')

--- a/src/pts/pyspark/literature_publication.py
+++ b/src/pts/pyspark/literature_publication.py
@@ -17,13 +17,13 @@ def literature_publication(
 ) -> None:
     spark = Session(app_name='literature', properties=properties)
 
-    logger.info(f'load data from: {source['pub_id_lut']}')
+    logger.info(f'load data from: {source["pub_id_lut"]}')
     pub_id_lut = PublicationIdLUT.from_csv(spark, source['pub_id_lut']).persist()
 
-    logger.info(f'load data from: {source['epmc_publication']}')
+    logger.info(f'load data from: {source["epmc_publication"]}')
     publication = EPMCPublication.from_source(spark, source['epmc_publication'], pub_id_lut)
 
-    logger.info(f'write processed publications to {destination['publication']}')
+    logger.info(f'write processed publications to {destination["publication"]}')
     (
         publication.df
         .write.mode('overwrite')


### PR DESCRIPTION
## Summary

The new `literature_*` pyspark steps reuse the outer quote inside f-string expressions (e.g. `f'... {source['match']}'`). That syntax is only valid from Python 3.12 onwards (PEP 701). The project supports Python 3.11 (`requires-python = ">=3.11,<3.14"`), so on 3.11 these files raise `SyntaxError` the moment they are imported.

This PR switches the inner quote style to double quotes so the same expressions parse on every supported Python version.

## Files touched

- `src/pts/pyspark/literature_cooccurrence.py` (2 lines)
- `src/pts/pyspark/literature_match.py` (3 lines)
- `src/pts/pyspark/literature_publication.py` (3 lines)

## Verification

```
$ uv run --python 3.11 python -c "import ast; [ast.parse(open(p).read()) for p in ('src/pts/pyspark/literature_cooccurrence.py', 'src/pts/pyspark/literature_match.py', 'src/pts/pyspark/literature_publication.py')]"
```

parses cleanly after the change and fails on the original.

## Test plan

- [ ] CI runs ruff/pytest on the resulting branch.
- [ ] Local `uv run pts -h` succeeds under Python 3.11.
