### PR TITLE
feat: gene sets propagation for GO and Reactome pathway facets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1674,6 +1674,7 @@ steps:
         diseases: output/disease
         targets: output/target
         go: output/go
+        reactome: output/reactome
       destination:
         targets: view/search_facet_target
         diseases: view/search_facet_disease

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.12"
+version = "26.06.13"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/search_facet.py
+++ b/src/pts/pyspark/search_facet.py
@@ -188,6 +188,9 @@ def _compute_go_facets(target_df: DataFrame, go_df: DataFrame, categories: dict[
             f.col('g.id').alias('id'),
             f.col('g.aspect').alias('aspect'),
         )
+        .join(go_df.select('id', 'ancestors'), 'id', 'left')
+        .withColumn('all_ids', f.when(f.col('ancestors').isNull(), f.array(f.col('id'))).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
+        .select('ensemblGeneId', f.explode('all_ids').alias('id'), 'aspect')
         .join(go_df, 'id', 'left')
         .where(f.col('label').isNotNull())
         .withColumn('datasourceId', f.col('id'))
@@ -260,31 +263,34 @@ def _compute_target_class_facets(target_df: DataFrame, categories: dict[str, str
     )
 
 
-def _compute_pathway_facets(target_df: DataFrame, categories: dict[str, str]) -> DataFrame:
+def _compute_pathway_facets(target_df: DataFrame, reactome_df: DataFrame, categories: dict[str, str]) -> DataFrame:
     """Compute Reactome pathway facets.
 
-    Explodes the pathways array, using pathway name as label and pathwayId as
-    datasourceId.
+    Explodes the pathways array, expands each pathwayId to include all ancestors
+    from the reactome ETL, then joins for labels.
 
     Args:
-        target_df: DataFrame with columns id, pathways (array of structs with
-            pathwayId, pathway, topLevelTerm).
+        target_df: DataFrame with columns id, pathways (array of structs with pathwayId).
+        reactome_df: Reactome ETL DataFrame with columns id, label, ancestors.
         categories: category label mapping.
 
     Returns:
         DataFrame with columns label, category, entityIds, datasourceId.
     """
     logger.info('Computing pathway facets')
+    reactome_ref = reactome_df.select('id', 'label', 'ancestors')
     return (
         target_df
         .where(f.col('pathways').isNotNull())
         .select(f.col('id').alias('ensemblGeneId'), f.explode('pathways').alias('p'))
-        .select(
-            f.col('ensemblGeneId'),
-            f.col('p.pathway').alias('label'),
-            f.lit(categories['pathways']).alias('category'),
-            f.col('p.pathwayId').alias('datasourceId'),
-        )
+        .select(f.col('ensemblGeneId'), f.col('p.pathwayId').alias('id'))
+        .join(reactome_ref.select('id', 'ancestors'), 'id', 'left')
+        .withColumn('all_ids', f.when(f.col('ancestors').isNull(), f.array(f.col('id'))).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
+        .select('ensemblGeneId', f.explode('all_ids').alias('id'))
+        .join(reactome_ref.select('id', 'label'), 'id', 'left')
+        .where(f.col('label').isNotNull())
+        .withColumn('category', f.lit(categories['pathways']))
+        .withColumnRenamed('id', 'datasourceId')
         .groupBy('label', 'category', 'datasourceId')
         .agg(f.collect_set('ensemblGeneId').alias('entityIds'))
     )
@@ -356,6 +362,9 @@ def search_facet(
     logger.info('Loading GO data from %s', source['go'])
     go_df = spark.read.parquet(source['go'])
 
+    logger.info('Loading Reactome data from %s', source['reactome'])
+    reactome_df = spark.read.parquet(source['reactome'])
+
     # ---- disease facets ----
     disease_facets = _compute_disease_name_facets(disease_df, categories).unionByName(
         _compute_therapeutic_areas_facets(disease_df, categories)
@@ -369,7 +378,7 @@ def search_facet(
         .unionByName(_compute_go_facets(target_df, go_df, categories))
         .unionByName(_compute_subcellular_location_facets(target_df, categories))
         .unionByName(_compute_target_class_facets(target_df, categories))
-        .unionByName(_compute_pathway_facets(target_df, categories))
+        .unionByName(_compute_pathway_facets(target_df, reactome_df, categories))
         .unionByName(_compute_tractability_facets(target_df, categories))
     )
 

--- a/src/pts/pyspark/search_facet.py
+++ b/src/pts/pyspark/search_facet.py
@@ -189,7 +189,9 @@ def _compute_go_facets(target_df: DataFrame, go_df: DataFrame, categories: dict[
             f.col('g.aspect').alias('aspect'),
         )
         .join(go_df.select('id', 'ancestors'), 'id', 'left')
-        .withColumn('all_ids', f.when(f.col('ancestors').isNull(), f.array(f.col('id'))).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
+        .withColumn('all_ids', f.when(
+            f.col('ancestors').isNull(), f.array(f.col('id'))
+        ).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
         .select('ensemblGeneId', f.explode('all_ids').alias('id'), 'aspect')
         .join(go_df, 'id', 'left')
         .where(f.col('label').isNotNull())
@@ -285,7 +287,9 @@ def _compute_pathway_facets(target_df: DataFrame, reactome_df: DataFrame, catego
         .select(f.col('id').alias('ensemblGeneId'), f.explode('pathways').alias('p'))
         .select(f.col('ensemblGeneId'), f.col('p.pathwayId').alias('id'))
         .join(reactome_ref.select('id', 'ancestors'), 'id', 'left')
-        .withColumn('all_ids', f.when(f.col('ancestors').isNull(), f.array(f.col('id'))).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
+        .withColumn('all_ids', f.when(
+            f.col('ancestors').isNull(), f.array(f.col('id'))
+        ).otherwise(f.array_union(f.array(f.col('id')), f.col('ancestors'))))
         .select('ensemblGeneId', f.explode('all_ids').alias('id'))
         .join(reactome_ref.select('id', 'label'), 'id', 'left')
         .where(f.col('label').isNotNull())

--- a/src/pts/schemas/go.py
+++ b/src/pts/schemas/go.py
@@ -13,4 +13,6 @@ go_schema = {
     'negativelyRegulates': pl.List(pl.String),
     'positivelyRegulates': pl.List(pl.String),
     'isObsolete': pl.Boolean,
+    'ancestors': pl.List(pl.String),
+    'descendants': pl.List(pl.String),
 }

--- a/src/pts/transformers/go.py
+++ b/src/pts/transformers/go.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, TextIO, cast
 
+import networkx as nx
 import obonet
 import polars as pl
 from loguru import logger
@@ -9,6 +10,13 @@ from otter.config.model import Config
 from otter.storage.synchronous.handle import StorageHandle
 
 from pts.schemas.go import go_schema
+
+
+def _non_obsolete_ids(graph) -> set[str]:
+    return {
+        n for n, data in graph.nodes(data=True)
+        if n.startswith('GO:') and data.get('is_obsolete', 'false') != 'true'
+    }
 
 
 def _rows_from_obo(graph) -> list[dict]:
@@ -68,6 +76,9 @@ def _rows_from_obo(graph) -> list[dict]:
             'negativelyRegulates': negatively_regulates,
             'positivelyRegulates': positively_regulates,
             'isObsolete': is_obsolete,
+            # populated after graph traversal
+            'ancestors': [],
+            'descendants': [],
         })
     logger.info(f'parsed {len(rows)} go terms, {obsolete_count} obsolete')
     return rows
@@ -86,6 +97,14 @@ def go(
 
     logger.info('transforming obo data')
     rows = _rows_from_obo(graph)
+
+    logger.info('computing ancestors and descendants')
+    live_ids = _non_obsolete_ids(graph)
+    for row in rows:
+        node = row['id']
+        # obonet edges go child→parent, so nx.descendants = ontological ancestors
+        row['ancestors'] = sorted(nx.descendants(graph, node) & live_ids)
+        row['descendants'] = sorted(nx.ancestors(graph, node) & live_ids)
 
     logger.info('creating dataframe from parsed data')
     df = pl.DataFrame(rows, schema=go_schema)

--- a/test/test_search_facet.py
+++ b/test/test_search_facet.py
@@ -236,6 +236,7 @@ TARGET_GO_SCHEMA = StructType([
 GO_SCHEMA = StructType([
     StructField('id', StringType()),
     StructField('label', StringType()),
+    StructField('ancestors', ArrayType(StringType())),
 ])
 
 
@@ -252,9 +253,9 @@ def test_go_facet_produces_f_p_c_categories(spark):
         ),
     ]
     go_data = [
-        Row(id='GO:0003677', label='DNA binding'),
-        Row(id='GO:0008150', label='biological_process'),
-        Row(id='GO:0005634', label='nucleus'),
+        Row(id='GO:0003677', label='DNA binding', ancestors=[]),
+        Row(id='GO:0008150', label='biological_process', ancestors=[]),
+        Row(id='GO:0005634', label='nucleus', ancestors=[]),
     ]
     target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
     go_df = spark.createDataFrame(go_data, GO_SCHEMA)
@@ -269,7 +270,7 @@ def test_go_facet_produces_f_p_c_categories(spark):
 def test_go_facet_entry_structure(spark):
     """GO facet entries have label, category, entityIds, datasourceId."""
     target_data = [Row(id='ENSG00000001', go=[Row(id='GO:0003677', aspect='F')])]
-    go_data = [Row(id='GO:0003677', label='DNA binding')]
+    go_data = [Row(id='GO:0003677', label='DNA binding', ancestors=[])]
     target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
     go_df = spark.createDataFrame(go_data, GO_SCHEMA)
     result = _compute_go_facets(target_df, go_df, CATEGORIES)
@@ -404,6 +405,12 @@ PATHWAY_SCHEMA = StructType([
     ),
 ])
 
+REACTOME_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('label', StringType()),
+    StructField('ancestors', ArrayType(StringType())),
+])
+
 
 def test_pathway_facet_category(spark):
     """Pathway facet produces 'Reactome' category."""
@@ -413,8 +420,10 @@ def test_pathway_facet_category(spark):
             pathways=[Row(pathwayId='R-HSA-1', pathway='Cell Cycle', topLevelTerm='Cell Cycle')],
         ),
     ]
+    reactome_data = [Row(id='R-HSA-1', label='Cell Cycle', ancestors=[])]
     df = spark.createDataFrame(data, PATHWAY_SCHEMA)
-    result = _compute_pathway_facets(df, CATEGORIES)
+    reactome_df = spark.createDataFrame(reactome_data, REACTOME_SCHEMA)
+    result = _compute_pathway_facets(df, reactome_df, CATEGORIES)
     rows = result.collect()
     categories = {r.category for r in rows}
     assert 'Reactome' in categories
@@ -428,8 +437,10 @@ def test_pathway_facet_entry_structure(spark):
             pathways=[Row(pathwayId='R-HSA-1', pathway='Cell Cycle', topLevelTerm='Cell Cycle')],
         ),
     ]
+    reactome_data = [Row(id='R-HSA-1', label='Cell Cycle', ancestors=[])]
     df = spark.createDataFrame(data, PATHWAY_SCHEMA)
-    result = _compute_pathway_facets(df, CATEGORIES)
+    reactome_df = spark.createDataFrame(reactome_data, REACTOME_SCHEMA)
+    result = _compute_pathway_facets(df, reactome_df, CATEGORIES)
     row = result.collect()[0]
     assert hasattr(row, 'label')
     assert hasattr(row, 'category')
@@ -437,6 +448,43 @@ def test_pathway_facet_entry_structure(spark):
     assert hasattr(row, 'datasourceId')
     assert row.label == 'Cell Cycle'
     assert row.datasourceId == 'R-HSA-1'
+
+
+def test_pathway_facet_propagates_to_ancestors(spark):
+    """Target mapped to a child pathway also appears in ancestor pathway facets."""
+    data = [
+        Row(
+            id='ENSG00000001',
+            pathways=[Row(pathwayId='R-HSA-2', pathway='DNA Repair', topLevelTerm='Cell Cycle')],
+        ),
+    ]
+    reactome_data = [
+        Row(id='R-HSA-2', label='DNA Repair', ancestors=['R-HSA-1']),
+        Row(id='R-HSA-1', label='Cell Cycle', ancestors=[]),
+    ]
+    df = spark.createDataFrame(data, PATHWAY_SCHEMA)
+    reactome_df = spark.createDataFrame(reactome_data, REACTOME_SCHEMA)
+    result = _compute_pathway_facets(df, reactome_df, CATEGORIES)
+    rows = {r.datasourceId: r for r in result.collect()}
+    assert 'R-HSA-2' in rows
+    assert 'R-HSA-1' in rows
+    assert 'ENSG00000001' in rows['R-HSA-1'].entityIds
+
+
+def test_go_facet_propagates_to_ancestors(spark):
+    """Target annotated with a child GO term also appears in ancestor GO term facets."""
+    target_data = [Row(id='ENSG00000001', go=[Row(id='GO:0003677', aspect='F')])]
+    go_data = [
+        Row(id='GO:0003677', label='DNA binding', ancestors=['GO:0005488']),
+        Row(id='GO:0005488', label='binding', ancestors=[]),
+    ]
+    target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
+    go_df = spark.createDataFrame(go_data, GO_SCHEMA)
+    result = _compute_go_facets(target_df, go_df, CATEGORIES)
+    rows = {r.datasourceId: r for r in result.collect()}
+    assert 'GO:0003677' in rows
+    assert 'GO:0005488' in rows
+    assert 'ENSG00000001' in rows['GO:0005488'].entityIds
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_search_facet.py
+++ b/test/test_search_facet.py
@@ -282,6 +282,22 @@ def test_go_facet_entry_structure(spark):
     assert row.datasourceId == 'GO:0003677'
 
 
+def test_go_facet_propagates_to_ancestors(spark):
+    """Target annotated with a child GO term also appears in ancestor GO term facets."""
+    target_data = [Row(id='ENSG00000001', go=[Row(id='GO:0003677', aspect='F')])]
+    go_data = [
+        Row(id='GO:0003677', label='DNA binding', ancestors=['GO:0005488']),
+        Row(id='GO:0005488', label='binding', ancestors=[]),
+    ]
+    target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
+    go_df = spark.createDataFrame(go_data, GO_SCHEMA)
+    result = _compute_go_facets(target_df, go_df, CATEGORIES)
+    rows = {r.datasourceId: r for r in result.collect()}
+    assert 'GO:0003677' in rows
+    assert 'GO:0005488' in rows
+    assert 'ENSG00000001' in rows['GO:0005488'].entityIds
+
+
 # ---------------------------------------------------------------------------
 # 5. Subcellular location facets
 # ---------------------------------------------------------------------------
@@ -469,22 +485,6 @@ def test_pathway_facet_propagates_to_ancestors(spark):
     assert 'R-HSA-2' in rows
     assert 'R-HSA-1' in rows
     assert 'ENSG00000001' in rows['R-HSA-1'].entityIds
-
-
-def test_go_facet_propagates_to_ancestors(spark):
-    """Target annotated with a child GO term also appears in ancestor GO term facets."""
-    target_data = [Row(id='ENSG00000001', go=[Row(id='GO:0003677', aspect='F')])]
-    go_data = [
-        Row(id='GO:0003677', label='DNA binding', ancestors=['GO:0005488']),
-        Row(id='GO:0005488', label='binding', ancestors=[]),
-    ]
-    target_df = spark.createDataFrame(target_data, TARGET_GO_SCHEMA)
-    go_df = spark.createDataFrame(go_data, GO_SCHEMA)
-    result = _compute_go_facets(target_df, go_df, CATEGORIES)
-    rows = {r.datasourceId: r for r in result.collect()}
-    assert 'GO:0003677' in rows
-    assert 'GO:0005488' in rows
-    assert 'ENSG00000001' in rows['GO:0005488'].entityIds
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `ancestors` and `descendants` columns to the GO step output (`output/go/go.parquet`) via full transitive closure over the obonet graph, mirroring the existing reactome approach
- Propagates GO and Reactome pathway annotations downstream in search facets: a target annotated with a specific term now also appears in facets for all ancestor terms
- Uses `output/reactome` as the single canonical source for pathway labels and ancestors in the facet step — `p.pathway` from the target struct is intentionally not used

## Details

**GO step (`src/pts/transformers/go.py`):**
- Reuses the NetworkX graph already built by obonet (`ignore_obsolete=False`)
- `nx.descendants(graph, node)` = ontological ancestors (obonet edges go child→parent)
- `nx.ancestors(graph, node)` = ontological descendants
- Obsolete terms excluded from both lists

**Search facet step (`src/pts/pyspark/search_facet.py`):**
- `_compute_go_facets`: expands each GO annotation to include all ancestor terms before grouping
- `_compute_pathway_facets`: joins with `output/reactome` for ancestors, expands each pathway annotation to include all ancestor pathways
- `output/reactome` added as a new source in `config.yaml`

## Test plan

- [ ] Existing search facet tests updated to match new function signatures
- [ ] `test_go_facet_propagates_to_ancestors`: target annotated with child GO term appears in ancestor facet
- [ ] `test_pathway_facet_propagates_to_ancestors`: target mapped to child pathway appears in ancestor pathway facet
- [ ] Full test suite passes (338 tests)