### PR TITLE
fix(clinical_report): only flag aact studies based on intervention intention

### DIFF
--- a/src/pts/pyspark/clinical_report.py
+++ b/src/pts/pyspark/clinical_report.py
@@ -19,7 +19,7 @@ from clinical_mining.data_sources.pmda import parse_pmda_approvals
 from clinical_mining.data_sources.ttd import extract_clinical_report as extract_ttd_clinical_report
 from clinical_mining.data_sources.ttd import extract_indication as extract_ttd_indication
 from clinical_mining.dataset import ClinicalReport
-from clinical_mining.schemas import ClinicalStageCategory
+from clinical_mining.schemas import ClinicalSource, ClinicalStageCategory
 from clinical_mining.utils.polars_helpers import filter_df, union_dfs
 from clinical_mining.utils.spark_helpers import spark_session
 from loguru import logger
@@ -443,10 +443,11 @@ def flag_indirect_primary_purpose(
     if llm_drug_intent is not None:
         reports_df = reports.df.join(llm_drug_intent, on='id', how='left')
         llm_drug_intent_condition = (
-            # Null drug_intent means the report wasn't in llm results — flag it
-            pl.col('drug_intent').is_null()
+            # Flagging should only act on AACT reports
+            (pl.col('source') == ClinicalSource.AACT.value) &
             # Non-therapeutic intents (supportive_care, prevention, diagnostic, other)
-            | (pl.col('drug_intent') != 'therapeutic')
+            # or when LLM was not able to infer the intent (null)
+            ((pl.col('drug_intent') != 'therapeutic') | pl.col('drug_intent').is_null())
         )
     else:
         reports_df = reports.df

--- a/src/pts/pyspark/drug_utils/labels.py
+++ b/src/pts/pyspark/drug_utils/labels.py
@@ -6,10 +6,11 @@ so they live in a neutral module to avoid an import cycle between the two.
 """
 
 import pyspark.sql.functions as f
+from clinical_mining.schemas import ClinicalSource
 from pyspark.sql.types import ArrayType, StringType, StructField, StructType
 
 CHEMBL_SOURCE = 'ChEMBL'
-AACT_SOURCE = 'AACT'
+AACT_SOURCE = ClinicalSource.AACT.value
 
 LABEL_SOURCE_SCHEMA = ArrayType(
     StructType([

--- a/test/test_clinical_report.py
+++ b/test/test_clinical_report.py
@@ -1,5 +1,6 @@
 import polars as pl
 from clinical_mining.dataset import ClinicalReport
+from clinical_mining.schemas import ClinicalSource
 
 from pts.pyspark.clinical_report import (
     ClinicalReportFlags,
@@ -24,7 +25,7 @@ def _report_entry(report_id: str, disease_struct: dict[str, str | None]) -> dict
         'id': report_id,
         'phaseFromSource': 'black box warning',
         'type': 'CURATED_RESOURCE',
-        'source': 'DailyMed',
+        'source': ClinicalSource.DailyMed.value,
         'year': None,
         'countries': ['United States'],
         'hasExpertReview': True,
@@ -67,12 +68,12 @@ def test_validate_disease_preserves_populated_diseases() -> None:
     ]
 
 
-def _report(id_: str, primary_purpose: str | None = None) -> dict:
+def _report(id_: str, source: str, primary_purpose: str | None = None) -> dict:
     return {
         'id': id_,
         'phaseFromSource': 'phase 3',
         'type': 'CURATED_RESOURCE',
-        'source': 'ClinicalTrials',
+        'source': source,
         'trialPrimaryPurpose': primary_purpose,
         'drugs': [{'drugFromSource': 'BENAZEPRIL', 'drugId': 'CHEMBL1694'}],
         'diseases': [{'diseaseFromSource': 'hypertension', 'diseaseId': 'EFO:0000537'}],
@@ -86,10 +87,10 @@ def _flagged(reports: ClinicalReport, report_id: str) -> bool:
 
 def test_flag_indirect_primary_purpose_device_feasibility() -> None:
     reports = _build_reports([
-        _report('r1', primary_purpose='TREATMENT'),
-        _report('r2', primary_purpose='DEVICE_FEASIBILITY'),
-        _report('r3', primary_purpose='DIAGNOSTIC'),
-        _report('r4', primary_purpose='OTHER'),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
+        _report('r2', ClinicalSource.AACT.value, primary_purpose='DEVICE_FEASIBILITY'),
+        _report('r3', ClinicalSource.AACT.value, primary_purpose='DIAGNOSTIC'),
+        _report('r4', ClinicalSource.AACT.value, primary_purpose='OTHER'),
     ])
     result = flag_indirect_primary_purpose(reports)
     assert not _flagged(result, 'r1')
@@ -101,7 +102,7 @@ def test_flag_indirect_primary_purpose_device_feasibility() -> None:
 def test_flag_indirect_primary_purpose_no_primary_purpose() -> None:
     """Reports without a trialPrimaryPurpose should not be flagged."""
     reports = _build_reports([
-        _report('r1', primary_purpose=None),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose=None),
     ])
     result = flag_indirect_primary_purpose(reports)
     assert not _flagged(result, 'r1')
@@ -110,7 +111,7 @@ def test_flag_indirect_primary_purpose_no_primary_purpose() -> None:
 def test_flag_indirect_primary_purpose_with_llm_no_match_is_flagged() -> None:
     """When llm_batch_results is provided but report has no match, drug_intent is null → flagged."""
     reports = _build_reports([
-        _report('r1', primary_purpose='TREATMENT'),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
     ])
     llm_batch_results = pl.DataFrame({'id': ['r_other'], 'drug_intent': ['therapeutic']})
     result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
@@ -120,7 +121,7 @@ def test_flag_indirect_primary_purpose_with_llm_no_match_is_flagged() -> None:
 def test_flag_indirect_primary_purpose_with_llm_therapeutic_not_flagged() -> None:
     """drug_intent='therapeutic' should not be flagged."""
     reports = _build_reports([
-        _report('r1', primary_purpose='TREATMENT'),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
     ])
     llm_batch_results = pl.DataFrame({'id': ['r1'], 'drug_intent': ['therapeutic']})
     result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
@@ -130,8 +131,8 @@ def test_flag_indirect_primary_purpose_with_llm_therapeutic_not_flagged() -> Non
 def test_flag_indirect_primary_purpose_with_llm_non_therapeutic_flagged() -> None:
     """Non-therapeutic drug_intent values (prevention, supportive_care, etc.) should be flagged."""
     reports = _build_reports([
-        _report('r1', primary_purpose='TREATMENT'),
-        _report('r2', primary_purpose='TREATMENT'),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
+        _report('r2', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
     ])
     llm_batch_results = pl.DataFrame({
         'id': ['r1', 'r2'],
@@ -145,8 +146,25 @@ def test_flag_indirect_primary_purpose_with_llm_non_therapeutic_flagged() -> Non
 def test_flag_indirect_primary_purpose_drops_drug_intent() -> None:
     """The drug_intent column must be dropped from the output."""
     reports = _build_reports([
-        _report('r1', primary_purpose='TREATMENT'),
+        _report('r1', ClinicalSource.AACT.value, primary_purpose='TREATMENT'),
     ])
     llm_batch_results = pl.DataFrame({'id': ['r1'], 'drug_intent': ['therapeutic']})
     result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
     assert 'drug_intent' not in result.df.columns
+
+
+def test_flag_indirect_primary_purpose_non_aact_not_flagged() -> None:
+    """Non-AACT sources should not be flagged based on drug_intent, even if null or non-therapeutic."""
+    reports = _build_reports([
+        _report('r1', ClinicalSource.DailyMed.value, primary_purpose=None),
+        _report('r2', ClinicalSource.DailyMed.value, primary_purpose=None),
+        _report('r3', ClinicalSource.DailyMed.value, primary_purpose=None),
+    ])
+    llm_batch_results = pl.DataFrame({
+        'id': ['r1', 'r2'],
+        'drug_intent': ['therapeutic', 'prevention'],
+    })
+    result = flag_indirect_primary_purpose(reports, llm_drug_intent=llm_batch_results)
+    assert not _flagged(result, 'r1')
+    assert not _flagged(result, 'r2')
+    assert not _flagged(result, 'r3')


### PR DESCRIPTION
The problem: `ClinicalReport.flag_indirect_primary_purpose` was flagging all clinical reports where `drug_intent == null`. 
This is correct for AACT trials, but the function is called on the full set of reports, meaning that all other sources will be flagged as they are not covered by the LLM extraction.

The fix: the flag in `flag_indirect_primary_purpose` is the same, with the additional condition that only AACT reports are checked.


The consequences can be seen downstream in the evidence set:
```
───────────────┬────────┬───────────┬─────────┐
│ clinicalStage ┆ count  ┆ old_count ┆ diff    │
│ ---           ┆ ---    ┆ ---       ┆ ---     │
│ str           ┆ u32    ┆ u32       ┆ i64     │
╞═══════════════╪════════╪═══════════╪═════════╡
│ PHASE_2       ┆ 298610 ┆ 180369    ┆ 118241  │
│ UNKNOWN       ┆ 93148  ┆ 45782     ┆ 47366   │
│ PHASE_1_2     ┆ 69078  ┆ 31743     ┆ 37335   │
│ PHASE_1       ┆ 101779 ┆ 72167     ┆ 29612   │
│ PHASE_3       ┆ 137848 ┆ 118380    ┆ 19468   │
│ PHASE_2_3     ┆ 21917  ┆ 14387     ┆ 7530    │
│ EARLY_PHASE_1 ┆ 11389  ┆ 6919      ┆ 4470    │
│ PHASE_4       ┆ 22899  ┆ 25639     ┆ -2740   │
│ APPROVAL      ┆ 690    ┆ 102184    ┆ -101494 │
└───────────────┴────────┴───────────┴─────────┘`
```
**Note:** even though only `PHASE_4` and `APPROVAL` are the only stages where the difference is negative, this bug is affecting all stages: **we are basically only building indications/evidence based on AACT trials that pass the criteria**. Once the fix is in place, we should see more evidence over the board.

I will put exact numbers once I run it locally.

**Changelog**
- Fix in `flag_indirect_primary_purpose` 
- Added `test_flag_indirect_primary_purpose_non_aact_not_flagged`
- Small fix that involves not hardcoding the clinical source names, and import them from the library instead