### PR TITLE
feat(dataset_metrics): config-driven dataset profiler step for the metric page

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1752,6 +1752,60 @@ steps:
         hf_data_dir: metrics
   ##################################################################################################
 
+  dataset_metrics:
+    - name: transform dataset_metrics
+      transformer: dataset_metrics
+      source: {}
+      destination:
+        directory: metrics
+      settings:
+        metric_scopes:
+          - /output/*
+        datasets:
+          study:
+            groupings:
+              studyType: "studyType"
+              datasource: "projectId"
+          credible_set:
+            groupings:
+              studyType: "studyType"
+          variant:
+            groupings:
+              consequence: "mostSevereConsequenceId"
+          colocalisation:
+            groupings:
+              studyTypePair: "concat('gwas-', rightStudyType)"
+          drug_molecule:
+            groupings:
+              clinicalStage: "maximumClinicalStage"
+          clinical_report:
+            groupings:
+              clinicalStage: "clinicalStage"
+          disease:
+            groupings:
+              therapeuticArea: "therapeuticAreas"
+          l2g_prediction:
+            filter_counts:
+              - name: prioritised_genes
+                filter: "score > 0.5"
+                distinct: geneId
+          association_by_datasource_direct:
+            groupings:
+              datasource: "aggregationValue"
+          association_by_datasource_indirect:
+            groupings:
+              datasource: "aggregationValue"
+          association_by_datatype_direct:
+            groupings:
+              datatype: "aggregationValue"
+          association_by_datatype_indirect:
+            groupings:
+              datatype: "aggregationValue"
+          evidence_*:
+            groupings:
+              datatype: "datatypeId"
+  ##################################################################################################
+
   #: LITERATURE STEP :#################################################################################
   literature:
     - name: pyspark literature_entity_lut

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "PTS"
-version = "26.06.18"
+version = "26.06.19"
 description = "Open Targets Pipeline Transformation Stage"
 readme = "README.md"
 requires-python = ">=3.11,<3.14"
@@ -20,6 +20,7 @@ dependencies = [
   "ontoma==2.3.1",
   "transformers>=4.40.0,<5.0.0",
   "gcsfs>=2026.2.0",
+  "fsspec>=2026.2.0",
   "pdfplumber>=0.11.9",
   "clinical-mining",
   "huggingface-hub>=0.32.4",

--- a/src/pts/transformers/dataset_metrics.py
+++ b/src/pts/transformers/dataset_metrics.py
@@ -3,6 +3,10 @@
 Sibling of ``release_metrics``: reuses its discovery/count helpers but emits a
 dataset-object profile (id, count, file_size, number_of_partitions, and optional
 config-driven breakdowns and filter counts).
+
+Datasets are assumed to be flat parquet directories with ``part-*.parquet`` files
+at the top level. Hive-partitioned datasets (e.g. ``key=value/part-*.parquet``)
+are not supported and would be skipped (no top-level ``part-*`` files to count).
 """
 
 from __future__ import annotations
@@ -107,7 +111,7 @@ def compute_filter_count(
         1
     """
     filtered = _as_lazy(frame).filter(pl.sql_expr(filter_expr))
-    if distinct:
+    if distinct is not None:
         return int(filtered.select(pl.col(distinct).n_unique()).collect().item())
     return int(filtered.select(pl.len()).collect().item())
 
@@ -116,8 +120,10 @@ def _dataset_file_stats(dataset_path: str) -> tuple[int, int]:
     """Return ``(total bytes, number of part files)`` for a dataset directory.
 
     Storage-agnostic via fsspec (local ``LocalFileSystem`` or ``gs://`` via
-    gcsfs). Only entries whose basename starts with ``part-`` are counted, so
-    ``_SUCCESS`` / checksum files are ignored.
+    gcsfs). Only top-level entries whose basename starts with ``part-`` are
+    counted, so ``_SUCCESS`` / checksum files are ignored. Assumes a flat
+    dataset directory; Hive-partitioned layouts (``key=value/part-*.parquet``)
+    have no top-level ``part-*`` files and would report zero partitions.
 
     Args:
         dataset_path (str): absolute path to the dataset directory.
@@ -169,7 +175,7 @@ def profile_dataset(dataset_path: str, name: str, dataset_config: dict[str, Any]
     try:
         count = _count_parquet_rows(dataset_path)
     except Exception:
-        logger.warning(f'Skipping unreadable dataset `{name}` at {dataset_path}')
+        logger.opt(exception=True).warning(f'Skipping unreadable dataset `{name}` at {dataset_path}')
         return None
 
     file_size, n_partitions = _dataset_file_stats(dataset_path)

--- a/src/pts/transformers/dataset_metrics.py
+++ b/src/pts/transformers/dataset_metrics.py
@@ -1,0 +1,264 @@
+"""Config-driven dataset profiler (one row per output dataset).
+
+Sibling of ``release_metrics``: reuses its discovery/count helpers but emits a
+dataset-object profile (id, count, file_size, number_of_partitions, and optional
+config-driven breakdowns and filter counts).
+"""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Any
+
+import fsspec
+import polars as pl
+from loguru import logger
+from otter.config.model import Config
+
+from pts.transformers.release_metrics import (
+    _count_parquet_rows,
+    _discover_dataset_paths,
+    _to_parquet_glob,
+)
+
+NULL_KEY = 'null'
+
+OUTPUT_SCHEMA: dict[str, pl.DataType] = {
+    'id': pl.String(),
+    'count': pl.Int64(),
+    'file_size': pl.Int64(),
+    'number_of_partitions': pl.Int32(),
+    'breakdowns': pl.List(
+        pl.Struct({
+            'grouping': pl.String(),
+            'groups': pl.List(pl.Struct({'value': pl.String(), 'count': pl.Int64()})),
+        })
+    ),
+    'filter_counts': pl.List(pl.Struct({'name': pl.String(), 'count': pl.Int64()})),
+}
+
+
+def _as_lazy(frame: pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
+    """Return a LazyFrame for either a DataFrame or a LazyFrame."""
+    return frame if isinstance(frame, pl.LazyFrame) else frame.lazy()
+
+
+def compute_breakdown(frame: pl.DataFrame | pl.LazyFrame, expression: str) -> dict[str, int]:
+    """Group a frame by a SQL expression and count rows per group.
+
+    The expression is evaluated with ``pl.sql_expr``. A plain column, a derived
+    expression, or a list column (auto-exploded) are all valid. Null group keys
+    are coalesced to ``"null"``. Returns ``{value: count}`` sorted by descending
+    count then key. Pass a ``scan_parquet`` LazyFrame for projection pushdown.
+
+    Args:
+        frame (pl.DataFrame | pl.LazyFrame): dataset to group.
+        expression (str): SQL expression producing the group key.
+
+    Returns:
+        dict[str, int]: count per group value.
+
+    Examples:
+        >>> import polars as pl
+        >>> df = pl.DataFrame({"studyType": ["gwas", "eqtl", "gwas", None]})
+        >>> compute_breakdown(df, "studyType")
+        {'gwas': 2, 'eqtl': 1, 'null': 1}
+        >>> df2 = pl.DataFrame({"rightStudyType": ["gwas", "eqtl", "eqtl"]})
+        >>> compute_breakdown(df2, "concat('gwas-', rightStudyType)")
+        {'gwas-eqtl': 2, 'gwas-gwas': 1}
+        >>> df3 = pl.DataFrame({"tas": [["a", "b"], ["a"]]})
+        >>> compute_breakdown(df3, "tas")
+        {'a': 2, 'b': 1}
+    """
+    selected = _as_lazy(frame).select(pl.sql_expr(expression).alias('k'))
+    if isinstance(selected.collect_schema()['k'], pl.List):
+        selected = selected.explode('k')
+    counts = (
+        selected
+        .with_columns(pl.col('k').cast(pl.String).fill_null(NULL_KEY))
+        .group_by('k')
+        .agg(pl.len().alias('count'))
+        .collect()
+    )
+    ordered = sorted(counts.iter_rows(), key=lambda kv: (-kv[1], kv[0]))
+    return {key: int(count) for key, count in ordered}
+
+
+def compute_filter_count(
+    frame: pl.DataFrame | pl.LazyFrame, filter_expr: str, distinct: str | None = None
+) -> int:
+    """Count rows (or distinct values) matching a SQL filter expression.
+
+    Args:
+        frame (pl.DataFrame | pl.LazyFrame): dataset to filter.
+        filter_expr (str): SQL boolean expression.
+        distinct (str | None): when given, count distinct values of this column.
+
+    Returns:
+        int: matching row count, or distinct count of ``distinct``.
+
+    Examples:
+        >>> import polars as pl
+        >>> df = pl.DataFrame({"score": [0.9, 0.2, 0.7], "geneId": ["g1", "g2", "g1"]})
+        >>> compute_filter_count(df, "score > 0.5")
+        2
+        >>> compute_filter_count(df, "score > 0.5", distinct="geneId")
+        1
+    """
+    filtered = _as_lazy(frame).filter(pl.sql_expr(filter_expr))
+    if distinct:
+        return int(filtered.select(pl.col(distinct).n_unique()).collect().item())
+    return int(filtered.select(pl.len()).collect().item())
+
+
+def _dataset_file_stats(dataset_path: str) -> tuple[int, int]:
+    """Return ``(total bytes, number of part files)`` for a dataset directory.
+
+    Storage-agnostic via fsspec (local ``LocalFileSystem`` or ``gs://`` via
+    gcsfs). Only entries whose basename starts with ``part-`` are counted, so
+    ``_SUCCESS`` / checksum files are ignored.
+
+    Args:
+        dataset_path (str): absolute path to the dataset directory.
+
+    Returns:
+        tuple[int, int]: total bytes and number of part files.
+    """
+    fs, root = fsspec.core.url_to_fs(dataset_path)
+    parts = [
+        entry
+        for entry in fs.ls(root, detail=True)
+        if entry['name'].rstrip('/').rsplit('/', 1)[-1].startswith('part-')
+    ]
+    file_size = sum(int(entry.get('size') or 0) for entry in parts)
+    return file_size, len(parts)
+
+
+def _breakdowns_to_struct(breakdowns: dict[str, dict[str, int]]) -> list[dict[str, Any]]:
+    """Shape ``{grouping: {value: count}}`` into the output ``list[struct]``."""
+    return [
+        {
+            'grouping': grouping,
+            'groups': [{'value': value, 'count': count} for value, count in groups.items()],
+        }
+        for grouping, groups in breakdowns.items()
+    ]
+
+
+def _filter_counts_to_struct(filter_counts: dict[str, int]) -> list[dict[str, Any]]:
+    """Shape ``{name: count}`` into the output ``list[struct]``."""
+    return [{'name': name, 'count': count} for name, count in filter_counts.items()]
+
+
+def profile_dataset(dataset_path: str, name: str, dataset_config: dict[str, Any]) -> dict[str, Any] | None:
+    """Profile one dataset into an output row, or ``None`` if unreadable.
+
+    ``count`` is read from parquet footers; ``file_size`` / partitions from
+    storage listing. Breakdowns/filters scan only their columns (lazy). A
+    dataset that cannot be read as parquet is skipped (logged), returning None.
+
+    Args:
+        dataset_path (str): absolute path to the dataset directory.
+        name (str): dataset id (basename).
+        dataset_config (dict): optional ``{groupings, filter_counts}`` overlay.
+
+    Returns:
+        dict | None: one output row, or None when the dataset cannot be read.
+    """
+    try:
+        count = _count_parquet_rows(dataset_path)
+    except Exception:
+        logger.warning(f'Skipping unreadable dataset `{name}` at {dataset_path}')
+        return None
+
+    file_size, n_partitions = _dataset_file_stats(dataset_path)
+
+    breakdowns: dict[str, dict[str, int]] = {}
+    filter_counts: dict[str, int] = {}
+    groupings = dataset_config.get('groupings', {})
+    filters = dataset_config.get('filter_counts', [])
+
+    if groupings or filters:
+        lazy_frame = pl.scan_parquet(_to_parquet_glob(dataset_path))
+        for grouping_name, expression in groupings.items():
+            breakdowns[grouping_name] = compute_breakdown(lazy_frame, expression)
+        for spec in filters:
+            filter_counts[spec['name']] = compute_filter_count(
+                lazy_frame, spec['filter'], spec.get('distinct')
+            )
+
+    return {
+        'id': name,
+        'count': count,
+        'file_size': file_size,
+        'number_of_partitions': n_partitions,
+        'breakdowns': _breakdowns_to_struct(breakdowns),
+        'filter_counts': _filter_counts_to_struct(filter_counts),
+    }
+
+
+def _config_for_dataset(name: str, datasets_config: dict[str, Any]) -> dict[str, Any]:
+    """Return the config overlay for a dataset, supporting fnmatch pattern keys.
+
+    Exact-name keys take precedence; otherwise the first matching glob pattern
+    key (sorted for determinism) applies. Returns ``{}`` when nothing matches.
+
+    Args:
+        name (str): dataset basename.
+        datasets_config (dict): the ``settings.datasets`` overlay.
+
+    Returns:
+        dict: the matched overlay, or an empty dict.
+    """
+    if name in datasets_config:
+        return datasets_config[name]
+    for pattern in sorted(datasets_config):
+        if fnmatch(name, pattern):
+            return datasets_config[pattern]
+    return {}
+
+
+def dataset_metrics(
+    source: dict[str, Path],
+    destination: dict[str, Path],
+    settings: dict[str, Any],
+    config: Config,
+) -> None:
+    """Profile every discovered dataset, writing one parquet per dataset.
+
+    Writes ``{destination['directory']}/{dataset}.parquet`` (a single-row
+    profile) for each discovered dataset.
+
+    Args:
+        source: unused.
+        destination: ``{"directory": <dir>}`` output directory (run-root
+            ``metrics/``).
+        settings: ``metric_scopes`` (default ``['/output/*']``) and a
+            ``datasets`` overlay keyed by dataset basename / fnmatch pattern
+            (``{groupings, filter_counts}``).
+        config: injected; discovery reads ``release_uri`` or ``work_path``.
+    """
+    del source
+
+    data_root_uri = config.release_uri or str(config.work_path)
+    scope_globs = list(settings.get('metric_scopes', ['/output/*']))
+    datasets_config = settings.get('datasets', {})
+
+    destination_dir = str(destination['directory']).rstrip('/')
+    destination_name = Path(destination_dir).name
+
+    discovered = _discover_dataset_paths(data_root_uri, scope_globs, config)
+
+    written = 0
+    for rel_path in sorted(discovered):
+        name = Path(rel_path).name
+        if name == destination_name:
+            continue
+        row = profile_dataset(discovered[rel_path], name, _config_for_dataset(name, datasets_config))
+        if row is None:
+            continue
+        pl.DataFrame([row], schema=OUTPUT_SCHEMA).write_parquet(f'{destination_dir}/{name}.parquet', mkdir=True)
+        written += 1
+
+    logger.info(f'Profiled {written} datasets (of {len(discovered)} discovered) under {scope_globs}')

--- a/src/pts/transformers/dataset_metrics.py
+++ b/src/pts/transformers/dataset_metrics.py
@@ -1,12 +1,18 @@
-"""Config-driven dataset profiler (one row per output dataset).
+"""Config-driven dataset profiler emitting one tidy row per measurement.
 
-Sibling of ``release_metrics``: reuses its discovery/count helpers but emits a
-dataset-object profile (id, count, file_size, number_of_partitions, and optional
-config-driven breakdowns and filter counts).
+Sibling of ``release_metrics``: reuses the shared discovery/count helpers but
+emits a long/tidy table — one row per (dataset, metric) measurement — and
+combines every discovered dataset into a single parquet for easy querying.
 
-Datasets are assumed to be flat parquet directories with ``part-*.parquet`` files
-at the top level. Hive-partitioned datasets (e.g. ``key=value/part-*.parquet``)
-are not supported and would be skipped (no top-level ``part-*`` files to count).
+Each row carries the ``run`` identifier (derived from the release/work root),
+the ``dataset`` id, the metric ``kind`` (``scalar``/``grouping``/``filter``),
+the metric name, the ``expression`` describing how it was computed (NULL for
+scalars), the ``group_value`` bucket (NULL for scalar/filter rows), and the
+integer ``value``.
+
+Datasets are assumed to be flat parquet directories with ``*.parquet`` files at
+the top level. Hive-partitioned datasets (e.g. ``key=value/part-*.parquet``)
+are not supported and would be skipped (no top-level parquet files to count).
 """
 
 from __future__ import annotations
@@ -20,26 +26,18 @@ import polars as pl
 from loguru import logger
 from otter.config.model import Config
 
-from pts.transformers.release_metrics import (
-    _count_parquet_rows,
-    _discover_dataset_paths,
-    _to_parquet_glob,
-)
+from pts.transformers.parquet_helpers import count_parquet_rows, discover_dataset_paths, to_parquet_glob
 
 NULL_KEY = 'null'
 
 OUTPUT_SCHEMA: dict[str, pl.DataType] = {
-    'id': pl.String(),
-    'count': pl.Int64(),
-    'file_size': pl.Int64(),
-    'number_of_partitions': pl.Int32(),
-    'breakdowns': pl.List(
-        pl.Struct({
-            'grouping': pl.String(),
-            'groups': pl.List(pl.Struct({'value': pl.String(), 'count': pl.Int64()})),
-        })
-    ),
-    'filter_counts': pl.List(pl.Struct({'name': pl.String(), 'count': pl.Int64()})),
+    'run': pl.String(),
+    'dataset': pl.String(),
+    'kind': pl.String(),
+    'metric': pl.String(),
+    'expression': pl.String(),
+    'group_value': pl.String(),
+    'value': pl.Int64(),
 }
 
 
@@ -48,7 +46,9 @@ def _as_lazy(frame: pl.DataFrame | pl.LazyFrame) -> pl.LazyFrame:
     return frame if isinstance(frame, pl.LazyFrame) else frame.lazy()
 
 
-def compute_breakdown(frame: pl.DataFrame | pl.LazyFrame, expression: str) -> dict[str, int]:
+def compute_breakdown(
+    frame: pl.DataFrame | pl.LazyFrame, expression: str, schema: pl.Schema | None = None
+) -> dict[str, int]:
     """Group a frame by a SQL expression and count rows per group.
 
     The expression is evaluated with ``pl.sql_expr``. A plain column, a derived
@@ -59,6 +59,9 @@ def compute_breakdown(frame: pl.DataFrame | pl.LazyFrame, expression: str) -> di
     Args:
         frame (pl.DataFrame | pl.LazyFrame): dataset to group.
         expression (str): SQL expression producing the group key.
+        schema (pl.Schema | None): the frame's schema; when given and the
+            expression is a bare column, list-detection avoids an extra metadata
+            read (useful for remote storage).
 
     Returns:
         dict[str, int]: count per group value.
@@ -76,7 +79,11 @@ def compute_breakdown(frame: pl.DataFrame | pl.LazyFrame, expression: str) -> di
         {'a': 2, 'b': 1}
     """
     selected = _as_lazy(frame).select(pl.sql_expr(expression).alias('k'))
-    if isinstance(selected.collect_schema()['k'], pl.List):
+    if schema is not None and expression in schema:
+        is_list = isinstance(schema[expression], pl.List)
+    else:
+        is_list = isinstance(selected.collect_schema()['k'], pl.List)
+    if is_list:
         selected = selected.explode('k')
     counts = (
         selected
@@ -89,9 +96,7 @@ def compute_breakdown(frame: pl.DataFrame | pl.LazyFrame, expression: str) -> di
     return {key: int(count) for key, count in ordered}
 
 
-def compute_filter_count(
-    frame: pl.DataFrame | pl.LazyFrame, filter_expr: str, distinct: str | None = None
-) -> int:
+def compute_filter_count(frame: pl.DataFrame | pl.LazyFrame, filter_expr: str, distinct: str | None = None) -> int:
     """Count rows (or distinct values) matching a SQL filter expression.
 
     Args:
@@ -143,67 +148,93 @@ def _dataset_file_stats(dataset_path: str) -> tuple[int, int]:
     return file_size, len(parts)
 
 
-def _breakdowns_to_struct(breakdowns: dict[str, dict[str, int]]) -> list[dict[str, Any]]:
-    """Shape ``{grouping: {value: count}}`` into the output ``list[struct]``."""
-    return [
-        {
-            'grouping': grouping,
-            'groups': [{'value': value, 'count': count} for value, count in groups.items()],
-        }
-        for grouping, groups in breakdowns.items()
-    ]
+def _metric_row(
+    run: str,
+    dataset: str,
+    kind: str,
+    metric: str,
+    value: int,
+    expression: str | None = None,
+    group_value: str | None = None,
+) -> dict[str, Any]:
+    """Build one tidy metric row matching ``OUTPUT_SCHEMA``."""
+    return {
+        'run': run,
+        'dataset': dataset,
+        'kind': kind,
+        'metric': metric,
+        'expression': expression,
+        'group_value': group_value,
+        'value': int(value),
+    }
 
 
-def _filter_counts_to_struct(filter_counts: dict[str, int]) -> list[dict[str, Any]]:
-    """Shape ``{name: count}`` into the output ``list[struct]``."""
-    return [{'name': name, 'count': count} for name, count in filter_counts.items()]
+def profile_dataset(
+    dataset_path: str, name: str, dataset_config: dict[str, Any], run: str
+) -> list[dict[str, Any]] | None:
+    """Profile one dataset into tidy rows, or ``None`` if it cannot be read.
 
+    Emits scalar rows (``count``, ``file_size``, ``number_of_partitions``), one
+    row per grouping bucket, and one row per filter. ``count`` is read from
+    parquet footers; ``file_size`` / partitions from a storage listing.
 
-def profile_dataset(dataset_path: str, name: str, dataset_config: dict[str, Any]) -> dict[str, Any] | None:
-    """Profile one dataset into an output row, or ``None`` if unreadable.
-
-    ``count`` is read from parquet footers; ``file_size`` / partitions from
-    storage listing. Breakdowns/filters scan only their columns (lazy). A
-    dataset that cannot be read as parquet is skipped (logged), returning None.
+    A dataset that cannot be read or listed is skipped (logged), returning None.
+    A malformed grouping/filter expression in config raises ``ValueError`` (fail
+    loud — it's an author error to fix).
 
     Args:
         dataset_path (str): absolute path to the dataset directory.
         name (str): dataset id (basename).
         dataset_config (dict): optional ``{groupings, filter_counts}`` overlay.
+        run (str): run identifier stamped on every row.
 
     Returns:
-        dict | None: one output row, or None when the dataset cannot be read.
+        list[dict] | None: tidy rows, or None when the dataset cannot be read.
     """
     try:
-        count = _count_parquet_rows(dataset_path)
+        count = count_parquet_rows(dataset_path)
+        file_size, n_partitions = _dataset_file_stats(dataset_path)
     except Exception:
         logger.opt(exception=True).warning(f'Skipping unreadable dataset `{name}` at {dataset_path}')
         return None
 
-    file_size, n_partitions = _dataset_file_stats(dataset_path)
+    rows: list[dict[str, Any]] = [
+        _metric_row(run, name, 'scalar', 'count', count),
+        _metric_row(run, name, 'scalar', 'file_size', file_size),
+        _metric_row(run, name, 'scalar', 'number_of_partitions', n_partitions),
+    ]
 
-    breakdowns: dict[str, dict[str, int]] = {}
-    filter_counts: dict[str, int] = {}
     groupings = dataset_config.get('groupings', {})
     filters = dataset_config.get('filter_counts', [])
+    if not groupings and not filters:
+        return rows
 
-    if groupings or filters:
-        lazy_frame = pl.scan_parquet(_to_parquet_glob(dataset_path))
-        for grouping_name, expression in groupings.items():
-            breakdowns[grouping_name] = compute_breakdown(lazy_frame, expression)
-        for spec in filters:
-            filter_counts[spec['name']] = compute_filter_count(
-                lazy_frame, spec['filter'], spec.get('distinct')
-            )
+    lazy_frame = pl.scan_parquet(to_parquet_glob(dataset_path))
+    schema = lazy_frame.collect_schema()
 
-    return {
-        'id': name,
-        'count': count,
-        'file_size': file_size,
-        'number_of_partitions': n_partitions,
-        'breakdowns': _breakdowns_to_struct(breakdowns),
-        'filter_counts': _filter_counts_to_struct(filter_counts),
-    }
+    for grouping_name, expression in groupings.items():
+        try:
+            counts = compute_breakdown(lazy_frame, expression, schema=schema)
+        except Exception as e:
+            msg = f"Failed to compute grouping '{grouping_name}' (expression '{expression}') for dataset '{name}'"
+            raise ValueError(msg) from e
+        rows.extend(
+            _metric_row(run, name, 'grouping', grouping_name, count, expression=expression, group_value=bucket)
+            for bucket, count in counts.items()
+        )
+
+    for spec in filters:
+        filter_expr = spec['filter']
+        distinct = spec.get('distinct')
+        try:
+            match_count = compute_filter_count(lazy_frame, filter_expr, distinct)
+        except Exception as e:
+            msg = f"Failed to compute filter '{spec['name']}' (filter '{filter_expr}') for dataset '{name}'"
+            raise ValueError(msg) from e
+        definition = f'distinct {distinct} where {filter_expr}' if distinct else filter_expr
+        rows.append(_metric_row(run, name, 'filter', spec['name'], match_count, expression=definition))
+
+    return rows
 
 
 def _config_for_dataset(name: str, datasets_config: dict[str, Any]) -> dict[str, Any]:
@@ -233,10 +264,10 @@ def dataset_metrics(
     settings: dict[str, Any],
     config: Config,
 ) -> None:
-    """Profile every discovered dataset, writing one parquet per dataset.
+    """Profile every discovered dataset into one combined tidy parquet.
 
-    Writes ``{destination['directory']}/{dataset}.parquet`` (a single-row
-    profile) for each discovered dataset.
+    Writes a single ``{destination['directory']}/dataset_metrics.parquet`` table
+    containing one row per measurement across all datasets.
 
     Args:
         source: unused.
@@ -245,28 +276,33 @@ def dataset_metrics(
         settings: ``metric_scopes`` (default ``['/output/*']``) and a
             ``datasets`` overlay keyed by dataset basename / fnmatch pattern
             (``{groupings, filter_counts}``).
-        config: injected; discovery reads ``release_uri`` or ``work_path``.
+        config: injected; discovery reads ``release_uri`` or ``work_path``, and
+            the ``run`` identifier is the last path segment of that root.
     """
     del source
 
     data_root_uri = config.release_uri or str(config.work_path)
+    run = data_root_uri.rstrip('/').rsplit('/', maxsplit=1)[-1]
     scope_globs = list(settings.get('metric_scopes', ['/output/*']))
     datasets_config = settings.get('datasets', {})
 
     destination_dir = str(destination['directory']).rstrip('/')
     destination_name = Path(destination_dir).name
 
-    discovered = _discover_dataset_paths(data_root_uri, scope_globs, config)
+    discovered = discover_dataset_paths(data_root_uri, scope_globs, config)
 
-    written = 0
+    all_rows: list[dict[str, Any]] = []
+    profiled = 0
     for rel_path in sorted(discovered):
         name = Path(rel_path).name
         if name == destination_name:
             continue
-        row = profile_dataset(discovered[rel_path], name, _config_for_dataset(name, datasets_config))
-        if row is None:
+        rows = profile_dataset(discovered[rel_path], name, _config_for_dataset(name, datasets_config), run)
+        if rows is None:
             continue
-        pl.DataFrame([row], schema=OUTPUT_SCHEMA).write_parquet(f'{destination_dir}/{name}.parquet', mkdir=True)
-        written += 1
+        all_rows.extend(rows)
+        profiled += 1
 
-    logger.info(f'Profiled {written} datasets (of {len(discovered)} discovered) under {scope_globs}')
+    out_file = f'{destination_dir}/dataset_metrics.parquet'
+    pl.DataFrame(all_rows, schema=OUTPUT_SCHEMA).write_parquet(out_file, mkdir=True)
+    logger.info(f'Profiled {profiled} datasets (of {len(discovered)} discovered) into {out_file}')

--- a/src/pts/transformers/dataset_metrics.py
+++ b/src/pts/transformers/dataset_metrics.py
@@ -102,7 +102,7 @@ def compute_filter_count(frame: pl.DataFrame | pl.LazyFrame, filter_expr: str, d
     Args:
         frame (pl.DataFrame | pl.LazyFrame): dataset to filter.
         filter_expr (str): SQL boolean expression.
-        distinct (str | None): when given, count distinct values of this column.
+        distinct (str | None): when given, count distinct non-null values of this column.
 
     Returns:
         int: matching row count, or distinct count of ``distinct``.
@@ -117,7 +117,7 @@ def compute_filter_count(frame: pl.DataFrame | pl.LazyFrame, filter_expr: str, d
     """
     filtered = _as_lazy(frame).filter(pl.sql_expr(filter_expr))
     if distinct is not None:
-        return int(filtered.select(pl.col(distinct).n_unique()).collect().item())
+        return int(filtered.select(pl.col(distinct).drop_nulls().n_unique()).collect().item())
     return int(filtered.select(pl.len()).collect().item())
 
 
@@ -138,6 +138,9 @@ def _dataset_file_stats(dataset_path: str) -> tuple[int, int]:
     Returns:
         tuple[int, int]: total bytes and number of parquet files.
     """
+    # Otter's storage backend and fsspec/gcsfs both authenticate via ambient
+    # ADC, so this bare fsspec listing uses the same credentials as discovery;
+    # it deliberately fetches counts and sizes in a single listing call.
     fs, root = fsspec.core.url_to_fs(dataset_path)
     parts = [
         entry
@@ -240,8 +243,9 @@ def profile_dataset(
 def _config_for_dataset(name: str, datasets_config: dict[str, Any]) -> dict[str, Any]:
     """Return the config overlay for a dataset, supporting fnmatch pattern keys.
 
-    Exact-name keys take precedence; otherwise the first matching glob pattern
-    key (sorted for determinism) applies. Returns ``{}`` when nothing matches.
+    Exact-name keys take precedence; otherwise the most specific matching glob
+    pattern wins (longest pattern first, then alphabetical for determinism).
+    Returns ``{}`` when nothing matches.
 
     Args:
         name (str): dataset basename.
@@ -252,7 +256,7 @@ def _config_for_dataset(name: str, datasets_config: dict[str, Any]) -> dict[str,
     """
     if name in datasets_config:
         return datasets_config[name]
-    for pattern in sorted(datasets_config):
+    for pattern in sorted(datasets_config, key=lambda p: (-len(p), p)):
         if fnmatch(name, pattern):
             return datasets_config[pattern]
     return {}

--- a/src/pts/transformers/dataset_metrics.py
+++ b/src/pts/transformers/dataset_metrics.py
@@ -117,25 +117,27 @@ def compute_filter_count(
 
 
 def _dataset_file_stats(dataset_path: str) -> tuple[int, int]:
-    """Return ``(total bytes, number of part files)`` for a dataset directory.
+    """Return ``(total bytes, number of parquet files)`` for a dataset directory.
 
     Storage-agnostic via fsspec (local ``LocalFileSystem`` or ``gs://`` via
-    gcsfs). Only top-level entries whose basename starts with ``part-`` are
-    counted, so ``_SUCCESS`` / checksum files are ignored. Assumes a flat
-    dataset directory; Hive-partitioned layouts (``key=value/part-*.parquet``)
-    have no top-level ``part-*`` files and would report zero partitions.
+    gcsfs). Counts top-level ``*.parquet`` files, covering both Spark
+    ``part-*.parquet`` outputs and single-file Polars outputs (e.g. transformer
+    datasets such as ``disease``/``clinical_report``); ``_SUCCESS`` and ``.crc``
+    markers are ignored. Assumes a flat dataset directory; Hive-partitioned
+    layouts (``key=value/part-*.parquet``) have no top-level parquet files and
+    would report zero partitions.
 
     Args:
         dataset_path (str): absolute path to the dataset directory.
 
     Returns:
-        tuple[int, int]: total bytes and number of part files.
+        tuple[int, int]: total bytes and number of parquet files.
     """
     fs, root = fsspec.core.url_to_fs(dataset_path)
     parts = [
         entry
         for entry in fs.ls(root, detail=True)
-        if entry['name'].rstrip('/').rsplit('/', 1)[-1].startswith('part-')
+        if entry.get('type') != 'directory' and entry['name'].rstrip('/').endswith('.parquet')
     ]
     file_size = sum(int(entry.get('size') or 0) for entry in parts)
     return file_size, len(parts)

--- a/src/pts/transformers/parquet_helpers.py
+++ b/src/pts/transformers/parquet_helpers.py
@@ -1,0 +1,115 @@
+"""Shared parquet discovery and counting helpers for transformer modules.
+
+Used by both ``release_metrics`` and ``dataset_metrics`` to discover datasets
+under a release/work root and to count rows from parquet footers without
+loading data.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+from otter.config.model import Config
+from otter.storage.synchronous.handle import StorageHandle
+
+
+def to_parquet_glob(path: str | Path) -> str:
+    """Normalize a dataset path to a parquet glob consumable by Polars."""
+    path_str = str(path)
+    if '.parquet' in path_str:
+        return path_str
+    return f'{path_str.rstrip("/")}/*.parquet'
+
+
+def count_parquet_rows(path: str) -> int:
+    """Count rows from a parquet dataset lazily without loading full data."""
+    return int(pl.scan_parquet(to_parquet_glob(path), glob=True).select(pl.len()).collect().item())
+
+
+def _to_release_relative_path(path: str, release_uri: str) -> str:
+    """Convert an absolute dataset path into a release-relative path key."""
+    release_root = release_uri.rstrip('/')
+    if path.startswith(release_root):
+        relative = path[len(release_root) :]
+    else:
+        relative = path
+
+    relative = relative.rstrip('/')
+    if not relative.startswith('/'):
+        relative = f'/{relative}'
+    return relative
+
+
+def _build_absolute_scope_pattern(release_uri: str, scope: str) -> str:
+    """Build an absolute storage glob pattern from release URI and scope."""
+    scope_path = scope if scope.startswith('/') else f'/{scope}'
+    return f'{release_uri.rstrip("/")}{scope_path}'
+
+
+def _scope_to_parquet_file_glob(scope: str) -> str:
+    """Convert a dataset scope into a parquet-file scope for robust discovery."""
+    normalized = scope.rstrip('/')
+    if normalized.endswith('.parquet'):
+        return normalized
+    return f'{normalized}/*.parquet'
+
+
+def _dataset_path_from_parquet_file(path: str) -> str:
+    """Return the dataset directory path for a parquet file URI/path."""
+    return path.rsplit('/', maxsplit=1)[0]
+
+
+def _has_glob_wildcards(path_pattern: str) -> bool:
+    """Return whether a path pattern contains glob wildcards."""
+    return any(char in path_pattern for char in '*?[')
+
+
+def _expand_storage_glob(path_pattern: str, config: Config) -> list[str]:
+    """Expand a storage glob pattern into concrete dataset paths.
+
+    Example:
+        path_pattern='gs://bucket/release/output/*/*.parquet'
+        -> root='gs://bucket/release/output'
+        -> glob pattern='*/*.parquet'
+        -> returns e.g.
+           [
+               'gs://bucket/release/output/disease/part-00000.parquet',
+               'gs://bucket/release/output/target/part-00000.parquet',
+           ]
+    If no wildcards are present, returns [path_pattern] unchanged.
+    """
+    wildcard_positions = [
+        idx for idx in (path_pattern.find('*'), path_pattern.find('?'), path_pattern.find('[')) if idx != -1
+    ]
+    if not wildcard_positions:
+        return [path_pattern]
+
+    first_wildcard = min(wildcard_positions)
+    slash_idx = path_pattern.rfind('/', 0, first_wildcard)
+    if slash_idx == -1:
+        msg = f'Invalid scope pattern: {path_pattern}'
+        raise ValueError(msg)
+
+    root = path_pattern[:slash_idx]
+    pattern = path_pattern[slash_idx + 1 :]
+    return sorted(StorageHandle(root, config=config).glob(pattern))
+
+
+def discover_dataset_paths(release_uri: str, scope_globs: list[str], config: Config) -> dict[str, str]:
+    """Discover datasets from configured scopes and key them by release-relative path."""
+    discovered: dict[str, str] = {}
+    for scope in scope_globs:
+        abs_pattern = _build_absolute_scope_pattern(release_uri, scope)
+        if not _has_glob_wildcards(scope):
+            for match in _expand_storage_glob(abs_pattern, config):
+                dataset_path = _dataset_path_from_parquet_file(match) if '.parquet' in match else match.rstrip('/')
+                relative = _to_release_relative_path(dataset_path, release_uri)
+                discovered[relative] = dataset_path
+
+        abs_parquet_pattern = _build_absolute_scope_pattern(release_uri, _scope_to_parquet_file_glob(scope))
+        for parquet_file in _expand_storage_glob(abs_parquet_pattern, config):
+            dataset_path = _dataset_path_from_parquet_file(parquet_file)
+            relative = _to_release_relative_path(dataset_path, release_uri)
+            discovered[relative] = dataset_path
+    return discovered

--- a/src/pts/transformers/release_metrics.py
+++ b/src/pts/transformers/release_metrics.py
@@ -12,8 +12,8 @@ import polars as pl
 from huggingface_hub import HfApi
 from loguru import logger
 from otter.config.model import Config
-from otter.storage.synchronous.handle import StorageHandle
 
+from pts.transformers.parquet_helpers import count_parquet_rows, discover_dataset_paths, to_parquet_glob
 from pts.transformers.utils import load_spark_schema_as_polars
 
 ASSOCIATION_MINIMAL_SCHEMA: dict[str, Any] = {
@@ -249,102 +249,6 @@ def _build_run_id(ot_release: str) -> str:
     return f'{run_release_normalised}-{release_timestamp}'
 
 
-def _to_parquet_glob(path: str | Path) -> str:
-    """Normalize a dataset path to a parquet glob consumable by Polars."""
-    path_str = str(path)
-    if '.parquet' in path_str:
-        return path_str
-    return f'{path_str.rstrip("/")}/*.parquet'
-
-
-def _to_release_relative_path(path: str, release_uri: str) -> str:
-    """Convert an absolute dataset path into a release-relative path key."""
-    release_root = release_uri.rstrip('/')
-    if path.startswith(release_root):
-        relative = path[len(release_root) :]
-    else:
-        relative = path
-
-    relative = relative.rstrip('/')
-    if not relative.startswith('/'):
-        relative = f'/{relative}'
-    return relative
-
-
-def _build_absolute_scope_pattern(release_uri: str, scope: str) -> str:
-    """Build an absolute storage glob pattern from release URI and scope."""
-    scope_path = scope if scope.startswith('/') else f'/{scope}'
-    return f'{release_uri.rstrip("/")}{scope_path}'
-
-
-def _scope_to_parquet_file_glob(scope: str) -> str:
-    """Convert a dataset scope into a parquet-file scope for robust discovery."""
-    normalized = scope.rstrip('/')
-    if normalized.endswith('.parquet'):
-        return normalized
-    return f'{normalized}/*.parquet'
-
-
-def _dataset_path_from_parquet_file(path: str) -> str:
-    """Return the dataset directory path for a parquet file URI/path."""
-    return path.rsplit('/', maxsplit=1)[0]
-
-
-def _has_glob_wildcards(path_pattern: str) -> bool:
-    """Return whether a path pattern contains glob wildcards."""
-    return any(char in path_pattern for char in '*?[')
-
-
-def _expand_storage_glob(path_pattern: str, config: Config) -> list[str]:
-    """Expand a storage glob pattern into concrete dataset paths.
-
-    Example:
-        path_pattern='gs://bucket/release/output/*/*.parquet'
-        -> root='gs://bucket/release/output'
-        -> glob pattern='*/*.parquet'
-        -> returns e.g.
-           [
-               'gs://bucket/release/output/disease/part-00000.parquet',
-               'gs://bucket/release/output/target/part-00000.parquet',
-           ]
-    If no wildcards are present, returns [path_pattern] unchanged.
-    """
-    wildcard_positions = [
-        idx for idx in (path_pattern.find('*'), path_pattern.find('?'), path_pattern.find('[')) if idx != -1
-    ]
-    if not wildcard_positions:
-        return [path_pattern]
-
-    first_wildcard = min(wildcard_positions)
-    slash_idx = path_pattern.rfind('/', 0, first_wildcard)
-    if slash_idx == -1:
-        msg = f'Invalid scope pattern: {path_pattern}'
-        raise ValueError(msg)
-
-    root = path_pattern[:slash_idx]
-    pattern = path_pattern[slash_idx + 1 :]
-    return sorted(StorageHandle(root, config=config).glob(pattern))
-
-
-def _discover_dataset_paths(release_uri: str, scope_globs: list[str], config: Config) -> dict[str, str]:
-    """Discover datasets from configured scopes and key them by release-relative path."""
-    discovered: dict[str, str] = {}
-    for scope in scope_globs:
-        abs_pattern = _build_absolute_scope_pattern(release_uri, scope)
-        if not _has_glob_wildcards(scope):
-            for match in _expand_storage_glob(abs_pattern, config):
-                dataset_path = _dataset_path_from_parquet_file(match) if '.parquet' in match else match.rstrip('/')
-                relative = _to_release_relative_path(dataset_path, release_uri)
-                discovered[relative] = dataset_path
-
-        abs_parquet_pattern = _build_absolute_scope_pattern(release_uri, _scope_to_parquet_file_glob(scope))
-        for parquet_file in _expand_storage_glob(abs_parquet_pattern, config):
-            dataset_path = _dataset_path_from_parquet_file(parquet_file)
-            relative = _to_release_relative_path(dataset_path, release_uri)
-            discovered[relative] = dataset_path
-    return discovered
-
-
 def _resolve_metric_lists(
     discovered_dataset_paths: dict[str, str],
     rich_dataset_whitelist: list[str],
@@ -401,12 +305,7 @@ def _read_associations_minimal(path: str) -> pl.DataFrame:
 
 def _load_parquet_dataset(path: str) -> pl.DataFrame:
     """Read a dataset parquet path (or directory) eagerly into a dataframe."""
-    return pl.read_parquet(_to_parquet_glob(path))
-
-
-def _count_parquet_rows(path: str) -> int:
-    """Count rows from a parquet dataset lazily without loading full data."""
-    return int(pl.scan_parquet(_to_parquet_glob(path), glob=True).select(pl.len()).collect().item())
+    return pl.read_parquet(to_parquet_glob(path))
 
 
 def _single_discovered_path(discovered: dict[str, str], rel_path: str) -> str | None:
@@ -557,7 +456,7 @@ def _compute_metrics(
     rich_patterns = list(settings.get('rich_dataset_whitelist', []))
     evidence_schema = load_spark_schema_as_polars('evidence.json')
 
-    discovered = _discover_dataset_paths(data_root_uri, scope_globs, config)
+    discovered = discover_dataset_paths(data_root_uri, scope_globs, config)
     rich_dataset_list, minimal_dataset_list = _resolve_metric_lists(discovered, rich_patterns)
 
     metric_frames: list[pl.DataFrame] = []
@@ -565,7 +464,7 @@ def _compute_metrics(
 
     if any(fnmatch(dataset, EVIDENCE_OUTPUT_PATTERN) for dataset in rich_dataset_list):
         evidence_paths = [
-            _to_parquet_glob(path) for rel, path in discovered.items() if fnmatch(rel, EVIDENCE_OUTPUT_PATTERN)
+            to_parquet_glob(path) for rel, path in discovered.items() if fnmatch(rel, EVIDENCE_OUTPUT_PATTERN)
         ]
         if evidence_paths:
             evidence = _read_evidence_with_canonical_schema_from_paths(evidence_paths, evidence_schema)
@@ -576,7 +475,7 @@ def _compute_metrics(
 
     if any(fnmatch(dataset, EVIDENCE_EXCLUDED_PATTERN) for dataset in rich_dataset_list):
         evidence_failed_paths = [
-            _to_parquet_glob(path) for rel, path in discovered.items() if fnmatch(rel, EVIDENCE_EXCLUDED_PATTERN)
+            to_parquet_glob(path) for rel, path in discovered.items() if fnmatch(rel, EVIDENCE_EXCLUDED_PATTERN)
         ]
         if evidence_failed_paths:
             evidence_failed = _read_evidence_with_canonical_schema_from_paths(evidence_failed_paths, evidence_schema)
@@ -596,12 +495,12 @@ def _compute_metrics(
             continue
 
         if rel_path == '/output/association_by_datasource_direct':
-            df = _read_associations_minimal(_to_parquet_glob(dataset_path))
+            df = _read_associations_minimal(to_parquet_glob(dataset_path))
             metric_frames.extend(_emit_association_metrics(df, 'Direct'))
             continue
 
         if rel_path == '/output/association_by_datasource_indirect':
-            df = _read_associations_minimal(_to_parquet_glob(dataset_path))
+            df = _read_associations_minimal(to_parquet_glob(dataset_path))
             metric_frames.extend(_emit_association_metrics(df, 'Indirect'))
             continue
 
@@ -615,7 +514,7 @@ def _compute_metrics(
             metric_frames.append(_document_count_by(datasource_view, 'datasourceId', f'{prefix}ByDatasource'))
 
     for rel_path in generic_minimal:
-        total = _count_parquet_rows(discovered[rel_path])
+        total = count_parquet_rows(discovered[rel_path])
         metric_frames.append(_document_total_value(total, f'{_metric_prefix(rel_path)}TotalCount'))
 
     logger.info(

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import polars as pl
+import pytest
 
 from pts.transformers.dataset_metrics import (
     OUTPUT_SCHEMA,
@@ -143,7 +144,7 @@ def test_profile_dataset_unreadable_returns_none(tmp_path: Path) -> None:
     assert profile_dataset(str(empty_dir), 'not_parquet', {}) is None
 
 
-def test_dataset_metrics_writes_one_parquet_per_dataset(tmp_path: Path, monkeypatch) -> None:
+def test_dataset_metrics_writes_one_parquet_per_dataset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     study = _write_dataset(tmp_path / 'study', pl.DataFrame({'studyType': ['gwas', 'eqtl', 'gwas']}))
     biosample = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
     # a discovered dataset whose basename collides with the output dir must be skipped:

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -11,6 +11,7 @@ from pts.transformers.dataset_metrics import (
     _filter_counts_to_struct,
     compute_breakdown,
     compute_filter_count,
+    profile_dataset,
 )
 
 
@@ -87,3 +88,53 @@ def test_output_schema_builds_and_roundtrips(tmp_path: Path) -> None:
     assert back.filter(pl.col('id') == 'study')['breakdowns'].to_list() == [
         [{'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 1}, {'value': 'eqtl', 'count': 1}]}]
     ]
+
+
+def _write_dataset(directory: Path, df: pl.DataFrame, n_files: int = 1) -> str:
+    directory.mkdir(parents=True, exist_ok=True)
+    rows_per = max(1, df.height // n_files)
+    for i in range(n_files):
+        chunk = df.slice(i * rows_per, rows_per if i < n_files - 1 else df.height - i * rows_per)
+        chunk.write_parquet(directory / f'part-{i}.parquet')
+    return str(directory)
+
+
+def test_profile_dataset_with_grouping_and_filter(tmp_path: Path) -> None:
+    df = pl.DataFrame({
+        'studyType': ['gwas', 'eqtl', 'gwas'],
+        'score': [0.9, 0.2, 0.7],
+        'geneId': ['g1', 'g2', 'g1'],
+    })
+    path = _write_dataset(tmp_path / 'l2g_like', df)
+    config = {
+        'groupings': {'studyType': 'studyType'},
+        'filter_counts': [{'name': 'high', 'filter': 'score > 0.5', 'distinct': 'geneId'}],
+    }
+
+    row = profile_dataset(path, 'l2g_like', config)
+
+    assert row is not None
+    assert row['id'] == 'l2g_like'
+    assert row['count'] == 3
+    assert row['number_of_partitions'] == 1
+    assert row['file_size'] > 0
+    assert row['breakdowns'] == [
+        {'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}
+    ]
+    assert row['filter_counts'] == [{'name': 'high', 'count': 1}]
+
+
+def test_profile_dataset_base_stats_only(tmp_path: Path) -> None:
+    path = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
+    row = profile_dataset(path, 'biosample', {})
+    assert row == {
+        'id': 'biosample', 'count': 2, 'file_size': row['file_size'],
+        'number_of_partitions': 1, 'breakdowns': [], 'filter_counts': [],
+    }
+
+
+def test_profile_dataset_unreadable_returns_none(tmp_path: Path) -> None:
+    empty_dir = tmp_path / 'not_parquet'
+    empty_dir.mkdir()
+    (empty_dir / 'readme.txt').write_text('not parquet')
+    assert profile_dataset(str(empty_dir), 'not_parquet', {}) is None

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -8,15 +8,28 @@ import pytest
 
 from pts.transformers.dataset_metrics import (
     OUTPUT_SCHEMA,
-    _breakdowns_to_struct,
     _config_for_dataset,
     _dataset_file_stats,
-    _filter_counts_to_struct,
     compute_breakdown,
     compute_filter_count,
     dataset_metrics,
     profile_dataset,
 )
+
+
+def _write_dataset(directory: Path, df: pl.DataFrame, n_files: int = 1) -> str:
+    directory.mkdir(parents=True, exist_ok=True)
+    rows_per = max(1, df.height // n_files)
+    for i in range(n_files):
+        chunk = df.slice(i * rows_per, rows_per if i < n_files - 1 else df.height - i * rows_per)
+        chunk.write_parquet(directory / f'part-{i}.parquet')
+    return str(directory)
+
+
+def _row(rows: list[dict], kind: str, metric: str, group_value: str | None = None) -> dict:
+    matches = [r for r in rows if r['kind'] == kind and r['metric'] == metric and r['group_value'] == group_value]
+    assert len(matches) == 1, f'expected one {kind}/{metric}/{group_value} row, got {matches}'
+    return matches[0]
 
 
 def test_compute_breakdown_plain_column_with_null() -> None:
@@ -59,52 +72,21 @@ def test_dataset_file_stats(tmp_path: Path) -> None:
     assert file_size > 0
 
 
-def test_breakdowns_to_struct() -> None:
-    out = _breakdowns_to_struct({'studyType': {'gwas': 2, 'eqtl': 1}})
-    assert out == [
-        {'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}
-    ]
-
-
-def test_filter_counts_to_struct() -> None:
-    assert _filter_counts_to_struct({'prioritised_genes': 18422}) == [
-        {'name': 'prioritised_genes', 'count': 18422}
-    ]
-
-
-def test_output_schema_builds_and_roundtrips(tmp_path: Path) -> None:
+def test_output_schema_roundtrips(tmp_path: Path) -> None:
     rows = [
-        {
-            'id': 'study', 'count': 2, 'file_size': 10, 'number_of_partitions': 1,
-            'breakdowns': _breakdowns_to_struct({'studyType': {'gwas': 1, 'eqtl': 1}}),
-            'filter_counts': [],
-        },
-        {
-            'id': 'biosample', 'count': 5, 'file_size': 7, 'number_of_partitions': 1,
-            'breakdowns': [], 'filter_counts': [],
-        },
+        {'run': 'r1', 'dataset': 'study', 'kind': 'scalar', 'metric': 'count',
+         'expression': None, 'group_value': None, 'value': 3},
+        {'run': 'r1', 'dataset': 'study', 'kind': 'grouping', 'metric': 'studyType',
+         'expression': 'studyType', 'group_value': 'gwas', 'value': 2},
     ]
-    out = tmp_path / 'metrics'
-    pl.DataFrame(rows, schema=OUTPUT_SCHEMA).write_parquet(out, mkdir=True)
+    out = tmp_path / 'dataset_metrics.parquet'
+    pl.DataFrame(rows, schema=OUTPUT_SCHEMA).write_parquet(out)
     back = pl.read_parquet(out)
-
-    assert back.height == 2
     assert back.schema == pl.Schema(OUTPUT_SCHEMA)
-    assert back.filter(pl.col('id') == 'study')['breakdowns'].to_list() == [
-        [{'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 1}, {'value': 'eqtl', 'count': 1}]}]
-    ]
+    assert back.height == 2
 
 
-def _write_dataset(directory: Path, df: pl.DataFrame, n_files: int = 1) -> str:
-    directory.mkdir(parents=True, exist_ok=True)
-    rows_per = max(1, df.height // n_files)
-    for i in range(n_files):
-        chunk = df.slice(i * rows_per, rows_per if i < n_files - 1 else df.height - i * rows_per)
-        chunk.write_parquet(directory / f'part-{i}.parquet')
-    return str(directory)
-
-
-def test_profile_dataset_with_grouping_and_filter(tmp_path: Path) -> None:
+def test_profile_dataset_emits_long_rows(tmp_path: Path) -> None:
     df = pl.DataFrame({
         'studyType': ['gwas', 'eqtl', 'gwas'],
         'score': [0.9, 0.2, 0.7],
@@ -116,36 +98,62 @@ def test_profile_dataset_with_grouping_and_filter(tmp_path: Path) -> None:
         'filter_counts': [{'name': 'high', 'filter': 'score > 0.5', 'distinct': 'geneId'}],
     }
 
-    row = profile_dataset(path, 'l2g_like', config)
+    rows = profile_dataset(path, 'l2g_like', config, run='26.03-test5')
 
-    assert row is not None
-    assert row['id'] == 'l2g_like'
-    assert row['count'] == 3
-    assert row['number_of_partitions'] == 1
-    assert row['file_size'] > 0
-    assert row['breakdowns'] == [
-        {'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}
-    ]
-    assert row['filter_counts'] == [{'name': 'high', 'count': 1}]
+    assert rows is not None
+    assert all(r['run'] == '26.03-test5' and r['dataset'] == 'l2g_like' for r in rows)
+
+    count_row = _row(rows, 'scalar', 'count')
+    assert count_row['value'] == 3
+    assert count_row['expression'] is None
+    assert _row(rows, 'scalar', 'number_of_partitions')['value'] == 1
+    assert _row(rows, 'scalar', 'file_size')['value'] > 0
+
+    gwas = _row(rows, 'grouping', 'studyType', 'gwas')
+    assert gwas['value'] == 2
+    assert gwas['expression'] == 'studyType'
+    assert _row(rows, 'grouping', 'studyType', 'eqtl')['value'] == 1
+
+    high = _row(rows, 'filter', 'high')
+    assert high['value'] == 1
+    assert high['expression'] == 'distinct geneId where score > 0.5'
+    assert high['group_value'] is None
 
 
 def test_profile_dataset_base_stats_only(tmp_path: Path) -> None:
     path = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
-    row = profile_dataset(path, 'biosample', {})
-    assert row == {
-        'id': 'biosample', 'count': 2, 'file_size': row['file_size'],
-        'number_of_partitions': 1, 'breakdowns': [], 'filter_counts': [],
-    }
+    rows = profile_dataset(path, 'biosample', {}, run='r1')
+    assert sorted((r['kind'], r['metric']) for r in rows) == [
+        ('scalar', 'count'), ('scalar', 'file_size'), ('scalar', 'number_of_partitions')
+    ]
+    assert _row(rows, 'scalar', 'count')['value'] == 2
 
 
 def test_profile_dataset_unreadable_returns_none(tmp_path: Path) -> None:
     empty_dir = tmp_path / 'not_parquet'
     empty_dir.mkdir()
     (empty_dir / 'readme.txt').write_text('not parquet')
-    assert profile_dataset(str(empty_dir), 'not_parquet', {}) is None
+    assert profile_dataset(str(empty_dir), 'not_parquet', {}, run='r1') is None
 
 
-def test_dataset_metrics_writes_one_parquet_per_dataset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_profile_dataset_bad_expression_fails_loud(tmp_path: Path) -> None:
+    path = _write_dataset(tmp_path / 'study', pl.DataFrame({'studyType': ['gwas']}))
+    config = {'groupings': {'oops': 'nonexistent_column'}}
+    with pytest.raises(ValueError, match='oops'):
+        profile_dataset(path, 'study', config, run='r1')
+
+
+def test_profile_dataset_listing_failure_skips(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_dataset(tmp_path / 'study', pl.DataFrame({'studyType': ['gwas']}))
+
+    def boom(_path: str) -> tuple[int, int]:
+        raise OSError('listing failed')
+
+    monkeypatch.setattr('pts.transformers.dataset_metrics._dataset_file_stats', boom)
+    assert profile_dataset(path, 'study', {}, run='r1') is None
+
+
+def test_dataset_metrics_writes_combined_table(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     study = _write_dataset(tmp_path / 'study', pl.DataFrame({'studyType': ['gwas', 'eqtl', 'gwas']}))
     biosample = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
     # a discovered dataset whose basename collides with the output dir must be skipped:
@@ -155,27 +163,34 @@ def test_dataset_metrics_writes_one_parquet_per_dataset(tmp_path: Path, monkeypa
         '/output/metrics': str(tmp_path / 'ignored'),
     }
     monkeypatch.setattr(
-        'pts.transformers.dataset_metrics._discover_dataset_paths',
+        'pts.transformers.dataset_metrics.discover_dataset_paths',
         lambda root, scopes, config: discovered,
     )
 
     out_dir = tmp_path / 'metrics'
-    config = SimpleNamespace(release_uri=str(tmp_path), work_path=tmp_path)
+    config = SimpleNamespace(release_uri='gs://bucket/26.03-test5', work_path=tmp_path)
     settings = {'datasets': {'study': {'groupings': {'studyType': 'studyType'}}}}
 
     dataset_metrics({}, {'directory': str(out_dir)}, settings, config)
 
+    # only the single combined table is written (no per-dataset files):
     files = sorted(p.name for p in out_dir.glob('*.parquet'))
-    assert files == ['biosample.parquet', 'study.parquet']  # 'metrics' skipped
+    assert files == ['dataset_metrics.parquet']
 
-    study_df = pl.read_parquet(out_dir / 'study.parquet')
-    assert study_df.height == 1
-    assert study_df['id'].item() == 'study'
-    assert study_df['count'].item() == 3
-    assert study_df['breakdowns'].to_list() == [
-        [{'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}]
-    ]
-    assert pl.read_parquet(out_dir / 'biosample.parquet')['breakdowns'].to_list() == [[]]
+    df = pl.read_parquet(out_dir / 'dataset_metrics.parquet')
+    assert df.schema == pl.Schema(OUTPUT_SCHEMA)
+    assert df['run'].unique().to_list() == ['26.03-test5']  # derived from release_uri basename
+    assert set(df['dataset'].unique().to_list()) == {'study', 'biosample'}  # 'metrics' skipped
+
+    study_count = df.filter(
+        (pl.col('dataset') == 'study') & (pl.col('kind') == 'scalar') & (pl.col('metric') == 'count')
+    )
+    assert study_count['value'].item() == 3
+    gwas = df.filter(
+        (pl.col('dataset') == 'study') & (pl.col('kind') == 'grouping')
+        & (pl.col('metric') == 'studyType') & (pl.col('group_value') == 'gwas')
+    )
+    assert gwas['value'].item() == 2
 
 
 def test_config_for_dataset_pattern_match() -> None:

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -74,10 +74,24 @@ def test_dataset_file_stats(tmp_path: Path) -> None:
 
 def test_output_schema_roundtrips(tmp_path: Path) -> None:
     rows = [
-        {'run': 'r1', 'dataset': 'study', 'kind': 'scalar', 'metric': 'count',
-         'expression': None, 'group_value': None, 'value': 3},
-        {'run': 'r1', 'dataset': 'study', 'kind': 'grouping', 'metric': 'studyType',
-         'expression': 'studyType', 'group_value': 'gwas', 'value': 2},
+        {
+            'run': 'r1',
+            'dataset': 'study',
+            'kind': 'scalar',
+            'metric': 'count',
+            'expression': None,
+            'group_value': None,
+            'value': 3,
+        },
+        {
+            'run': 'r1',
+            'dataset': 'study',
+            'kind': 'grouping',
+            'metric': 'studyType',
+            'expression': 'studyType',
+            'group_value': 'gwas',
+            'value': 2,
+        },
     ]
     out = tmp_path / 'dataset_metrics.parquet'
     pl.DataFrame(rows, schema=OUTPUT_SCHEMA).write_parquet(out)
@@ -124,7 +138,9 @@ def test_profile_dataset_base_stats_only(tmp_path: Path) -> None:
     path = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
     rows = profile_dataset(path, 'biosample', {}, run='r1')
     assert sorted((r['kind'], r['metric']) for r in rows) == [
-        ('scalar', 'count'), ('scalar', 'file_size'), ('scalar', 'number_of_partitions')
+        ('scalar', 'count'),
+        ('scalar', 'file_size'),
+        ('scalar', 'number_of_partitions'),
     ]
     assert _row(rows, 'scalar', 'count')['value'] == 2
 
@@ -187,8 +203,10 @@ def test_dataset_metrics_writes_combined_table(tmp_path: Path, monkeypatch: pyte
     )
     assert study_count['value'].item() == 3
     gwas = df.filter(
-        (pl.col('dataset') == 'study') & (pl.col('kind') == 'grouping')
-        & (pl.col('metric') == 'studyType') & (pl.col('group_value') == 'gwas')
+        (pl.col('dataset') == 'study')
+        & (pl.col('kind') == 'grouping')
+        & (pl.col('metric') == 'studyType')
+        & (pl.col('group_value') == 'gwas')
     )
     assert gwas['value'].item() == 2
 
@@ -201,3 +219,19 @@ def test_config_for_dataset_pattern_match() -> None:
     assert _config_for_dataset('study', cfg) == {'groupings': {'a': 'a'}}
     assert _config_for_dataset('evidence_eva', cfg) == {'groupings': {'datatype': 'datatypeId'}}
     assert _config_for_dataset('biosample', cfg) == {}
+
+
+def test_config_for_dataset_specificity_precedence() -> None:
+    cfg = {
+        '*': {'groupings': {'all': 'all'}},
+        'evidence_*': {'groupings': {'datatype': 'datatypeId'}},
+    }
+    # the more specific (longer) pattern wins over the catch-all
+    assert _config_for_dataset('evidence_eva', cfg) == {'groupings': {'datatype': 'datatypeId'}}
+    assert _config_for_dataset('study', cfg) == {'groupings': {'all': 'all'}}
+
+
+def test_compute_filter_count_distinct_excludes_null() -> None:
+    df = pl.DataFrame({'score': [0.9, 0.7, 0.8], 'geneId': ['g1', None, 'g1']})
+    # all three rows pass score > 0.5; geneId is {g1, null} -> a null is not a gene
+    assert compute_filter_count(df, 'score > 0.5', distinct='geneId') == 1

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import polars as pl
 
-from pts.transformers.dataset_metrics import compute_breakdown
+from pts.transformers.dataset_metrics import compute_breakdown, compute_filter_count
 
 
 def test_compute_breakdown_plain_column_with_null() -> None:
@@ -18,3 +18,13 @@ def test_compute_breakdown_derived_expression() -> None:
 def test_compute_breakdown_explodes_list_column() -> None:
     df = pl.DataFrame({'tas': [['a', 'b'], ['a']]})
     assert compute_breakdown(df, 'tas') == {'a': 2, 'b': 1}
+
+
+def test_compute_filter_count_rows() -> None:
+    df = pl.DataFrame({'score': [0.9, 0.2, 0.7], 'geneId': ['g1', 'g2', 'g1']})
+    assert compute_filter_count(df, 'score > 0.5') == 2
+
+
+def test_compute_filter_count_distinct() -> None:
+    df = pl.DataFrame({'score': [0.9, 0.2, 0.7], 'geneId': ['g1', 'g2', 'g1']})
+    assert compute_filter_count(df, 'score > 0.5', distinct='geneId') == 1

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import polars as pl
 
-from pts.transformers.dataset_metrics import compute_breakdown, compute_filter_count
+from pts.transformers.dataset_metrics import _dataset_file_stats, compute_breakdown, compute_filter_count
 
 
 def test_compute_breakdown_plain_column_with_null() -> None:
@@ -28,3 +30,17 @@ def test_compute_filter_count_rows() -> None:
 def test_compute_filter_count_distinct() -> None:
     df = pl.DataFrame({'score': [0.9, 0.2, 0.7], 'geneId': ['g1', 'g2', 'g1']})
     assert compute_filter_count(df, 'score > 0.5', distinct='geneId') == 1
+
+
+def test_dataset_file_stats(tmp_path: Path) -> None:
+    dataset_dir = tmp_path / 'study'
+    dataset_dir.mkdir()
+    df = pl.DataFrame({'studyType': ['gwas', 'eqtl']})
+    df.write_parquet(dataset_dir / 'part-0.parquet')
+    df.write_parquet(dataset_dir / 'part-1.parquet')
+    (dataset_dir / '_SUCCESS').write_text('')  # must be ignored
+
+    file_size, n_partitions = _dataset_file_stats(str(dataset_dir))
+
+    assert n_partitions == 2
+    assert file_size > 0

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import polars as pl
+
+from pts.transformers.dataset_metrics import compute_breakdown
+
+
+def test_compute_breakdown_plain_column_with_null() -> None:
+    df = pl.DataFrame({'studyType': ['gwas', 'eqtl', 'gwas', None]})
+    assert compute_breakdown(df, 'studyType') == {'gwas': 2, 'eqtl': 1, 'null': 1}
+
+
+def test_compute_breakdown_derived_expression() -> None:
+    df = pl.DataFrame({'rightStudyType': ['gwas', 'eqtl', 'eqtl']})
+    assert compute_breakdown(df, "concat('gwas-', rightStudyType)") == {'gwas-eqtl': 2, 'gwas-gwas': 1}
+
+
+def test_compute_breakdown_explodes_list_column() -> None:
+    df = pl.DataFrame({'tas': [['a', 'b'], ['a']]})
+    assert compute_breakdown(df, 'tas') == {'a': 2, 'b': 1}

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -48,13 +48,14 @@ def test_dataset_file_stats(tmp_path: Path) -> None:
     dataset_dir = tmp_path / 'study'
     dataset_dir.mkdir()
     df = pl.DataFrame({'studyType': ['gwas', 'eqtl']})
-    df.write_parquet(dataset_dir / 'part-0.parquet')
-    df.write_parquet(dataset_dir / 'part-1.parquet')
-    (dataset_dir / '_SUCCESS').write_text('')  # must be ignored
+    df.write_parquet(dataset_dir / 'part-0.parquet')  # Spark-style name
+    df.write_parquet(dataset_dir / 'data-abc.parquet')  # single-file Polars-style name
+    (dataset_dir / '_SUCCESS').write_text('')  # marker must be ignored
+    (dataset_dir / '.part-0.parquet.crc').write_text('')  # checksum must be ignored
 
     file_size, n_partitions = _dataset_file_stats(str(dataset_dir))
 
-    assert n_partitions == 2
+    assert n_partitions == 2  # both .parquet files counted, regardless of prefix
     assert file_size > 0
 
 

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 import polars as pl
 
-from pts.transformers.dataset_metrics import _dataset_file_stats, compute_breakdown, compute_filter_count
+from pts.transformers.dataset_metrics import (
+    OUTPUT_SCHEMA,
+    _breakdowns_to_struct,
+    _dataset_file_stats,
+    _filter_counts_to_struct,
+    compute_breakdown,
+    compute_filter_count,
+)
 
 
 def test_compute_breakdown_plain_column_with_null() -> None:
@@ -44,3 +51,39 @@ def test_dataset_file_stats(tmp_path: Path) -> None:
 
     assert n_partitions == 2
     assert file_size > 0
+
+
+def test_breakdowns_to_struct() -> None:
+    out = _breakdowns_to_struct({'studyType': {'gwas': 2, 'eqtl': 1}})
+    assert out == [
+        {'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}
+    ]
+
+
+def test_filter_counts_to_struct() -> None:
+    assert _filter_counts_to_struct({'prioritised_genes': 18422}) == [
+        {'name': 'prioritised_genes', 'count': 18422}
+    ]
+
+
+def test_output_schema_builds_and_roundtrips(tmp_path: Path) -> None:
+    rows = [
+        {
+            'id': 'study', 'count': 2, 'file_size': 10, 'number_of_partitions': 1,
+            'breakdowns': _breakdowns_to_struct({'studyType': {'gwas': 1, 'eqtl': 1}}),
+            'filter_counts': [],
+        },
+        {
+            'id': 'biosample', 'count': 5, 'file_size': 7, 'number_of_partitions': 1,
+            'breakdowns': [], 'filter_counts': [],
+        },
+    ]
+    out = tmp_path / 'metrics'
+    pl.DataFrame(rows, schema=OUTPUT_SCHEMA).write_parquet(out, mkdir=True)
+    back = pl.read_parquet(out)
+
+    assert back.height == 2
+    assert back.schema == pl.Schema(OUTPUT_SCHEMA)
+    assert back.filter(pl.col('id') == 'study')['breakdowns'].to_list() == [
+        [{'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 1}, {'value': 'eqtl', 'count': 1}]}]
+    ]

--- a/test/test_dataset_metrics.py
+++ b/test/test_dataset_metrics.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import polars as pl
 
 from pts.transformers.dataset_metrics import (
     OUTPUT_SCHEMA,
     _breakdowns_to_struct,
+    _config_for_dataset,
     _dataset_file_stats,
     _filter_counts_to_struct,
     compute_breakdown,
     compute_filter_count,
+    dataset_metrics,
     profile_dataset,
 )
 
@@ -138,3 +141,46 @@ def test_profile_dataset_unreadable_returns_none(tmp_path: Path) -> None:
     empty_dir.mkdir()
     (empty_dir / 'readme.txt').write_text('not parquet')
     assert profile_dataset(str(empty_dir), 'not_parquet', {}) is None
+
+
+def test_dataset_metrics_writes_one_parquet_per_dataset(tmp_path: Path, monkeypatch) -> None:
+    study = _write_dataset(tmp_path / 'study', pl.DataFrame({'studyType': ['gwas', 'eqtl', 'gwas']}))
+    biosample = _write_dataset(tmp_path / 'biosample', pl.DataFrame({'id': ['b1', 'b2']}))
+    # a discovered dataset whose basename collides with the output dir must be skipped:
+    discovered = {
+        '/output/study': study,
+        '/output/biosample': biosample,
+        '/output/metrics': str(tmp_path / 'ignored'),
+    }
+    monkeypatch.setattr(
+        'pts.transformers.dataset_metrics._discover_dataset_paths',
+        lambda root, scopes, config: discovered,
+    )
+
+    out_dir = tmp_path / 'metrics'
+    config = SimpleNamespace(release_uri=str(tmp_path), work_path=tmp_path)
+    settings = {'datasets': {'study': {'groupings': {'studyType': 'studyType'}}}}
+
+    dataset_metrics({}, {'directory': str(out_dir)}, settings, config)
+
+    files = sorted(p.name for p in out_dir.glob('*.parquet'))
+    assert files == ['biosample.parquet', 'study.parquet']  # 'metrics' skipped
+
+    study_df = pl.read_parquet(out_dir / 'study.parquet')
+    assert study_df.height == 1
+    assert study_df['id'].item() == 'study'
+    assert study_df['count'].item() == 3
+    assert study_df['breakdowns'].to_list() == [
+        [{'grouping': 'studyType', 'groups': [{'value': 'gwas', 'count': 2}, {'value': 'eqtl', 'count': 1}]}]
+    ]
+    assert pl.read_parquet(out_dir / 'biosample.parquet')['breakdowns'].to_list() == [[]]
+
+
+def test_config_for_dataset_pattern_match() -> None:
+    cfg = {
+        'study': {'groupings': {'a': 'a'}},
+        'evidence_*': {'groupings': {'datatype': 'datatypeId'}},
+    }
+    assert _config_for_dataset('study', cfg) == {'groupings': {'a': 'a'}}
+    assert _config_for_dataset('evidence_eva', cfg) == {'groupings': {'datatype': 'datatypeId'}}
+    assert _config_for_dataset('biosample', cfg) == {}

--- a/test/test_release_metrics.py
+++ b/test/test_release_metrics.py
@@ -7,9 +7,9 @@ import polars as pl
 import pytest
 from otter.config.model import Config
 
+from pts.transformers.parquet_helpers import discover_dataset_paths
 from pts.transformers.release_metrics import (
     _build_run_id,
-    _discover_dataset_paths,
     _emit_association_metrics,
     _emit_evidence_failed_metrics,
     _emit_evidence_metrics,
@@ -238,9 +238,9 @@ def test_discover_dataset_paths_recovers_missing_directory_markers(monkeypatch) 
             ]
         return []
 
-    monkeypatch.setattr('pts.transformers.release_metrics._expand_storage_glob', fake_expand_storage_glob)
+    monkeypatch.setattr('pts.transformers.parquet_helpers._expand_storage_glob', fake_expand_storage_glob)
 
-    discovered = _discover_dataset_paths(release_uri, ['/output/*/'], config=config)
+    discovered = discover_dataset_paths(release_uri, ['/output/*/'], config=config)
 
     assert set(discovered) == {'/output/disease', '/output/go', '/output/target'}
 
@@ -259,10 +259,10 @@ def test_discover_dataset_paths_scope_trailing_slash_equivalent(monkeypatch) -> 
             ]
         return []
 
-    monkeypatch.setattr('pts.transformers.release_metrics._expand_storage_glob', fake_expand_storage_glob)
+    monkeypatch.setattr('pts.transformers.parquet_helpers._expand_storage_glob', fake_expand_storage_glob)
 
-    discovered_without_slash = _discover_dataset_paths(release_uri, ['/output/*'], config=config)
-    discovered_with_slash = _discover_dataset_paths(release_uri, ['/output/*/'], config=config)
+    discovered_without_slash = discover_dataset_paths(release_uri, ['/output/*'], config=config)
+    discovered_with_slash = discover_dataset_paths(release_uri, ['/output/*/'], config=config)
 
     assert discovered_without_slash == discovered_with_slash
     assert set(discovered_without_slash) == {'/output/disease', '/output/target'}

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -945,9 +945,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/0f/a91f143f356523ff682309732b175765a9bc2836fd7c081c2c67fedc1ad4/greenlet-3.5.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:8f1cc966c126639cd152fdaa52624d2655f492faa79e013fea161de3e6dda082", size = 284726, upload-time = "2026-04-27T12:20:51.402Z" },
     { url = "https://files.pythonhosted.org/packages/95/82/800646c7ffc5dbabd75ddd2f6b519bb898c0c9c969e5d0473bfe5d20bcce/greenlet-3.5.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:362624e6a8e5bca3b8233e45eef33903a100e9539a2b995c364d595dbc4018b3", size = 604264, upload-time = "2026-04-27T12:52:39.494Z" },
     { url = "https://files.pythonhosted.org/packages/ca/ac/354867c0bba812fc33b15bc55aedafedd0aee3c7dd91dfca22444157dc0c/greenlet-3.5.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5ecd83806b0f4c2f53b1018e0005cd82269ea01d42befc0368730028d850ed1c", size = 616099, upload-time = "2026-04-27T12:59:39.623Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/ab/192090c4a5b30df148c22bf4b8895457d739a7c7c5a7b9c41e5dd7f537f2/greenlet-3.5.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa94cb2288681e3a11645958f1871d48ee9211bd2f66628fdace505927d6e564", size = 623976, upload-time = "2026-04-27T13:02:37.363Z" },
     { url = "https://files.pythonhosted.org/packages/ff/b0/815bece7399e01cadb69014219eebd0042339875c59a59b0820a46ece356/greenlet-3.5.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0ff251e9a0279522e62f6176412869395a64ddf2b5c5f782ff609a8216a4e662", size = 615198, upload-time = "2026-04-27T12:25:25.928Z" },
-    { url = "https://files.pythonhosted.org/packages/24/11/05eb2b9b188c6df7d68a89c99134d644a7af616a40b9808e8e6ced315d5d/greenlet-3.5.0-cp311-cp311-manylinux_2_39_riscv64.whl", hash = "sha256:64d6ac45f7271f48e45f67c95b54ef73534c52ec041fcda8edf520c6d811f4bc", size = 418379, upload-time = "2026-04-27T13:05:12.755Z" },
     { url = "https://files.pythonhosted.org/packages/10/80/3b2c0a895d6698f6ddb31b07942ebfa982f3e30888bc5546a5b5990de8b2/greenlet-3.5.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d874e79afd41a96e11ff4c5d0bc90a80973e476fda1c2c64985667397df432b", size = 1574927, upload-time = "2026-04-27T12:53:25.81Z" },
     { url = "https://files.pythonhosted.org/packages/44/0e/f354af514a4c61454dbc68e44d47544a5a4d6317e30b77ddfa3a09f4c5f3/greenlet-3.5.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:0ed006e4b86c59de7467eb2601cd1b77b5a7d657d1ee55e30fe30d76451edba4", size = 1642683, upload-time = "2026-04-27T12:25:23.9Z" },
     { url = "https://files.pythonhosted.org/packages/fa/6a/87f38255201e993a1915265ebb80cd7c2c78b04a45744995abbf6b259fd8/greenlet-3.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:703cb211b820dbffbbc55a16bfc6e4583a6e6e990f33a119d2cc8b83211119c8", size = 238115, upload-time = "2026-04-27T12:21:48.845Z" },
@@ -955,9 +953,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ef/32/f2ce6d4cac3e55bc6173f92dbe627e782e1850f89d986c3606feb63aafa7/greenlet-3.5.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:db2910d3c809444e0a20147361f343fe2798e106af8d9d8506f5305302655a9f", size = 286228, upload-time = "2026-04-27T12:20:34.421Z" },
     { url = "https://files.pythonhosted.org/packages/b7/aa/caed9e5adf742315fc7be2a84196373aab4816e540e38ba0d76cb7584d68/greenlet-3.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ec9ea74e7268ace7f9aab1b1a4e730193fc661b39a993cd91c606c32d4a3628", size = 601775, upload-time = "2026-04-27T12:52:41.045Z" },
     { url = "https://files.pythonhosted.org/packages/c7/af/90ae08497400a941595d12774447f752d3dfe0fbb012e35b76bc5c0ff37e/greenlet-3.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54d243512da35485fc7a6bf3c178fdda6327a9d6506fcdd62b1abd1e41b2927b", size = 614436, upload-time = "2026-04-27T12:59:41.595Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e9/4eeadf8cb3403ac274245ba75f07844abc7fa5f6787583fc9156ba741e0f/greenlet-3.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:41353ec2ecedf7aa8f682753a41919f8718031a6edac46b8d3dc7ed9e1ceb136", size = 620610, upload-time = "2026-04-27T13:02:39.194Z" },
     { url = "https://files.pythonhosted.org/packages/2b/e0/2e13df68f367e2f9960616927d60857dd7e56aaadd59a47c644216b2f920/greenlet-3.5.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d280a7f5c331622c69f97eb167f33577ff2d1df282c41cd15907fc0a3ca198c", size = 611388, upload-time = "2026-04-27T12:25:28.008Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/ef/f913b3c0eb7d26d86a2401c5e1546c9d46b657efee724b06f6f4ac5d8824/greenlet-3.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:58c1c374fe2b3d852f9b6b11a7dff4c85404e51b9a596fd9e89cf904eb09866d", size = 422775, upload-time = "2026-04-27T13:05:14.261Z" },
     { url = "https://files.pythonhosted.org/packages/82/f7/393c64055132ac0d488ef6be549253b7e6274194863967ddc0bc8f5b87b8/greenlet-3.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1eb67d5adefb5bd2e182d42678a328979a209e4e82eb93575708185d31d1f588", size = 1570768, upload-time = "2026-04-27T12:53:28.099Z" },
     { url = "https://files.pythonhosted.org/packages/b8/4b/eaf7735253522cf56d1b74d672a58f54fc114702ceaf05def59aae72f6e1/greenlet-3.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2628d6c86f6cb0cb45e0c3c54058bbec559f57eaae699447748cb3928150577e", size = 1635983, upload-time = "2026-04-27T12:25:26.903Z" },
     { url = "https://files.pythonhosted.org/packages/4c/fe/4fb3a0805bd5165da5ebf858da7cc01cce8061674106d2cf5bdab32cbfde/greenlet-3.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:d4d9f0624c775f2dfc56ba54d515a8c771044346852a918b405914f6b19d7fd8", size = 238840, upload-time = "2026-04-27T12:23:54.806Z" },
@@ -965,9 +961,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
     { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
     { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
     { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
-    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
     { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
     { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
     { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
@@ -2119,11 +2113,12 @@ wheels = [
 
 [[package]]
 name = "pts"
-version = "26.6.17"
+version = "26.6.19"
 source = { editable = "." }
 dependencies = [
     { name = "clinical-mining" },
     { name = "defusedxml" },
+    { name = "fsspec" },
     { name = "gcsfs" },
     { name = "huggingface-hub" },
     { name = "loguru" },
@@ -2168,6 +2163,7 @@ requires-dist = [
     { name = "coverage", marker = "extra == 'test'", specifier = "==7.13.4" },
     { name = "defusedxml", specifier = ">=0.7.1" },
     { name = "freezegun", marker = "extra == 'test'", specifier = "==1.5.5" },
+    { name = "fsspec", specifier = ">=2026.2.0" },
     { name = "gcsfs", specifier = ">=2026.2.0" },
     { name = "huggingface-hub", specifier = ">=0.32.4" },
     { name = "loguru", specifier = "==0.7.3" },


### PR DESCRIPTION
## Summary

New Polars transformer `dataset_metrics` (sibling of `release_metrics`) that profiles every `output/*` dataset into **one parquet per dataset** under a root-level `metrics/` directory, for the Platform/PPP metric page (opentargets/issues#4328).

Each per-dataset profile row carries:
- `id`, `count` (read from parquet footers — no data scan), `file_size`, `number_of_partitions`
- config-driven `breakdowns` — SQL-expression groupings (`pl.sql_expr`), with list columns auto-exploded
- config-driven `filter_counts` — SQL filter, optional `distinct` column

The `dataset_metrics` step is registered in `config.yaml` with the metric-page groupings/filters: study (studyType, projectId), credible_set, variant (most-severe consequence), colocalisation (study-type pair), drug_molecule (clinical stage), clinical_report (clinical stage), disease (therapeutic area), l2g_prediction (prioritised genes, L2G>0.5 distinct gene), associations by datasource/datatype (direct & indirect), and an `evidence_*` pattern key for datatype.

Discovery/count helpers are reused from `release_metrics`; `release_metrics` and its HuggingFace pipeline are untouched. A disposable (uncommitted) `scripts/metrics_to_jsonl.py` converts the output to shareable JSONL.

## Test plan

- [x] `uv run pytest test/test_dataset_metrics.py --doctest-modules src/pts/transformers/dataset_metrics.py` → 16 passed
- [x] `uv run ruff check src/pts/transformers/dataset_metrics.py test/test_dataset_metrics.py` → clean
- [x] Validated read-only against `gs://open-targets-pipeline-runs/ds/26.03-test5/`: study count 2,001,827 (+ studyType/projectId breakdowns); colocalisation 217,914,314 (studyTypePair: gwas-gwas 167M, gwas-eqtl 28.9M, …); l2g prioritised_genes (score>0.5 distinct geneId) 15,509
- [ ] Run `pts --step dataset_metrics` on Dataproc against 26.03-test5 → writes `metrics/<dataset>.parquet`; export JSONL for stakeholders
