### PR TITLE
fix(search): demote childChemblIds from drug keywords to terms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.16"
+version = "26.06.17"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"

--- a/src/pts/pyspark/search.py
+++ b/src/pts/pyspark/search.py
@@ -551,11 +551,13 @@ def _build_drug_index(
         entity_col=f.lit('drug'),
         category_col=f.array(f.col('drugType')),
         keywords_col=_flatten_cat(
-            'synonyms', 'tradeNames', 'array(name)', 'array(drugId)', 'childChemblIds', 'crossReferences', 'nctIds'
+            'synonyms', 'tradeNames', 'array(name)', 'array(drugId)', 'crossReferences', 'nctIds'
         ),
         prefixes_col=_flatten_cat('synonyms', 'tradeNames', 'array(name)', 'descriptions'),
         ngrams_col=_flatten_cat('array(name)', 'synonyms', 'tradeNames', 'descriptions'),
-        terms_col=_flatten_cat('disease_labels', 'target_labels', 'indicationLabels', 'therapeutic_labels'),
+        terms_col=_flatten_cat(
+            'disease_labels', 'target_labels', 'indicationLabels', 'therapeutic_labels', 'childChemblIds'
+        ),
         multiplier_col=f.when(
             f.col('drug_relevance').isNotNull(),
             f.log1p(f.col('drug_relevance')) + f.lit(1.0),

--- a/test/test_search.py
+++ b/test/test_search.py
@@ -736,6 +736,38 @@ def test_build_drug_index_nct_ids_appear_in_keywords(spark):
     assert 'nct00005678' in keywords
 
 
+def test_build_drug_index_child_chembl_ids_appear_in_terms_not_keywords(spark):
+    """childChemblIds belong in terms (low-priority) not keywords (top-hit ranked)."""
+    drugs = spark.createDataFrame(
+        [
+            Row(
+                drugId='CHEMBL2010601',
+                name='Ivacaftor',
+                description=None,
+                drugType='Small molecule',
+                synonyms=[],
+                tradeNames=[],
+                childChemblIds=['CHEMBL4297603'],
+                crossReferences=[],
+                rows=[],
+                indications=[],
+            )
+        ],
+        _DRUG_SCHEMA,
+    )
+
+    result = _build_drug_index(
+        drugs,
+        spark.createDataFrame([], _ASSOC_DRUG_SCHEMA),
+        spark.createDataFrame([], _TARGET_LUT_SCHEMA),
+        spark.createDataFrame([], _DISEASE_LUT2_SCHEMA),
+        spark.createDataFrame([], _NCT_BY_DRUG_SCHEMA),
+    )
+    row = result.collect()[0]
+    assert 'CHEMBL4297603' not in row.keywords
+    assert 'CHEMBL4297603' in row.terms
+
+
 def test_build_drug_index_missing_nct_ids_yields_no_crash(spark):
     """_build_drug_index works correctly when a drug has no NCT IDs."""
     drugs = spark.createDataFrame(

--- a/uv.lock
+++ b/uv.lock
@@ -2119,7 +2119,7 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "26.6.16"
+version = "26.6.17"
 source = { editable = "." }
 dependencies = [
     { name = "clinical-mining" },


### PR DESCRIPTION
## Summary
- A search for a child molecule CHEMBL ID (e.g. `CHEMBL2010601`) was returning the parent drug as the top hit because `childChemblIds` were ranked alongside the drug's own IDs in the high-priority `keywords` array of the drug search index.
- Move `childChemblIds` from `keywords_col` to `terms_col` in `_build_drug_index` (per @jdhayhurst's suggestion), so a direct ID match outranks the parent and child molecules still contribute to recall via terms.

Closes https://github.com/opentargets/issues/issues/4163

## Test plan
- [x] `uv run pytest test/test_search.py` — 26 passed (added regression test asserting child CHEMBL IDs appear in `terms` and not `keywords`)
- [x] `uv run pytest test --doctest-modules src/pts` — 345 passed
- [x] `uv run ruff check src/pts/pyspark/search.py test/test_search.py` — clean
- [ ] After next ETL run, verify that searching a child CHEMBL ID returns the correct molecule as top hit in OpenSearch.