### PR TITLE
fix(target): remove deprecated Project Score cross-references

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -351,22 +351,6 @@ steps:
       destination: intermediate/target/hpa/subcellular_locations_ssl.parquet
       separator: "\t"
 
-    - name: unzip essentiality matrix
-      source: input/target/project-scores/essentiality_matrices.zip
-      inner_file: EssentialityMatrices/04_binaryDepScores.tsv
-      destination: intermediate/target/project-scores/04_binaryDepScores.tsv
-    - name: csv_to_parquet essentiality matrix
-      requires:
-        - unzip essentiality matrix
-      source: intermediate/target/project-scores/04_binaryDepScores.tsv
-      local_source: True
-      destination: intermediate/target/project-scores/04_binaryDepScores.parquet
-      separator: "\t"
-
-    - name: csv_to_parquet gene identifier
-      source: input/target/project-scores/gene_identifiers_latest.csv.gz
-      destination: intermediate/target/project-scores/gene_identifiers_latest.parquet
-
     - name: download ensembl
       source: input/target/ensembl/homo_sapiens.json
     - name: transform ensembl
@@ -415,8 +399,6 @@ steps:
         hpa: intermediate/target/hpa/subcellular_location.tsv.gz
         hpa_sl: intermediate/target/hpa/subcellular_locations_ssl.parquet
         ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
-        project_scores_ids: intermediate/target/project-scores/gene_identifiers_latest.parquet
-        project_scores_essentiality_matrix: intermediate/target/project-scores/04_binaryDepScores.parquet
         reactome_etl: output/reactome
         reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
         safety_evidence: intermediate/target/safety.parquet

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -14,7 +14,6 @@ Scala sources ported:
     - Hgnc.scala
     - Ncbi.scala
     - Ortholog.scala
-    - ProjectScores.scala
     - ProteinClassification.scala
     - Reactome.scala
     - Safety.scala
@@ -144,8 +143,6 @@ def target(
     tep_raw = spark.read.json(source['tep'])
     hpa_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['hpa'])
     hpa_sl_raw = spark.read.parquet(source['hpa_sl'])
-    ps_ids_raw = spark.read.parquet(source['project_scores_ids'])
-    ps_matrix_raw = spark.read.parquet(source['project_scores_essentiality_matrix'])
     chembl_raw = spark.read.json(source['chembl'])
     genetic_constraints_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['genetic_constraints'])
     homology_dict_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['homology_dictionary'])
