### PR TITLE
ci: resolve version from git tags, drop bump check

### DIFF
--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -7,55 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  check-version:
-    name: Ensure version has been bumped
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'pull_request' # Only run on PRs
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install toml package
-        run: pip install toml
-
-      - name: Check version
-        run: |
-          # Read current version from PR branch
-          CURRENT_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
-          echo "Current version: $CURRENT_VERSION"
-
-          # Checkout main branch to compare
-          git fetch origin main
-          git checkout origin/main
-
-          # Read version from main branch
-          MAIN_VERSION=$(python -c "import toml; print(toml.load('pyproject.toml')['project']['version'])")
-          echo "Main version: $MAIN_VERSION"
-
-          # Checkout back to PR branch
-          git checkout -
-
-          # Compare versions
-          if [ "$CURRENT_VERSION" = "$MAIN_VERSION" ]; then
-            echo "Error: Version has not been bumped from $MAIN_VERSION"
-            exit 1
-          fi
-
-          # Check if new version already exists as a tag
-          if git rev-parse "v$CURRENT_VERSION" >/dev/null 2>&1; then
-            echo "Error: Version v$CURRENT_VERSION already exists as a tag"
-            exit 1
-          fi
-
-          echo "Version v$CURRENT_VERSION is new and has been bumped from v$MAIN_VERSION"
-
   test:
     name: Run tests
     runs-on: ubuntu-22.04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.23"
+dynamic = ["version"]
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -62,8 +62,11 @@ test = [
 pts = "pts.core:main"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.coverage.report]
 exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]

--- a/uv.lock
+++ b/uv.lock
@@ -2715,7 +2715,6 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "26.6.21"
 source = { editable = "." }
 dependencies = [
     { name = "clinical-mining" },


### PR DESCRIPTION
## Summary

- Replace hard-coded `project.version` in `pyproject.toml` with `dynamic = ["version"]` + `hatch-vcs`, which reads the version from git tags at build time.
- Remove the `check-version` job from `.github/workflows/ci-pr.yaml`. Test and lint jobs are unchanged.
- Drop the now-stale `version = "26.6.17"` line from the `pts` entry in `uv.lock`.

## Why

Concurrent PRs were racing to claim a version number: PR-B opens with `26.06.18`, PR-A merges first with the same number, and now PR-B's check fails because `main` caught up. Every concurrent PR paid this tax in extra "bump version" commits.

After this change, contributors don't touch the version at all. The version baked into the docker image comes from the git tag that triggered the build, so they're guaranteed to match. The existing dev/release tag-triggered builds (`build-dev.yaml`, `build-release.yaml`) keep their current cadence — there's no auto-tagging, no image-per-merge.

## What stays the same

- Image build cadence: one image per intentional tag.
- Image tagging: still derived from `github.ref_name` (the `v` prefix is stripped as before).
- The dev (`v*.*.*-*`) vs release (`v*.*.*` GitHub Release) split.

## What changes for local dev

For untagged checkouts, `importlib.metadata.version("PTS")` returns a hatch-vcs dev version like `26.3.1.dev52+g54dd40537.d20260519` (last tag + commits since + sha + date) instead of a static string. Nothing in `src/pts/` reads `__version__` today, so this is informational only.

## Test plan

- [x] `uv sync --all-extras --dev` succeeds locally.
- [x] `uv sync --frozen` (used by the Dockerfile) succeeds.
- [x] `importlib.metadata.version("PTS")` returns a hatch-vcs-derived value.
- [ ] CI `test` and `lint` jobs pass.
- [ ] After merge, the next pushed tag (e.g. `v26.06.18-dev.1`) still triggers `build-dev.yaml` and produces an image tagged `26.06.18-dev.1`.