### PR TITLE
refactor(evidence_postprocess): native SQL pvalue scoring (C7 + I4)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -930,7 +930,16 @@ steps:
       settings:
         evidence_format: json
         datasource_id: expression_atlas
-        score_expression: 'array_min(array(1.0, pvalue_linear_score(resourceScore) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)))'
+        score_expression: >-
+          array_min(array(1.0,
+            (CASE
+              WHEN resourceScore IS NULL OR isnan(resourceScore) THEN NULL
+              WHEN resourceScore <= 0 THEN 1.0
+              ELSE LEAST(1.0, GREATEST(0.0,
+                (1.0 - 0.0) * (log10(resourceScore) - log10(1.0)) / (log10(1e-10) - log10(1.0)) + 0.0
+              ))
+            END) * (abs(log2FoldChangeValue) / 10) * (log2FoldChangePercentileRank / 100)
+          ))
         unique_fields:
           - targetId
           - targetFromSourceId
@@ -1506,7 +1515,14 @@ steps:
       settings:
         evidence_format: parquet
         datasource_id: intogen
-        score_expression: pvalue_linear_score(resourceScore, 0.1, 1e-10, 0.25, 1.0)
+        score_expression: >-
+          CASE
+            WHEN resourceScore IS NULL OR isnan(resourceScore) THEN NULL
+            WHEN resourceScore <= 0 THEN 1.0
+            ELSE LEAST(1.0, GREATEST(0.25,
+              (1.0 - 0.25) * (log10(resourceScore) - log10(0.1)) / (log10(1e-10) - log10(0.1)) + 0.25
+            ))
+          END
         unique_fields:
           - targetId
           - targetFromSourceId
@@ -1548,7 +1564,14 @@ steps:
       settings:
         evidence_format: parquet
         datasource_id: gene_burden
-        score_expression: pvalue_linear_score(resourceScore, 1e-7, 1e-17, 0.25, 1.0)
+        score_expression: >-
+          CASE
+            WHEN resourceScore IS NULL OR isnan(resourceScore) THEN NULL
+            WHEN resourceScore <= 0 THEN 1.0
+            ELSE LEAST(1.0, GREATEST(0.25,
+              (1.0 - 0.25) * (log10(resourceScore) - log10(1e-7)) / (log10(1e-17) - log10(1e-7)) + 0.25
+            ))
+          END
         unique_fields:
           - targetId
           - targetFromSourceId
@@ -1580,7 +1603,14 @@ steps:
       settings:
         evidence_format: parquet
         datasource_id: crispr_screen
-        score_expression: pvalue_linear_score(resourceScore, 0.5, 0.005, 0.0, 1.0)
+        score_expression: >-
+          CASE
+            WHEN resourceScore IS NULL OR isnan(resourceScore) THEN NULL
+            WHEN resourceScore <= 0 THEN 1.0
+            ELSE LEAST(1.0, GREATEST(0.0,
+              (1.0 - 0.0) * (log10(resourceScore) - log10(0.5)) / (log10(0.005) - log10(0.5)) + 0.0
+            ))
+          END
         unique_fields:
           - targetId
           - targetFromSourceId
@@ -1729,7 +1759,14 @@ steps:
       settings:
         evidence_format: json
         datasource_id: encore
-        score_expression: pvalue_linear_score(geneticInteractionPValue, 1.0, 0.01, 0.0, 1.0)
+        score_expression: >-
+          CASE
+            WHEN geneticInteractionPValue IS NULL OR isnan(geneticInteractionPValue) THEN NULL
+            WHEN geneticInteractionPValue <= 0 THEN 1.0
+            ELSE LEAST(1.0, GREATEST(0.0,
+              (1.0 - 0.0) * (log10(geneticInteractionPValue) - log10(1.0)) / (log10(0.01) - log10(1.0)) + 0.0
+            ))
+          END
         unique_fields:
           - targetId
           - targetFromSourceId

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.19"
+version = "26.06.20"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/common/utils.py
+++ b/src/pts/pyspark/common/utils.py
@@ -3,7 +3,6 @@ import json
 from collections.abc import Callable, Iterable
 from enum import Enum
 from functools import wraps
-from math import log10
 from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import pyspark.sql.functions as f
