### PR TITLE
feat(clinical): use reports with flag to build indications and evidence

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -520,7 +520,6 @@ steps:
       settings:
         invalid_clinical_report_qc:
           - PHASE_IV_NOT_APPROVED
-          - UNVALIDATED_INDICATION
           - INDIRECT_PRIMARY_PURPOSE
   ##################################################################################################
 
@@ -1964,7 +1963,7 @@ steps:
         hf_data_dir: metrics
   ##################################################################################################
 
-#: LITERATURE_ENTITY_LUT STEP :#####################################################################
+  #: LITERATURE_ENTITY_LUT STEP :#####################################################################
   literature_entity_lut:
     - name: pyspark literature_entity_lut
       pyspark: literature_entity_lut
@@ -1976,7 +1975,7 @@ steps:
         spark.sql.shuffle.partitions: '10000'
   ##################################################################################################
 
-#: LITERATURE_EMBEDDING STEP :######################################################################
+  #: LITERATURE_EMBEDDING STEP :######################################################################
   literature_embedding:
     - name: pyspark literature_embedding
       pyspark: literature_embedding
@@ -1988,7 +1987,7 @@ steps:
         spark.sql.shuffle.partitions: '15000'
   ##################################################################################################
 
-#: LITERATURE_VECTOR STEP :#########################################################################
+  #: LITERATURE_VECTOR STEP :#########################################################################
   literature_vector:
     - name: pyspark literature_vector
       pyspark: literature_vector

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ explicit = true
 torch = [{ index = "pytorch-cpu" }]
 torchvision = [{ index = "pytorch-cpu" }]
 ot-literature = { git = "https://github.com/opentargets/ot-literature", tag = "0.1.0" }
-clinical-mining = { git = "https://github.com/opentargets/clinical_mining", tag = "0.6.0" }
+clinical-mining = { git = "https://github.com/opentargets/clinical_mining", tag = "0.6.3" }
 cellex = { git = "https://github.com/perslab/CELLEX", rev = "119c7ca" }
 
 [dependency-groups]

--- a/src/pts/pyspark/clinical_report.py
+++ b/src/pts/pyspark/clinical_report.py
@@ -8,7 +8,7 @@ import pdfplumber
 import polars as pl
 import torch
 from clinical_mining.data_sources.aact import extract_clinical_report as extract_aact_clinical_report
-from clinical_mining.data_sources.aact.llm_extractor import parse_indication_batch_results
+from clinical_mining.data_sources.aact.llm_extractor import parse_batch_results
 from clinical_mining.data_sources.chembl.drug_warnings import (
     extract_clinical_report as extract_drug_warning_clinical_report,
 )
@@ -33,6 +33,8 @@ class ClinicalReportFlags(StrEnum):
     PHASE_IV_NOT_APPROVED = 'PHASE_IV_NOT_APPROVED'
     UNVALIDATED_INDICATION = 'UNVALIDATED_INDICATION'
     INDIRECT_PRIMARY_PURPOSE = 'INDIRECT_PRIMARY_PURPOSE'
