### PR TITLE
fix(ot_crispr): study table is now exported in csv

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -625,7 +625,7 @@ steps:
     - name: pyspark ot_crispr
       pyspark: ot_crispr
       source:
-        study_table: input/evidence/ot_crispr/config.tsv
+        study_table: input/evidence/ot_crispr/config.csv
         ot_crispr_data: input/evidence/ot_crispr/data
       destination: intermediate/evidence/ot_crispr.parquet
   ##################################################################################################

--- a/src/pts/pyspark/ot_crispr.py
+++ b/src/pts/pyspark/ot_crispr.py
@@ -419,7 +419,7 @@ def ot_crispr(
     spark = Session(app_name='ot_crispr', properties=properties)
 
     logger.info(f'loading data from: {source}')
-    study_table_df = spark.load_data(source['study_table'], format='csv', header=True, inferSchema=True, sep='\t')
+    study_table_df = spark.load_data(source['study_table'], format='csv', header=True, inferSchema=True, sep=',')
 
     logger.info('parse study study table')
     parsed_studies_df = StudyParser(study_table=study_table_df).process_studies()


### PR DESCRIPTION
Due to the updated way of fetching data from form google spreadsheets, ot_crispr study table is not saved as csv and not tsv. Update was required on how the data is read. 