### PR TITLE
fix(deps): require ontoma>=2.5.2 (classpath-based Spark NLP check)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
   "obonet>=0.3.1",
   "polars-hash>=0.5.6",
   "torch>=2.10.0",
-  "ontoma>=2.5.1",
+  "ontoma>=2.5.2",
   "ot-literature",
   "transformers>=4.40.0,<5.0.0",
   "gcsfs>=2026.2.0",


### PR DESCRIPTION
## What

Bump the `ontoma` pin to `>=2.5.2`.

## Why

This is the pts half of the fix for opentargets/issues#4453 (PTS Dataproc jobs
re-run Spark-NLP Ivy resolution on every step).

The companion orchestration change (opentargets/orchestration#217) makes the
`pts` / `pts_literature` clusters load Spark-NLP from a pre-resolved fat jar via
`spark.jars` (staged into the pipelines bucket before cluster creation) instead
of `spark.jars.packages`, which triggers Ivy resolution against Maven Central on
**every** `spark-submit`.

`spark.jars` does **not** populate `spark.jars.packages` — and OnToma up to 2.5.1
*guarded* on `spark.jars.packages` containing `'spark-nlp'`, so the ~9 PTS steps
that construct `OnToma` (every `add_efo_mapping` caller + `ontoma_lut_generation`,
plus the literature steps) would have failed to start once the cluster stopped
setting that property.

**OnToma 2.5.2 (opentargets/OnToma#60)** fixes this at the source: it validates
Spark-NLP by probing the JVM classpath for `com.johnsnowlabs.nlp.DocumentAssembler`
rather than inspecting a config string, so it accepts jars loaded via
`spark.jars.packages`, `spark.jars`, **or** a custom image. Requiring `>=2.5.2`
is all pts needs — no application-side workaround.

### Supersedes the earlier approach

This PR previously set `spark.jars.packages` in the app's `SparkConf` (the
Dataproc branch of `Session._create_config`) to satisfy OnToma's old guard
post-SparkSubmit. With the OnToma classpath probe that hack is unnecessary, so
that commit has been dropped and replaced by this dependency bump.

## Coordination / merge order

| Repo | PR | Role |
|---|---|---|
| opentargets/OnToma | opentargets/OnToma#60 | validate Spark-NLP by classpath probe (release **2.5.2**) |
| opentargets/orchestration | opentargets/orchestration#217 | stage the fat jar + point the `pts`/`pts_literature` clusters' `spark.jars` at it |
| **this** (pts) | #146 | require `ontoma>=2.5.2` |

1. Merge & **publish OnToma 2.5.2 to PyPI** (opentargets/OnToma#60).
2. Merge this PR and regenerate `uv.lock` — blocked until 2.5.2 is on PyPI
   (the lockfile still resolves `ontoma==2.5.1`; `uv lock` cannot pick up 2.5.2
   before it is published, so CI's lock-consistency check will fail until then).
3. Ship opentargets/orchestration#217 against a `pts_version` that includes this
   PR, so the OnToma steps never lose Spark-NLP.

## Test

- Behavioural validation on the next Dataproc run (acceptance criteria in
  opentargets/issues#4453): driver logs show no Ivy `:: resolution report ::`
  block, OnToma steps still map diseases, non-OnToma steps start clean.

Refs opentargets/issues#4453
