### PR TITLE
perf(literature_match): persist match_mapped before fan-out

### DIFF
--- a/src/pts/pyspark/literature_match.py
+++ b/src/pts/pyspark/literature_match.py
@@ -31,6 +31,8 @@ def literature_match(
             type_col_name='type'
         )
     )
+    # consumed by both the disambiguated path and the isMapped==False filter
+    match_mapped.df.persist()
 
     logger.info('disambiguate')
     match_disambiguated = (
@@ -74,3 +76,5 @@ def literature_match(
         .write.mode('overwrite')
         .parquet(destination['match_failed'])
     )
+
+    match_mapped.df.unpersist()


### PR DESCRIPTION
## Summary

`literature_match` writes two outputs (`match_valid`, `match_failed`) from a shared upstream pipeline, which fans out across three references to `match_mapped.df`:

- `match_valid` ← `match_disambiguated.df.filter(isValid)` — derives from `match_mapped`
- `match_failed` branch A ← `match_disambiguated.df.filter(~isValid)` — derives from `match_mapped`
- `match_failed` branch B ← `match_mapped.df.filter(~isMapped)` — direct

Spark does not memoise plans across actions, so `Publication.extract_matches() → map_labels()` (which joins against the OnToma label LUT) is currently recomputed three times: once per write, plus an extra pass for the `isMapped==False` branch. `disambiguate()` is recomputed twice.

This PR persists `match_mapped.df` before the fan-out and unpersists after both writes finish. With the persist in place, the upstream `load → extract_matches → map_labels` chain runs exactly once.

## Diff

```python
match_mapped = (
    Publication(publication)
    .extract_matches()
    .map_labels(...)
)
+# consumed by both the disambiguated path and the isMapped==False filter
+match_mapped.df.persist()

# ... writes ...

+match_mapped.df.unpersist()
```

## Notes

- This PR persists `match_mapped` only. `match_disambiguated.df` is also consumed twice (by `match_valid` and by the `~isValid` branch of `match_failed`), so persisting it would avoid recomputing `disambiguate()` as well. Left as a follow-up to keep this change minimal — happy to fold it in if preferred.
- Default storage level (`MEMORY_AND_DISK`) is fine for this dataset size; if the pipeline is run on a memory-constrained cluster, switch to `StorageLevel.DISK_ONLY`.

## Test plan

- [ ] Run end-to-end with a small fixture and confirm the Spark UI shows a single execution of the `extract_matches → map_labels` stage.
- [ ] Confirm row counts of `match_valid` / `match_failed` are unchanged.
