### PR TITLE
fix(evidence_postprocess): raise ValueError instead of asserting on missing LUTs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.8"
+version = "26.06.9"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -131,7 +131,6 @@ ignore = [
   'RUF012',  # ultra-noisy and dicts in classvars are very common
   'RUF015',  # not always more readable
   'RUF067',  # we often put code inside init modules
-  'S101',    # we use asserts outside tests, and do not run python with `-O` (also see B011)
   'S311',    # false positives, it does not care about the context
   'S324',    # all our md5/sha1 usages are for non-security purposes
   'S404',    # useless, triggers on *all* subprocess imports
@@ -139,7 +138,6 @@ ignore = [
   'S405',    # we don't use lxml in unsafe ways
   'S603',    # useless, triggers on *all* subprocess calls: https://github.com/astral-sh/ruff/issues/4045
   'S607',    # we trust the PATH to be sane
-  'B011',    # we don't run python with `-O` (also see S101)
   'B904',    # possibly useful but too noisy
   'COM812',  # trailing commas on multiline lists are nice, but we have 2.5k violations
   'PIE807',  # `lambda: []` is much clearer for `load_default` in schemas
@@ -204,7 +202,7 @@ parametrize-values-type = 'list'
 parametrize-values-row-type = 'tuple'
 
 [tool.ruff.lint.per-file-ignores]
-'test/*.py' = ['S108', 'S602', 'D']
+'test/*.py' = ['S101', 'S108', 'S602', 'D']
 '**/__init__.py' = ['F401']
 '**/tasks/*.py' = ['D102']
 '**/transformers/*.py' = ['D100', 'D103']

--- a/src/pts/pyspark/evidence_postprocess.py
+++ b/src/pts/pyspark/evidence_postprocess.py
@@ -53,9 +53,12 @@ def evidence_postprocess(
 
     # Reading look up tables and make surer all looks good:
     lookup_tables = LookUpTables(session, source)
-    assert lookup_tables.disease_lut is not None, 'disease_lut not generated'
-    assert lookup_tables.target_lut is not None, 'target_lut not generated'
-    assert lookup_tables.publication_lut is not None, 'publication_lut not generated'
+    if lookup_tables.disease_lut is None:
+        raise ValueError('disease_lut not generated')
+    if lookup_tables.target_lut is None:
+        raise ValueError('target_lut not generated')
+    if lookup_tables.publication_lut is None:
+        raise ValueError('publication_lut not generated')
 
     # Processing evidence:
     processed_evidence = (


### PR DESCRIPTION
## Summary

- Replace three `assert lookup_tables.<lut> is not None` checks in `evidence_postprocess` with explicit `if ... is None: raise ValueError(...)`. `assert` is stripped under `python -O` / `PYTHONOPTIMIZE=1`, which would turn a misconfigured LUT path into a confusing `AttributeError: 'NoneType' object has no attribute ...` deep in the pipeline instead of the intended message.
- Re-enable ruff `S101` and `B011` (both were globally ignored with the rationale "we don't run python with -O"); add a `test/*.py` per-file-ignore so pytest's `assert` keeps working.

Addresses **C6** from `docs/audit-2026-04-30.md`.

## Test plan

- [x] `uv run ruff check src/ test/` passes
- [x] `uv run ruff check --select S101 .` clean across the project
- [x] `uv run ruff check --select B011 .` clean across the project
- [ ] CI green