+    NO_DISEASE = 'NO_DISEASE'
+    NO_DRUGS = 'NO_DRUGS'
 
 
 def clinical_report(
@@ -95,7 +97,12 @@ def clinical_report(
     chembl_drug_warning_references = pl.read_parquet(source['chembl_drug_warning_references']).select(
         'warning_id', 'ref_type', 'ref_id', 'ref_url'
     )
-    llm_indications = parse_indication_batch_results(source['trial_extraction_batch_results'])
+    llm_batch_results = parse_batch_results(source['trial_extraction_batch_results'])
+    llm_indications = llm_batch_results.select(
+        'id',
+        pl.col('investigated_drugs').list.eval(pl.element().struct.field('drug').unique()).alias('drugs'),
+        pl.col('primary_indications').list.eval(pl.element().struct.field('name').unique()).alias('diseases'),
+    )
 
     logger.info('extract clinical report')
     pmda_pdf_handler = StorageHandle(source['pmda'])
@@ -164,8 +171,10 @@ def clinical_report(
         )
         .pipe(validate_disease, disease_index=pl.read_parquet(source['disease']))
         .pipe(create_title)
+        .pipe(flag_null_diseases)
+        .pipe(flag_null_drugs)
         .pipe(flag_phase_iv_not_approved)
-        .pipe(flag_indirect_primary_purpose)
+        .pipe(flag_indirect_primary_purpose, llm_drug_intent=llm_batch_results.select('id', 'drug_intent'))
         .pipe(flag_unvalidated_indication, chembl_indication_report=chembl_indication_report)
     )
 
@@ -419,16 +428,61 @@ def flag_unvalidated_indication(
     )
 
 
-def flag_indirect_primary_purpose(reports: ClinicalReport) -> ClinicalReport:
-    """Flag reports where the primary purpose is indirect."""
+def flag_indirect_primary_purpose(
+    reports: ClinicalReport, llm_drug_intent: pl.DataFrame | None = None
+) -> ClinicalReport:
+    """Flag reports where the primary purpose is not a therapeutic direct purpose.
+
+    Args:
+        reports: ClinicalReport to flag
+        llm_drug_intent: DataFrame with drug_intent extracted from LLM
+
+    Returns:
+        ClinicalReport with indirect primary purpose flag
+    """
+    if llm_drug_intent is not None:
+        reports_df = reports.df.join(llm_drug_intent, on='id', how='left')
+        llm_drug_intent_condition = (
+            # Null drug_intent means the report wasn't in llm results — flag it
+            pl.col('drug_intent').is_null()
+            # Non-therapeutic intents (supportive_care, prevention, diagnostic, other)
+            | (pl.col('drug_intent') != 'therapeutic')
+        )
+    else:
+        reports_df = reports.df
+        llm_drug_intent_condition = pl.lit(False)
     return ClinicalReport(
         df=update_quality_flag(
-            df=reports.df,
+            df=reports_df,
             flag_condition=(
                 # Flag consists of reports where the primary purpose is indirect
                 pl.col('trialPrimaryPurpose').is_in(['DEVICE_FEASIBILITY', 'DIAGNOSTIC'])
+                # or the extracted drug_intent is missing or non-therapeutic
+                | llm_drug_intent_condition
             ),
             flag_text=ClinicalReportFlags.INDIRECT_PRIMARY_PURPOSE.value,
+        ).select(pl.all().exclude('drug_intent'))
+    )
+
+
+def flag_null_diseases(reports: ClinicalReport) -> ClinicalReport:
+    """Flag reports where the diseases column is null."""
+    return ClinicalReport(
+        df=update_quality_flag(
+            df=reports.df,
+            flag_condition=pl.col('diseases').is_null(),
+            flag_text=ClinicalReportFlags.NO_DISEASE.value,
+        )
+    )
+
+
+def flag_null_drugs(reports: ClinicalReport) -> ClinicalReport:
+    """Flag reports where the drugs column is null."""
+    return ClinicalReport(
+        df=update_quality_flag(
+            df=reports.df,
+            flag_condition=pl.col('drugs').is_null(),
+            flag_text=ClinicalReportFlags.NO_DRUGS.value,
         )
     )
 

--- a/test/test_clinical_report.py
+++ b/test/test_clinical_report.py
@@ -1,7 +1,11 @@
 import polars as pl
 from clinical_mining.dataset import ClinicalReport
 
-from pts.pyspark.clinical_report import validate_disease
+from pts.pyspark.clinical_report import (
+    ClinicalReportFlags,
+    flag_indirect_primary_purpose,
+    validate_disease,
+)
 
 
 def _build_reports(entries) -> ClinicalReport:
@@ -61,3 +65,88 @@ def test_validate_disease_preserves_populated_diseases() -> None:
     assert diseases == [
         {'diseaseFromSource': 'teratogenicity', 'diseaseId': 'EFO:0009880'},
     ]
+
+
+def _report(id_: str, primary_purpose: str | None = None) -> dict:
+    return {
+        'id': id_,
+        'phaseFromSource': 'phase 3',
+        'type': 'CURATED_RESOURCE',
+        'source': 'ClinicalTrials',
+        'trialPrimaryPurpose': primary_purpose,
+        'drugs': [{'drugFromSource': 'BENAZEPRIL', 'drugId': 'CHEMBL1694'}],
+        'diseases': [{'diseaseFromSource': 'hypertension', 'diseaseId': 'EFO:0000537'}],
+    }
+
+
+def _flagged(reports: ClinicalReport, report_id: str) -> bool:
+    qc = reports.df.filter(pl.col('id') == report_id).select('qualityControls').to_series().to_list()[0]
+    return qc is not None and ClinicalReportFlags.INDIRECT_PRIMARY_PURPOSE.value in qc
+
+
+def test_flag_indirect_primary_purpose_device_feasibility() -> None:
+    reports = _build_reports([
+        _report('r1', primary_purpose='TREATMENT'),
+        _report('r2', primary_purpose='DEVICE_FEASIBILITY'),
+        _report('r3', primary_purpose='DIAGNOSTIC'),
+        _report('r4', primary_purpose='OTHER'),
+    ])
+    result = flag_indirect_primary_purpose(reports)
+    assert not _flagged(result, 'r1')
+    assert _flagged(result, 'r2')
+    assert _flagged(result, 'r3')
+    assert not _flagged(result, 'r4')
+
+
+def test_flag_indirect_primary_purpose_no_primary_purpose() -> None:
+    """Reports without a trialPrimaryPurpose should not be flagged."""
+    reports = _build_reports([
+        _report('r1', primary_purpose=None),
+    ])
+    result = flag_indirect_primary_purpose(reports)
+    assert not _flagged(result, 'r1')
+
+
+def test_flag_indirect_primary_purpose_with_llm_no_match_is_flagged() -> None:
+    """When llm_batch_results is provided but report has no match, drug_intent is null → flagged."""
+    reports = _build_reports([
+        _report('r1', primary_purpose='TREATMENT'),
+    ])
+    llm_batch_results = pl.DataFrame({'id': ['r_other'], 'drug_intent': ['therapeutic']})
+    result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
+    assert _flagged(result, 'r1')
+
+
+def test_flag_indirect_primary_purpose_with_llm_therapeutic_not_flagged() -> None:
+    """drug_intent='therapeutic' should not be flagged."""
+    reports = _build_reports([
+        _report('r1', primary_purpose='TREATMENT'),
+    ])
+    llm_batch_results = pl.DataFrame({'id': ['r1'], 'drug_intent': ['therapeutic']})
+    result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
+    assert not _flagged(result, 'r1')
+
+
+def test_flag_indirect_primary_purpose_with_llm_non_therapeutic_flagged() -> None:
+    """Non-therapeutic drug_intent values (prevention, supportive_care, etc.) should be flagged."""
+    reports = _build_reports([
+        _report('r1', primary_purpose='TREATMENT'),
+        _report('r2', primary_purpose='TREATMENT'),
+    ])
+    llm_batch_results = pl.DataFrame({
+        'id': ['r1', 'r2'],
+        'drug_intent': ['therapeutic', 'prevention'],
+    })
+    result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
+    assert not _flagged(result, 'r1')
+    assert _flagged(result, 'r2')
+
+
+def test_flag_indirect_primary_purpose_drops_drug_intent() -> None:
+    """The drug_intent column must be dropped from the output."""
+    reports = _build_reports([
+        _report('r1', primary_purpose='TREATMENT'),
+    ])
+    llm_batch_results = pl.DataFrame({'id': ['r1'], 'drug_intent': ['therapeutic']})
+    result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
+    assert 'drug_intent' not in result.df.columns


### PR DESCRIPTION
This PR includes:
- Upgrade `clinical_mining` to 0.6.3 and adjustments in the `clinical_report` step
- **Added** two new flags in `clinical_indication`: `NO_DISEASE` and `NO_DRUG` to track cases where the diseases or drugs arrays come empty as a result of the extraction
    - 796 reports without diseases 
    - 0 reports without drugs
- **Changed** logic for `INDIRECT_PRIMARY_PURPOSE`: here we are using the `drug_intent` field we extracted with the LLM work: 113,636 reports have this flag now.
- **Removed** `UNVALIDATED_INDICATION` as a QC flag for `evidence_clinical_precedence` and `clinical_indication` (more about this on the [ticket](https://github.com/opentargets/issues/issues/4387))

```
qualityControls | count
-- | --
list[str] | u32
null | 137268
["INDIRECT_PRIMARY_PURPOSE"] | 86432
["UNVALIDATED_INDICATION"] | 27286
["INDIRECT_PRIMARY_PURPOSE", "NO_DISEASE"] | 21190
["PHASE_IV_NOT_APPROVED"] | 6673
["PHASE_IV_NOT_APPROVED", "UNVALIDATED_INDICATION"] | 4279
["INDIRECT_PRIMARY_PURPOSE", "UNVALIDATED_INDICATION"] | 3621
["INDIRECT_PRIMARY_PURPOSE", "PHASE_IV_NOT_APPROVED"] | 1577
["INDIRECT_PRIMARY_PURPOSE", "PHASE_IV_NOT_APPROVED", "UNVALIDATED_INDICATION"] | 816
["NO_DISEASE"] | 796
```