@@ -218,9 +215,6 @@ def target(
     logger.info('Building HPA subcellular locations')
     hpa_df = _build_gene_with_location(hpa_raw, hpa_sl_raw)
 
-    logger.info('Building ProjectScores')
-    project_scores_df = _build_project_scores(ps_ids_raw, ps_matrix_raw)
-
     logger.info('Building ProteinClassification')
     protein_class_df = _build_protein_classification(chembl_raw)
 
@@ -246,14 +240,13 @@ def target(
     uniprot_df = _build_uniprot(uniprot_raw, uniprot_ssl_raw)
 
     # --- Merge ---------------------------------------------------------------
-    logger.info('Merging HGNC + Ensembl + GO + ProjectScores + Hallmarks')
+    logger.info('Merging HGNC + Ensembl + GO + Hallmarks')
     hgnc_ensembl = _merge_hgnc_ensembl(hgnc_df, ensembl_df)
 
     hgnc_ensembl_go = (
         hgnc_ensembl
         .join(go_df, hgnc_ensembl['id'] == go_df['ensemblId'], 'left_outer')
         .drop('ensemblId')
-        .join(project_scores_df, 'id', 'left_outer')
         .join(hallmarks_df, 'approvedSymbol', 'left_outer')
     )
 
@@ -277,7 +270,7 @@ def target(
         .withColumn('proteinIds', _safe_array_union(f.col('proteinIds'), f.col('pid')))
         .withColumn(
             'dbXrefs',
-            _safe_array_union(f.col('hgncId'), f.col('dbXrefs'), f.col('signalP'), f.col('xRef')),
+            _safe_array_union(f.col('hgncId'), f.col('dbXrefs'), f.col('signalP')),
         )
         .withColumn('symbolSynonyms', _safe_array_union(f.col('symbolSynonyms'), f.col('hgncSymbolSynonyms')))
         .withColumn('nameSynonyms', _safe_array_union(f.col('nameSynonyms'), f.col('hgncNameSynonyms')))
@@ -297,7 +290,6 @@ def target(
             'hgncObsoleteSymbols',
             'uniprotIds',
             'signalP',
-            'xRef',
         )
         .persist()
     )
@@ -1089,60 +1081,6 @@ def _build_gene_with_location(df: DataFrame, sl_df: DataFrame) -> DataFrame:
         )
         .groupBy('id')
         .agg(f.collect_list('locations').alias('locations'))
-    )
-
-
-# ===========================================================================
-# ProjectScores.scala → _build_project_scores
-# ===========================================================================
-
-
-def _build_project_scores(ids_df: DataFrame, matrix_df: DataFrame) -> DataFrame:
-    """Build project scores (DepMap) cross-references.
-
-    Args:
-        ids_df: Gene identifiers mapping (gene_id, ensembl_gene_id, hgnc_symbol).
-        matrix_df: Binary dependency scores matrix (Gene column + per-cell-line columns).
-
-    Returns:
-        DataFrame with [id, xRef[{id, source}]].
-    """
-    id_source_schema = ArrayType(
-        StructType([
-            StructField('id', StringType()),
-            StructField('source', StringType()),
-        ])
-    )
-
-    ps_ids = ids_df.filter(f.col('ensembl_gene_id').isNotNull()).select(
-        f.col('gene_id').alias('ps_gene_id'),
-        f.col('ensembl_gene_id'),
-        f.col('hgnc_symbol'),
-    )
-
-    # Build a proper total using stack expression
-    data_cols = [c for c in matrix_df.columns if c != 'Gene']
-    if data_cols:
-        stack_expr = f'stack({len(data_cols)}, {", ".join([f"`{c}`" for c in data_cols])}) as val'
-        total_df = (
-            matrix_df
-            .select('Gene', f.expr(stack_expr).alias('val'))
-            .groupBy('Gene')
-            .agg(f.sum('val').alias('total'))
-            .filter(f.col('total') > 0)
-        )
-
-    return total_df.join(ps_ids, total_df['Gene'] == ps_ids['hgnc_symbol']).select(
-        f.col('ensembl_gene_id').alias('id'),
-        f
-        .array(
-            f.struct(
-                f.col('ps_gene_id').alias('id'),
-                f.lit('ProjectScore').alias('source'),
-            )
-        )
-        .cast(id_source_schema)
-        .alias('xRef'),
     )
 
 


### PR DESCRIPTION
## Summary

Project Score has been deprecated upstream. This drops the xref pipeline that emitted `{id: SIDG..., source: 'ProjectScore'}` entries into the target `dbXrefs` field.

- Remove `_build_project_scores` (and its two `project-scores/` parquet inputs, the join into `hgnc_ensembl_go`, and the `xRef` column merged into `dbXrefs`) from `src/pts/pyspark/target.py`
- Drop the 3 project-scores pre-processing tasks and the 2 `project_scores_*` source entries on the `target` pyspark step in `config.yaml`

Out of scope (intentionally unaffected):
- `src/pts/pyspark/project_score.py` — Project Score v2 CRISPR evidence parser (separate dataset, still maintained)
- `target_gene_essentiality` step — backed by DepMap, not Project Score

Follow-up PRs needed:
- `pis` — drop the two `cog.sanger.ac.uk/cmp/download/` fetches under `input/target/project-scores/`
- `orchestration` — mirror both changes in `dags/config/{pis,pts}.yaml` and remove the `project-scores/` entries from `scripts/validate_pts_step.py`

Refs opentargets/issues#4367

## Test plan

- [ ] Spot-check the output `target` parquet to verify `dbXrefs` no longer contains `source: ProjectScore` entries
- [ ] Confirm `gene_essentiality` output is unchanged