### PR TITLE
fix(literature_match): keep match_failed union disjoint

### DIFF
--- a/src/pts/pyspark/literature_match.py
+++ b/src/pts/pyspark/literature_match.py
@@ -52,11 +52,15 @@ def literature_match(
         .filter(f.col('isValid') == True)
     )
 
+    # rows that fail mapping are already emitted via the isMapped==False branch,
+    # so guard the disambiguation branch with isMapped==True to keep the union disjoint
     match_failed = (
         match_mapped.df
         .filter(f.col('isMapped') == False)
         .unionByName(
-            match_disambiguated.df.filter(f.col('isValid') == False),
+            match_disambiguated.df
+            .filter(f.col('isMapped') == True)
+            .filter(f.col('isValid') == False),
             allowMissingColumns=True
         )
     )


### PR DESCRIPTION
## Summary

`match_failed` is the union of two filters:

- `match_mapped.df.filter(isMapped == False)` — rows that never got mapped
- `match_disambiguated.df.filter(isValid == False)` — rows that mapped but failed disambiguation

The two halves are intended to be disjoint, but the code does not actually guarantee it. Whether they are disjoint depends entirely on whether `disambiguate()` drops or carries through rows with `isMapped == False`:

- If `disambiguate()` only operates on rows where `isMapped == True` and drops the rest, the halves are disjoint and we're fine.
- If `disambiguate()` carries through unmapped rows (with `isValid == False` since they cannot be valid), every unmapped row appears in **both** halves and gets double-counted in the output.

This is a contract assumption from `ot-literature` that the call site has no way to enforce. This PR adds a one-line defensive filter so the disjointness holds *regardless* of what `disambiguate()` does internally, which makes `literature_match` robust against future changes to `disambiguate()` semantics.

## Diff

```python
match_failed = (
    match_mapped.df
    .filter(f.col('isMapped') == False)
    .unionByName(
        match_disambiguated.df
+       .filter(f.col('isMapped') == True)   # disjoint guard
        .filter(f.col('isValid') == False),
        allowMissingColumns=True
    )
)
```

## Notes

- I left the existing `== True` / `== False` style on the new filter to match the surrounding code on this branch. After [#118](https://github.com/opentargets/pts/pull/118) (idiomatic boolean filters) merges, this line should be folded in (`f.col('isMapped')`). Mechanical.
- This is purely defensive — if you can confirm `disambiguate()` always strips unmapped rows, the filter is redundant and can be dropped. I'd still advocate keeping it as a documentation-by-code that the union is disjoint.

## Test plan

- [ ] On a fixture with at least one row that has `isMapped == False`, confirm `match_failed.count()` is unchanged from before the PR (i.e., no duplicates introduced) and matches `match_failed.distinct().count()`.