@@ -172,54 +171,6 @@ def linear_rescaling(
 
     # clamp to [out_range_min, out_range_max]
     return min(max(score, out_range_min), out_range_max)
-
-
-def pvalue_linear_rescaling(
-    pvalue: float,
-    in_range_min: float = 1.0,
-    in_range_max: float = 1e-10,
-    out_range_min: float = 0.0,
-    out_range_max: float = 1.0,
-) -> float:
-    """Convert p-value to log10 space and apply linear_rescaling.
-
-    Args:
-        pvalue (float): p-value to rescale
-        in_range_min (float): minimum of the starting p-value range
-        in_range_max (float): maximum of the starting p-value range
-        out_range_min (float): minimum of the resulting range
-        out_range_max (float): maximum of the resulting range
-
-    Returns:
-        float: re-scaled value
-
-    Examples:
-    Examples:
-        >>> # p = 1  -> log10(1) == 0 -> maps to out_range_min (0.0)
-        >>> pvalue_linear_rescaling(1.0)
-        0.0
-
-        >>> # p = 1e-10 -> log10 == -10 -> maps to out_range_max (1.0)
-        >>> pvalue_linear_rescaling(1e-10)
-        1.0
-
-        >>> # p = 1e-5 -> log10 == -5 -> halfway between 0 and -10 -> 0.5
-        >>> pvalue_linear_rescaling(1e-5)
-        0.5
-
-        >>> # p smaller than in_range_max: maps beyond out_range_max but clamped to 1.0
-        >>> pvalue_linear_rescaling(1e-12)
-        1.0
-
-        >>> # p larger than in_range_min: would map below 0.0 but is clamped to 0.0
-        >>> pvalue_linear_rescaling(2.0)
-        0.0
-    """
-    pvalue_log = log10(pvalue)
-    in_min_log = log10(in_range_min)
-    in_max_log = log10(in_range_max)
-
-    return linear_rescaling(pvalue_log, in_min_log, in_max_log, out_range_min, out_range_max)
 
 
 def parse_spark_schema(schema_json: str) -> StructType:

--- a/src/pts/pyspark/evidence_postprocess.py
+++ b/src/pts/pyspark/evidence_postprocess.py
@@ -8,10 +8,7 @@ from loguru import logger
 from pyspark.storagelevel import StorageLevel
 
 from pts.pyspark.common.session import Session
-from pts.pyspark.common.utils import (
-    linear_rescaling,
-    pvalue_linear_rescaling,
-)
+from pts.pyspark.common.utils import linear_rescaling
 from pts.pyspark.evidence_utils.evidence import Evidence
 from pts.pyspark.evidence_utils.validation_lut import LookUpTables
 
@@ -47,7 +44,6 @@ def evidence_postprocess(
 
     # Registering UDFs in the spark session:
     session.spark.udf.register('linear_rescale', linear_rescaling)
-    session.spark.udf.register('pvalue_linear_score', pvalue_linear_rescaling)
 
     # Read input data:
     source_evidence = session.load_data(source['evidence_path'], format=evidence_format)


### PR DESCRIPTION
> **Draft** — opening for early review and discussion of the approach. The numerical-equivalence evaluation is complete (see below); this PR is otherwise ready.

## Summary

Replaces the `pvalue_linear_score` Python UDF with native Spark SQL `CASE` / `log10` / `LEAST` / `GREATEST` expressions inlined into each datasource's `score_expression` in `config.yaml`.

This addresses two audit findings simultaneously:

- **C7** — `pvalue_linear_rescaling` crashed on null / 0 / negative p-values because Python's `math.log10` raises `ValueError` / `TypeError` on those inputs. A single bad row would fail the task, exhaust task retries, and abort the entire datasource's `evidence_postprocess` job.
- **I4** — the UDF was a per-row Python callable, so every evidence row in expression_atlas / intogen / gene_burden / crispr_screens / encore (5 datasources) crossed the JVM ↔ Python boundary just to run a few arithmetic ops.

## What changed

**`src/pts/pyspark/evidence_postprocess.py`**: drop the `pvalue_linear_score` UDF registration and the `pvalue_linear_rescaling` import.

**`src/pts/pyspark/common/utils.py`**: delete the now-unused `pvalue_linear_rescaling` function and its `from math import log10`.

**`config.yaml`**: rewrite the 5 `pvalue_linear_score(...)` callsites (lines 771, 1347, 1389, 1421, 1570) as native SQL of the form:

```sql
CASE
  WHEN p IS NULL OR isnan(p) THEN NULL
  WHEN p <= 0 THEN <out_max>     -- treat 0 / negative as the maximally-significant end
  ELSE LEAST(<out_max>, GREATEST(<out_min>,
    (<out_max> - <out_min>) * (log10(p) - log10(<in_min>)) / (log10(<in_max>) - log10(<in_min>)) + <out_min>
  ))
END
```

Spark constant-folds the `log10(<literal>)` calls at planning time, so per-row cost is one `log10(p)` plus a handful of arithmetic / comparison ops — all in the JVM.

The `linear_rescale` UDF (used only by the `crispr` datasource at `config.yaml:1495`) is kept registered for now. Removing it is a straightforward follow-up but isn't on C7's critical path.

## Numerical-equivalence evaluation

Ran a 4-datasource × 3-trial-each comparison locally on `gs://open-targets-pipeline-runs/ds/26.03-test5/` data (encore not present in that snapshot, so 4 of 5 datasources). Pulled inputs + `output/target` + `output/disease` + `input/literature/literature_export` to local disk; ran `evidence_postprocess` on `main` and on this branch with identical Spark config; compared `(id, score)` outputs.

**Result: scores agree to within IEEE 754 double precision.**

| Datasource         | Rows    | Same-survivor* | Max \|Δscore\|      | Rows \|Δ\|>1e-15 |
|--------------------|---------|----------------|---------------------|--------------------|
| intogen            | 4,223   | 4,223          | 2.220e-16           | 0                  |
| crispr_screens     | 21,659  | 21,604         | 2.220e-16           | 0                  |
| expression_atlas   | 237,329 | 237,329        | 1.110e-16           | 0                  |
| gene_burden        | 40,444  | 40,356         | 3.331e-16           | 0                  |

*The naive `(id) -> score` join initially showed up to 0.75 score deltas in crispr_screens / gene_burden, but every one of those rows had a *different* `resourceScore` value between baseline and candidate — i.e., baseline's `f.rand()`-based dedup (audit finding **C3**, addressed in #125) picked a different surviving duplicate row each run. The same non-determinism reproduces *between two baseline runs* (45 rows in crispr_screens, 87 in gene_burden disagree on `resourceScore` for the same `id` between trial 1 and trial 2 of the same code on the same input), confirming the diff is C3, not C7+I4. Filtering to rows where baseline & candidate retained the same survivor gives the table above.

**Recommendation: merge #125 (C3+C4) before any production-scale comparison of this branch, otherwise dedup non-determinism will keep masking the equivalence.**

## Runtime

| Datasource         | Baseline (s, median of 3) | Candidate (s, median of 3) | Δ          |
|--------------------|---------------------------|----------------------------|------------|
| intogen            | 37.32                     | 38.39                      | +2.9%      |
| crispr_screens     | 38.41                     | 36.98                      | −3.7%      |
| expression_atlas   | 37.67                     | 36.31                      | −3.6%      |
| gene_burden        | 39.18                     | 38.36                      | −2.1%      |

Within trial-to-trial noise. Local-mode runs on these data sizes are dominated by ~30 s of Spark startup, which drowns out the per-row UDF crossover savings the I4 fix is supposed to expose. The benefit should be visible at production scale on Dataproc — but no regression observed locally, in any case.

## Tests

- `uv run pytest test/test_evidence_postprocess.py test/test_common_utils.py` — 34 passed
- `uv run pytest --doctest-modules src/pts/pyspark/common/utils.py` — 4 passed
- `uv run ruff check src/pts/pyspark/evidence_postprocess.py src/pts/pyspark/common/utils.py` — clean

## Behavioural notes for review

- **Null / NaN p-value** — previously: Python `math.log10` raises → task fails → job aborts. Now: returns `NULL` (propagates to a null score). This is a deliberate behaviour change; it makes the pipeline robust to dirty input.
- **Zero / negative p-value** — previously: same crash. Now: returns `out_max` (treats as the maximally-significant end of the range, matching the limit the original formula approaches). Defensible default; flag if you'd rather have it propagate `NULL`.
- **Encore** is not in `gs://open-targets-pipeline-runs/ds/26.03-test5/` so it wasn't part of the evaluation; will need a separate snapshot to validate end-to-end.

## Test plan

- [ ] CI green
- [ ] Confirm score equivalence on a production-size Dataproc run (after #125 lands)
- [ ] Validate `encore` once a snapshot containing it is available