### PR TITLE
fix(target): restrict protein classification to single-component ChEMBL targets

### DIFF
--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -1154,7 +1154,13 @@ def _build_protein_classification(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with [accession, targetClass[{id, label, level}]].
     """
-    accession_pc = df.select(
+    # Restrict to single-component ChEMBL targets. Multi-component records
+    # (complexes, PPIs) carry classifications that are not positionally aligned
+    # with `target_components`, so zipping them misattributes classes across
+    # subunits.
+    single = df.filter(f.size(f.col('target_components')) == 1)
+
+    accession_pc = single.select(
         f.explode(
             f.arrays_zip(
                 f.col('_metadata.protein_classification'),


### PR DESCRIPTION
## Summary

`_build_protein_classification` in `src/pts/pyspark/target.py` zipped `_metadata.protein_classification` with `target_components.accession`, assuming the two top-level arrays are positionally aligned. They are not in multi-component records.

The classification array is parallel to `_metadata.target_component`, **not** to `target_components`. The two component orderings disagree for **860 of 1898 multi-component records (~45%)** in the current `chembl_target.jsonl`, causing classifications to be swapped across subunits.

### Worked example — CRBN (Q96SW2 / ENSG00000113851), `CHEMBL5465218`

| idx | `target_components.accession` | `_metadata.target_component.accession` | `_metadata.protein_classification` |
|---|---|---|---|
| 0 | Q15004 (PAF15) | Q96SW2 (CRBN)  | `601 Unclassified protein` |
| 1 | Q96SW2 (CRBN)  | Q15004 (PAF15) | `5 Other nuclear protein`  |

The zip pairs Q96SW2 with `5 Other nuclear protein` (PAF15's class). The per-component truth from `_metadata.target_component[*].protein_classifications` says Q96SW2 → 601, Q15004 → 5. CRBN is cytosolic, not nuclear.

## Fix

Filter `_build_protein_classification` to single-component ChEMBL targets only. In that subset, positional alignment is trivially correct. Per-protein classifications still flow in via each protein's dedicated `SINGLE PROTEIN` record (e.g. CRBN's class 601 comes through `CHEMBL3763008`).

## Test plan
- [ ] Run `target` step end-to-end and confirm `ENSG00000113851.targetClass` contains only `Unclassified protein` (id 601) rather than the previous mix.
- [ ] Spot-check a handful of other proteins known to appear in many PPI / complex records (e.g. CRBN, DDB1, CUL4A, common kinases used in PROTAC complexes).
- [ ] Compare row count / set of `(accession, protein_class_id)` against previous run; expected behaviour is *fewer* classifications per accession, never an expansion.
- [ ] `uv run pytest test --doctest-modules src/pts`
- [ ] `uv run ruff check`

Draft until I've eyeballed the dataset diff.