### PR TITLE
perf(evidence_postprocess): persist before valid/invalid split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.9"
+version = "26.06.10"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/evidence_postprocess.py
+++ b/src/pts/pyspark/evidence_postprocess.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from loguru import logger
+from pyspark.storagelevel import StorageLevel
 
 from pts.pyspark.common.session import Session
 from pts.pyspark.common.utils import (
@@ -85,6 +86,11 @@ def evidence_postprocess(
         .hash_long_variant_identifiers()
     )
 
-    # Writing outputs:
-    processed_evidence.get_invalid_evidence().write.mode('overwrite').parquet(destination['failed_evidence'])
-    processed_evidence.get_valid_evidence().write.mode('overwrite').parquet(destination['evidence'])
+    # Writing outputs: persist before the valid/invalid split so the upstream chain
+    # (LUT joins, hashing, scoring, direction-of-effect) only runs once.
+    processed_evidence.df = processed_evidence.df.persist(StorageLevel.MEMORY_AND_DISK)
+    try:
+        processed_evidence.get_invalid_evidence().write.mode('overwrite').parquet(destination['failed_evidence'])
+        processed_evidence.get_valid_evidence().write.mode('overwrite').parquet(destination['evidence'])
+    finally:
+        processed_evidence.df.unpersist()


### PR DESCRIPTION
## Summary

`evidence_postprocess` writes two parquet outputs (`failed_evidence` and `evidence`) by filtering the same `processed_evidence` dataframe twice. Without an explicit cache, the full upstream pipeline — LUT joins (disease, target, publication), QC flag updates, evidence-ID hashing, regex-based variant hashing, score computation, direction-of-effect joins — runs **twice** per step invocation.

This change persists the dataframe (`MEMORY_AND_DISK`) before the split and unpersists after both writes, in a `try`/`finally` so the cache is released even on failure.

Identified during a repo-wide audit (finding C5).

## Benchmark

Step: `evidence_postprocess_gwas_credible_sets` against `gs://open-targets-pipeline-runs/ds/26.03-test5/intermediate/evidence/l2g_evidence/` (110 MB) plus the corresponding `target` (81 MB), `disease` (7 MB), and `literature_export` (400 MB) inputs.

Hardware: local laptop, Spark `local[*]`, 4 GB driver memory. Each run was preceded by a warm-up so the OS page cache was hot for both branches. The reported number is the otter-reported `task finished running` time (excludes uv + JVM bootstrap).

| Branch | Run 1 | Run 2 | Mean |
|---|---|---|---|
| `main` | 61.659 s | 62.816 s | **62.24 s** |
| `perf/evidence-postprocess-cache-before-split` | 45.012 s | 46.139 s | **45.58 s** |

**Δ −16.66 s per run, −27 %.** The improvement is below the naive 2× upper bound because (a) much of the wall time is the parquet write itself, which only happens once per output either way, (b) AQE softens some of the duplicated upstream work, and (c) input reads are page-cached. The remaining ~17 s recovered is exactly the per-row work in the chain (LUT joins, QC updates, hashing, scoring) that no longer happens twice.

## Test plan

- [x] `uv run ruff check src/pts/pyspark/evidence_postprocess.py` — clean
- [x] `uv run ruff format --check src/pts/pyspark/evidence_postprocess.py` — already formatted
- [x] `uv run pytest test/test_evidence_postprocess.py -q` — 24/24 pass
- [x] End-to-end `evidence_postprocess_gwas_credible_sets` run against real `26.03-test5` data — succeeds; output unchanged
- [x] Wall-clock benchmark (above)