### PR TITLE
feat: chr-prefixed variant identifiers in the search index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.14"
+version = "26.06.15"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/search.py
+++ b/src/pts/pyspark/search.py
@@ -569,9 +569,12 @@ def _build_variant_index(variants: DataFrame) -> DataFrame:
     """
     variant_df = (
         variants
-        .withColumn('locationUnderscore', f.concat(f.col('chromosome'), f.lit('_'), f.col('position'), f.lit('_')))
-        .withColumn('locationDash', f.concat(f.col('chromosome'), f.lit('-'), f.col('position'), f.lit('-')))
-        .withColumn('locationColon', f.concat(f.col('chromosome'), f.lit(':'), f.col('position'), f.lit(':')))
+        .withColumn('chrVariantId', f.concat(f.lit('chr'), f.col('variantId')))
+        .withColumn(
+            'locationUnderscore',
+            f.concat(f.col('chromosome'), f.lit('_'), f.col('position'), f.lit('_')),
+        )
+        .withColumn('chrLocationUnderscore', f.concat(f.lit('chr'), f.col('locationUnderscore')))
     )
     return _search_index(
         variant_df,
@@ -585,15 +588,17 @@ def _build_variant_index(variants: DataFrame) -> DataFrame:
             'dbXrefs.id',
             'rsIds',
             'array(locationUnderscore)',
-            'array(locationDash)',
-            'array(locationColon)',
+            'array(chrVariantId)',
+            'array(chrLocationUnderscore)',
         ),
         prefixes_col=_flatten_cat(
             'array(variantId)',
             'array(hgvsId)',
             'dbXrefs.id',
             'rsIds',
-            'array(locationColon)',
+            'array(locationUnderscore)',
+            'array(chrVariantId)',
+            'array(chrLocationUnderscore)',
         ),
         ngrams_col=_flatten_cat('array(variantId)', 'dbXrefs.id'),
         multiplier_col=f.lit(1.0),

--- a/src/pts/pyspark/search.py
+++ b/src/pts/pyspark/search.py
@@ -332,6 +332,12 @@ def _build_target_index(
     # Variant labels per target
     variant_labels_df = (
         variants
+        # gnomad dbXrefs ids (e.g. 1-14677-G-A) are the dash-delimited variantId,
+        # 100% redundant with variantId once OpenSearch normalises delimiters.
+        .withColumn(
+            'dbXrefs',
+            f.filter(f.col('dbXrefs'), lambda x: ~x.getField('source').eqNullSafe('gnomad')),
+        )
         .withColumn('transcriptConsequences', f.explode(f.col('transcriptConsequences')))
         .withColumn(
             'consequenceScore',
@@ -571,6 +577,12 @@ def _build_variant_index(variants: DataFrame) -> DataFrame:
     """
     variant_df = (
         variants
+        # gnomad dbXrefs ids (e.g. 1-14677-G-A) are the dash-delimited variantId,
+        # 100% redundant with variantId once OpenSearch normalises delimiters.
+        .withColumn(
+            'dbXrefs',
+            f.filter(f.col('dbXrefs'), lambda x: ~x.getField('source').eqNullSafe('gnomad')),
+        )
         .withColumn('chrVariantId', f.concat(f.lit('chr'), f.col('variantId')))
         .withColumn(
             'locationUnderscore',

--- a/src/pts/pyspark/search.py
+++ b/src/pts/pyspark/search.py
@@ -346,10 +346,12 @@ def _build_target_index(
             (f.col('transcriptConsequences.consequenceScore') + f.lit(1))
             * f.col('transcriptConsequences.distanceFromFootprint'),
         )
+        .withColumn('chrVariantId', f.concat(f.lit('chr'), f.col('variantId')))
         .withColumn(
             'variant_labels',
             _flatten_cat(
                 'array(variantId)',
+                'array(chrVariantId)',
                 'array(hgvsId)',
                 'dbXrefs.id',
                 'rsIds',

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -151,7 +151,10 @@ _VARIANT_SCHEMA = StructType([
     StructField('position', StringType()),
     StructField('rsIds', ArrayType(StringType())),
     StructField('hgvsId', StringType()),
-    StructField('dbXrefs', ArrayType(StructType([StructField('id', StringType())]))),
+    StructField(
+        'dbXrefs',
+        ArrayType(StructType([StructField('id', StringType()), StructField('source', StringType())])),
+    ),
     StructField(
         'transcriptConsequences',
         ArrayType(
@@ -271,6 +274,59 @@ def test_build_target_index_terms_include_chr_prefixed_variant(spark):
     assert 'chr1_100_A_G' in row.terms5
 
 
+def test_build_target_index_drops_gnomad_dbxrefs_from_variant_labels(spark):
+    """_build_target_index drops gnomad dbXrefs from variant labels but keeps other sources."""
+    targets = spark.createDataFrame(
+        [
+            Row(
+                targetId='ENSG001',
+                approvedSymbol='BRCA1',
+                approvedName='Breast cancer 1',
+                biotype='protein_coding',
+                synonyms=[],
+                proteinIds=[],
+                dbXRefs=[],
+            )
+        ],
+        _TARGET_SCHEMA,
+    )
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[
+                    Row(id='1-100-A-G', source='gnomad'),
+                    Row(id='RCV000123', source='clinvar'),
+                ],
+                transcriptConsequences=[
+                    Row(targetId='ENSG001', consequenceScore=1.0, distanceFromFootprint=1.0)
+                ],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    assocs = spark.createDataFrame(
+        [Row(associationId='EFO_001-ENSG001', targetId='ENSG001', diseaseId='EFO_001', score=0.5)],
+        _ASSOC_SCHEMA,
+    )
+    d_lut = spark.createDataFrame(
+        [Row(diseaseId='EFO_001', disease_labels=[], disease_name='Cancer', therapeutic_labels=[])],
+        _DISEASE_LUT_SCHEMA,
+    )
+    dr_lut = spark.createDataFrame([], _DRUG_LUT_SCHEMA)
+
+    result = _build_target_index(targets, assocs, d_lut, dr_lut, variants)
+    row = result.collect()[0]
+    assert '1-100-A-G' not in row.terms
+    assert '1-100-A-G' not in row.terms25
+    assert '1-100-A-G' not in row.terms5
+    assert 'RCV000123' in row.terms
+
+
 # ---------------------------------------------------------------------------
 # 4. _build_variant_index
 # ---------------------------------------------------------------------------
@@ -286,7 +342,7 @@ def test_build_variant_index_output_schema(spark):
                 position='100',
                 rsIds=['rs123'],
                 hgvsId='1:100:A:G',
-                dbXrefs=[Row(id='rs123')],
+                dbXrefs=[Row(id='rs123', source='ensembl_variation')],
                 transcriptConsequences=[],
             )
         ],
@@ -387,6 +443,37 @@ def test_build_variant_index_drops_dash_and_colon_location_forms(spark):
     assert '1:100:' not in row.keywords
     assert '1-100-' not in row.prefixes
     assert '1:100:' not in row.prefixes
+
+
+def test_build_variant_index_drops_gnomad_dbxrefs(spark):
+    """_build_variant_index drops gnomad dbXrefs but keeps other sources."""
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[
+                    Row(id='1-100-A-G', source='gnomad'),
+                    Row(id='RCV000123', source='clinvar'),
+                    Row(id='UNKNOWN999', source=None),
+                ],
+                transcriptConsequences=[],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    row = _build_variant_index(variants).collect()[0]
+    assert '1-100-A-G' not in row.keywords
+    assert '1-100-A-G' not in row.prefixes
+    assert '1-100-A-G' not in row.ngrams
+    assert 'RCV000123' in row.keywords
+    assert 'RCV000123' in row.prefixes
+    assert 'RCV000123' in row.ngrams
+    # null-source entries are kept (only gnomad is dropped)
+    assert 'UNKNOWN999' in row.keywords
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -221,6 +221,56 @@ def test_build_target_index_entity_is_target(spark):
     assert row.entity == 'target'
 
 
+def test_build_target_index_terms_include_chr_prefixed_variant(spark):
+    """_build_target_index includes both bare and chr-prefixed variant IDs in target terms."""
+    targets = spark.createDataFrame(
+        [
+            Row(
+                targetId='ENSG001',
+                approvedSymbol='BRCA1',
+                approvedName='Breast cancer 1',
+                biotype='protein_coding',
+                synonyms=[],
+                proteinIds=[],
+                dbXRefs=[],
+            )
+        ],
+        _TARGET_SCHEMA,
+    )
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[],
+                transcriptConsequences=[
+                    Row(targetId='ENSG001', consequenceScore=1.0, distanceFromFootprint=1.0)
+                ],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    assocs = spark.createDataFrame(
+        [Row(associationId='EFO_001-ENSG001', targetId='ENSG001', diseaseId='EFO_001', score=0.5)],
+        _ASSOC_SCHEMA,
+    )
+    d_lut = spark.createDataFrame(
+        [Row(diseaseId='EFO_001', disease_labels=[], disease_name='Cancer', therapeutic_labels=[])],
+        _DISEASE_LUT_SCHEMA,
+    )
+    dr_lut = spark.createDataFrame([], _DRUG_LUT_SCHEMA)
+
+    result = _build_target_index(targets, assocs, d_lut, dr_lut, variants)
+    row = result.collect()[0]
+    assert 'chr1_100_A_G' in row.terms
+    assert '1_100_A_G' in row.terms
+    assert 'chr1_100_A_G' in row.terms25
+    assert 'chr1_100_A_G' in row.terms5
+
+
 # ---------------------------------------------------------------------------
 # 4. _build_variant_index
 # ---------------------------------------------------------------------------

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -270,6 +270,75 @@ def test_build_variant_index_entity_is_variant(spark):
     assert row.entity == 'variant'
 
 
+def test_build_variant_index_keywords_include_chr_prefixed_forms(spark):
+    """_build_variant_index adds chr-prefixed variant ID and location to keywords."""
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[],
+                transcriptConsequences=[],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    row = _build_variant_index(variants).collect()[0]
+    assert '1_100_A_G' in row.keywords
+    assert 'chr1_100_A_G' in row.keywords
+    assert 'chr1_100_' in row.keywords
+    assert '1_100_' in row.keywords
+
+
+def test_build_variant_index_prefixes_include_chr_prefixed_forms(spark):
+    """_build_variant_index adds chr-prefixed variant ID and location to prefixes."""
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[],
+                transcriptConsequences=[],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    row = _build_variant_index(variants).collect()[0]
+    assert '1_100_A_G' in row.prefixes
+    assert 'chr1_100_A_G' in row.prefixes
+    assert 'chr1_100_' in row.prefixes
+    assert '1_100_' in row.prefixes
+
+
+def test_build_variant_index_drops_dash_and_colon_location_forms(spark):
+    """_build_variant_index no longer emits dash/colon variant location forms."""
+    variants = spark.createDataFrame(
+        [
+            Row(
+                variantId='1_100_A_G',
+                chromosome='1',
+                position='100',
+                rsIds=[],
+                hgvsId=None,
+                dbXrefs=[],
+                transcriptConsequences=[],
+            )
+        ],
+        _VARIANT_SCHEMA,
+    )
+    row = _build_variant_index(variants).collect()[0]
+    assert '1-100-' not in row.keywords
+    assert '1:100:' not in row.keywords
+    assert '1-100-' not in row.prefixes
+    assert '1:100:' not in row.prefixes
+
+
 # ---------------------------------------------------------------------------
 # 5. _build_drug_index
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses the data-side enhancement in opentargets/issues#3837 — let users search variants by `chr`-prefixed identifiers (e.g. `chr2_29229_A_T` as well as `2_29229_A_T`).

Changes in `src/pts/pyspark/search.py`:

- **`_build_variant_index`** (feeds `search_variant`): adds `chrVariantId` (`chr` + `variantId`) and `chrLocationUnderscore` (`chr` + `chrom_pos_`) to `keywords` and `prefixes`. Removes the per-delimiter location forms (`locationDash`, `locationColon`) — delimiter normalisation (`:`/`-`/`/` → `_`) now lives in the OpenSearch analyzer, so PTS only needs the single underscore form.
- **`_build_target_index`** (feeds `search_target`): adds the `chr`-prefixed variant ID to the variant labels that flow into the target document's `terms`/`terms25`/`terms5`.
- **Both builders**: drop the `gnomad` `dbXrefs` source — its `id` is the dash-delimited `variantId`, 100% redundant with `variantId` once OpenSearch normalises delimiters. The other four sources (`clinvar`, `protvar`, `omim`, `ensembl_variation`) are kept.

## Test Plan

- [x] `uv run pytest test/test_search.py` — 25 passed (4 new tests covering chr-prefixed forms, dropped dash/colon location forms, and gnomad dbXrefs removal)
- [x] `uv run ruff check` — clean
- [x] Scoped local run of `_build_variant_index` and `_build_target_index` against real `26.03-test5` inputs — verified `chr`-prefixed forms present, gnomad dash forms gone, non-gnomad dbXrefs retained