### PR TITLE
feat(literature): add trade_name_component as trusted source

### DIFF
--- a/src/pts/pyspark/literature_publication_match.py
+++ b/src/pts/pyspark/literature_publication_match.py
@@ -169,6 +169,7 @@ def literature_publication_match(
             'clinvar_xrefs',
             'approved_name',
             'approved_symbol',
+            'trade_name_component',
         ]
     )
     # consumed by the isValid==True and isValid==False filters


### PR DESCRIPTION
OnToma added a new label-id mapping source where products are now extracted from trade names/synonyms with the pattern `{molecule} component of {product}`, resulting in label-id mappings of products to the ids of their components:
> symkevi → {CHEMBL2010601 (Ivacaftor), CHEMBL3544914 (Tezacaftor)}

However, as now we have one label being mapped to multiple ids, this will be flagged as ambiguous in the literature pipeline.

This PR addresses this by adding `trade_name_component` to the list of `trusted_sources`