### PR TITLE
feat(target): extract transcript, safetyLiabilities, tractability, chemicalProbes into standalone steps

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -414,6 +414,18 @@ steps:
         gene_essentiality: output/target_essentiality
   ##################################################################################################
 
+  #: TRANSCRIPT STEP :#################################################################################
+  transcript:
+    - name: pyspark transcript
+      pyspark: transcript
+      settings:
+        partition_count: 2
+      source:
+        gene_code: input/target/gencode/gencode.gff3.gz
+        ensembl: intermediate/target/ensembl/homo_sapiens.parquet
+      destination: output/transcript
+  ##################################################################################################
+
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now
   target_safety:
     - name: pyspark safety

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-work_path: ../pipeline_work
+work_path: /Users/dsuveges/project_data/releases/26.06
 log_level: DEBUG
 pool_size: 4
 
@@ -424,6 +424,19 @@ steps:
         gene_code: input/target/gencode/gencode.gff3.gz
         ensembl: intermediate/target/ensembl/homo_sapiens.parquet
       destination: output/transcript
+  ##################################################################################################
+
+  #: SAFETY_LIABILITY STEP :#############################################################################
+  safety_liability:
+    - name: pyspark safety_liability
+      pyspark: safety_liability
+      settings:
+        partition_count: 2
+      source:
+        safety_evidence: intermediate/target/safety.parquet
+        target: output/target
+        diseases: output/disease
+      destination: output/safety_liability
   ##################################################################################################
 
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now

--- a/config.yaml
+++ b/config.yaml
@@ -439,6 +439,18 @@ steps:
       destination: output/safety_liability
   ##################################################################################################
 
+  #: TARGET_TRACTABILITY STEP :#########################################################################
+  target_tractability:
+    - name: pyspark target_tractability
+      pyspark: target_tractability
+      settings:
+        partition_count: 2
+      source:
+        tractability: input/target/tractability/tractability.tsv
+        target: output/target
+      destination: output/target_tractability
+  ##################################################################################################
+
   #: TARGET_SAFETY STEP :############### - part of target, pyspark tasks must run standalone for now
   target_safety:
     - name: pyspark safety

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-work_path: /Users/dsuveges/project_data/releases/26.06
+work_path: ../pipeline_work
 log_level: DEBUG
 pool_size: 4
 
@@ -280,11 +280,14 @@ steps:
   chemical_probes:
     - name: pyspark chemical probes
       pyspark: chemical_probes
+      settings:
+        partition_count: 2
       source:
         probes_excel: input/target/chemicalprobes/probes.xlsx
         drugs_csv: input/target/chemicalprobes/probes_links.csv
         chembl_molecule: intermediate/chembl_molecule
-      destination: intermediate/chemical_probes_evidence.parquet
+        target: output/target
+      destination: output/chemical_probes
   ##################################################################################################
 
   #: CODING VARIANT STEP :##########################################################################
@@ -407,7 +410,6 @@ steps:
         uniprot: intermediate/target/uniprot/uniprot.parquet
         uniprot_ssl: input/target/uniprot/uniprot-ssl.tsv.gz
         chembl: input/target/chembl/chembl_target.jsonl
-        chemical_probes: intermediate/chemical_probes_evidence.parquet
         gene_essentiality: intermediate/target/gene-essentiality/essentiality.parquet
       destination:
         target: output/target
@@ -730,7 +732,7 @@ steps:
         partition_count: 1
       source:
         molecule: intermediate/chembl_molecule
-        chemical_probes: intermediate/chemical_probes_evidence.parquet
+        chemical_probes: output/chemical_probes
         mechanism_of_action: output/drug_mechanism_of_action
         clinical_report: output/clinical_report
         disease: output/disease

--- a/config.yaml
+++ b/config.yaml
@@ -386,7 +386,6 @@ steps:
           target: 3
           gene_essentiality: 4
       source:
-        diseases: output/disease
         ensembl: intermediate/target/ensembl/homo_sapiens.parquet
         gene_code: input/target/gencode/gencode.gff3.gz
         genetic_constraints: input/target/gnomad/gnomad_constraint_metrics.tsv
@@ -404,9 +403,7 @@ steps:
         ncbi: input/target/ncbi/Homo_sapiens.gene_info.gz
         reactome_etl: output/reactome
         reactome_pathways: input/target/reactome/Ensembl2Reactome.txt
-        safety_evidence: intermediate/target/safety.parquet
         tep: input/target/tep/tep.json.gz
-        tractability: input/target/tractability/tractability.tsv
         uniprot: intermediate/target/uniprot/uniprot.parquet
         uniprot_ssl: input/target/uniprot/uniprot-ssl.tsv.gz
         chembl: input/target/chembl/chembl_target.jsonl

--- a/src/pts/pyspark/chemical_probes.py
+++ b/src/pts/pyspark/chemical_probes.py
@@ -1,4 +1,11 @@
-"""Parser to process chemical probes data and generate evidence."""
+"""Chemical probes dataset generation.
+
+Processes the Open Targets chemical probes Excel/CSV sources, resolves gene
+symbols to ENSG IDs via output/target, and produces a flat per-probe index
+validated against the target universe.
+"""
+
+from __future__ import annotations
 
 from typing import Any
 
@@ -8,6 +15,7 @@ from pyspark.sql import functions as f
 from pyspark.sql import types as t
 
 from pts.pyspark.common import Session
+from pts.pyspark.common.utils import maybe_coalesce
 
 # Chemical probe data sources
 PROBES_SETS = [
@@ -38,32 +46,86 @@ def chemical_probes(
     settings: dict[str, Any],
     properties: dict[str, str],
 ) -> None:
-    """Process chemical probes data and generate evidence."""
-    # Starting spark session
+    """Process chemical probes data, resolve target IDs, and write the output dataset.
+
+    Parses the chemical probes Excel/CSV sources, resolves gene symbols/UniProt
+    accessions to ENSG IDs via output/target, drops probes that cannot be mapped,
+    and writes a flat per-probe parquet to the destination.
+
+    Args:
+        source: Mapping with keys ``probes_excel``, ``drugs_csv``,
+            ``chembl_molecule``, and ``target`` (output/target parquet for
+            ENSG ID resolution and validation).
+        destination: Output path for the chemical probes parquet dataset.
+        settings: Step settings; supports ``partition_count`` (int, default 2).
+        properties: Spark properties passed to :class:`Session`.
+    """
     session = Session(app_name='chemical_probes', properties=properties)
 
-    # Extract input dataset locations from config
-    probes_excel = source['probes_excel']
-    drugs_csv = source['drugs_csv']
-    chembl_molecule_path = source['chembl_molecule']
+    chembl_molecule_df = session.load_data(source['chembl_molecule'])
+    target_df = session.spark.read.parquet(source['target'])
 
-    # Load ChEMBL molecule data for drug ID validation
-    chembl_molecule_df = session.load_data(chembl_molecule_path)
+    probes_data = process_probes_data(session.spark, source['probes_excel'])
+    probes_targets_data = process_probes_targets_data(session.spark, source['probes_excel'])
+    probes_sets_data = process_probes_sets_data(session.spark, source['probes_excel'])
+    targets_xref_data = process_targets_xrefs(session.spark, source['probes_excel'])
+    drugs_xref_data = process_drugs_xrefs(session.spark, source['drugs_csv'], chembl_molecule_df)
 
-    # Process chemical probes data from Excel and CSV files
-    probes_data = process_probes_data(session.spark, probes_excel)
-    probes_targets_data = process_probes_targets_data(session.spark, probes_excel)
-    probes_sets_data = process_probes_sets_data(session.spark, probes_excel)
-    targets_xref_data = process_targets_xrefs(session.spark, probes_excel)
-    drugs_xref_data = process_drugs_xrefs(session.spark, drugs_csv, chembl_molecule_df)
-
-    # Generate evidence from chemical probes
     evidence = generate_chemical_probes_evidence(
         session.spark, probes_data, probes_targets_data, probes_sets_data, targets_xref_data, drugs_xref_data
     )
 
-    # Write the final evidence dataset
-    evidence.write.mode('overwrite').parquet(destination)
+    ensg_lookup = _build_ensg_lookup(target_df)
+    result = _resolve_targets(evidence, ensg_lookup)
+
+    partition_count = (settings or {}).get('partition_count', 2)
+    maybe_coalesce(result, partition_count).write.mode('overwrite').parquet(destination)
+
+
+def _build_ensg_lookup(target_df: DataFrame) -> DataFrame:
+    """Build a symbol/proteinId → ENSG ID lookup from the target dataset.
+
+    Args:
+        target_df: Target parquet from ``output/target``.
+
+    Returns:
+        DataFrame with columns ``ensgId`` and ``name``
+        (``array<str>`` of protein accessions and approved symbol).
+    """
+    return target_df.select(
+        f.col('id').alias('ensgId'),
+        f.flatten(f.array(
+            f.col('proteinIds.id'),
+            f.array(f.col('approvedSymbol')),
+        )).alias('name'),
+    )
+
+
+def _resolve_targets(evidence: DataFrame, ensg_lookup: DataFrame) -> DataFrame:
+    """Resolve targetFromSourceId to ENSG IDs.
+
+    Rows with no matching ENSG are kept with a null ``targetId``: the
+    drug/probe fields on this dataset (``drugId``, ``drugFromSourceId``) are
+    consumed independently of target resolution by ``drug_molecule``, so
+    dropping unresolvable rows here would silently shrink that dataset too.
+    Consumers that join on ``targetId`` (e.g. ``target.py``) naturally
+    exclude null-targetId rows since they match no real target id.
+
+    Args:
+        evidence: Chemical probes evidence DataFrame from
+            :func:`generate_chemical_probes_evidence`.
+        ensg_lookup: ENSG lookup from :func:`_build_ensg_lookup`.
+
+    Returns:
+        DataFrame with ``targetId`` column added (nullable) and
+        ``targetFromSourceId`` retained.
+    """
+    return (
+        evidence
+        .join(ensg_lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')), 'left_outer')
+        .drop('name')
+        .withColumnRenamed('ensgId', 'targetId')
+    )
 
 
 def collapse_cols_data_in_array(df: DataFrame, source_cols: list[str], destination_col: str) -> DataFrame:

--- a/src/pts/pyspark/safety_liability.py
+++ b/src/pts/pyspark/safety_liability.py
@@ -1,0 +1,142 @@
+"""Safety liability dataset generation.
+
+Produces a per-target safety liability index by joining the pre-processed safety
+evidence parquet (from pts_target_safety) with output/target for ENSG ID
+resolution and output/disease for obsolete EFO term remapping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame
+
+from pts.pyspark.common.session import Session
+from pts.pyspark.common.utils import maybe_coalesce
+
+
+def safety_liability(
+    source: dict[str, str],
+    destination: str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate the safety liability dataset.
+
+    Resolves ENSG IDs for symbol-keyed entries (ToxCast), remaps obsolete EFO
+    disease terms to their current equivalents, and groups safety evidence by
+    target into a ``safetyLiabilities`` array.
+
+    Args:
+        source: Mapping of logical input names to paths. Expected keys:
+            ``safety_evidence`` (intermediate safety parquet from pts_target_safety),
+            ``target`` (output/target parquet), and ``diseases`` (output/disease parquet).
+        destination: Output path for the safety liability parquet dataset.
+        settings: Step settings; supports ``partition_count`` (int, default 2).
+        properties: Spark session properties passed to :class:`Session`.
+    """
+    spark = Session(app_name='safety_liability', properties=properties).spark
+
+    safety_raw = spark.read.parquet(source['safety_evidence'])
+    target_raw = spark.read.parquet(source['target'])
+    diseases_raw = spark.read.parquet(source['diseases'])
+
+    ensg_lookup = _build_ensg_lookup(target_raw)
+    result = _build_safety_liabilities(safety_raw, ensg_lookup, diseases_raw)
+
+    partition_count = (settings or {}).get('partition_count', 2)
+    logger.info(f'writing safety liability to {destination} ({partition_count} partitions)')
+    maybe_coalesce(result, partition_count).write.mode('overwrite').parquet(destination)
+
+
+def _build_ensg_lookup(target_df: DataFrame) -> DataFrame:
+    """Build a symbol/proteinId → ENSG ID lookup from the target dataset.
+
+    ToxCast safety entries carry only a gene symbol or protein accession in
+    ``targetFromSourceId`` rather than an ENSG ID. This lookup enables resolving
+    those entries to their canonical ENSG ID.
+
+    Args:
+        target_df: Target parquet from ``output/target``.
+
+    Returns:
+        DataFrame with columns ``ensgId`` and ``name``
+        (``array<str>`` of protein accessions and approved symbol).
+    """
+    return (
+        target_df
+        .select(
+            f.col('id').alias('ensgId'),
+            f.flatten(f.array(
+                f.col('proteinIds.id'),
+                f.array(f.col('approvedSymbol')),
+            )).alias('name'),
+        )
+    )
+
+
+def _build_safety_liabilities(
+    safety_df: DataFrame,
+    ensg_lookup: DataFrame,
+    diseases_df: DataFrame,
+) -> DataFrame:
+    """Build the safety liability output from pre-processed safety evidence.
+
+    Resolves missing ENSG IDs via symbol/protein lookup and replaces obsolete
+    EFO disease terms with their current equivalents before grouping into the
+    per-target ``safetyLiabilities`` array.
+
+    Args:
+        safety_df: Pre-processed safety evidence parquet (from pts_target_safety).
+        ensg_lookup: ENSG lookup from :func:`_build_ensg_lookup`.
+        diseases_df: Disease index parquet from ``output/disease``.
+
+    Returns:
+        DataFrame with columns ``targetId`` and ``safetyLiabilities``.
+    """
+    # Resolve ENSG IDs for symbol-keyed entries (ToxCast provides targetFromSourceId)
+    enriched = (
+        safety_df
+        .join(ensg_lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')), 'left_outer')
+        .drop(*[c for c in ensg_lookup.columns if c != 'ensgId'])
+        .withColumn('id', f.coalesce(f.col('id'), f.col('ensgId')))
+        .drop('ensgId')
+    )
+
+    # Remap obsolete EFO terms to their current equivalents
+    disease_mapping = (
+        diseases_df
+        .select(
+            f.col('id').alias('diseaseId'),
+            f.explode(f.col('obsoleteTerms')).alias('obsoleteTerm'),
+        )
+    )
+
+    enriched = (
+        enriched
+        .join(disease_mapping, enriched['eventId'] == disease_mapping['obsoleteTerm'], 'left_outer')
+        .withColumn('eventId', f.coalesce(f.col('diseaseId'), f.col('eventId')))
+        .drop('obsoleteTerm', 'diseaseId')
+    )
+
+    return (
+        enriched
+        .filter(f.col('id').isNotNull())
+        .select(
+            f.col('id').alias('targetId'),
+            f.struct(
+                'event',
+                'eventId',
+                'effects',
+                'biosamples',
+                'datasource',
+                'literature',
+                'url',
+                'studies',
+            ).alias('liability'),
+        )
+        .groupBy('targetId')
+        .agg(f.collect_set('liability').alias('safetyLiabilities'))
+    )

--- a/src/pts/pyspark/safety_liability.py
+++ b/src/pts/pyspark/safety_liability.py
@@ -94,7 +94,9 @@ def _build_safety_liabilities(
         diseases_df: Disease index parquet from ``output/disease``.
 
     Returns:
-        DataFrame with columns ``targetId`` and ``safetyLiabilities``.
+        DataFrame with one row per safety liability record and columns
+        ``targetId``, ``event``, ``eventId``, ``effects``, ``biosamples``,
+        ``datasource``, ``literature``, ``url``, ``studies``.
     """
     # Resolve ENSG IDs for symbol-keyed entries (ToxCast provides targetFromSourceId)
     enriched = (
@@ -114,29 +116,21 @@ def _build_safety_liabilities(
         )
     )
 
-    enriched = (
+    return (
         enriched
         .join(disease_mapping, enriched['eventId'] == disease_mapping['obsoleteTerm'], 'left_outer')
         .withColumn('eventId', f.coalesce(f.col('diseaseId'), f.col('eventId')))
         .drop('obsoleteTerm', 'diseaseId')
-    )
-
-    return (
-        enriched
         .filter(f.col('id').isNotNull())
         .select(
             f.col('id').alias('targetId'),
-            f.struct(
-                'event',
-                'eventId',
-                'effects',
-                'biosamples',
-                'datasource',
-                'literature',
-                'url',
-                'studies',
-            ).alias('liability'),
+            'event',
+            'eventId',
+            'effects',
+            'biosamples',
+            'datasource',
+            'literature',
+            'url',
+            'studies',
         )
-        .groupBy('targetId')
-        .agg(f.collect_set('liability').alias('safetyLiabilities'))
     )

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -66,7 +66,6 @@ REQUIRED_OUTPUT_COLUMNS = {
     'subcellularLocations',
     'targetClass',
     'hallmarks',
-    'chemicalProbes',
     'tep',
     'synonyms',
     'symbolSynonyms',
@@ -161,7 +160,6 @@ def target(
     tractability_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['tractability'])
     safety_raw = spark.read.parquet(source['safety_evidence'])
     diseases_raw = spark.read.parquet(source['diseases'])
-    chemical_probes_raw = spark.read.parquet(source['chemical_probes'])
     gene_essentiality_raw = spark.read.parquet(source['gene_essentiality'])
 
     # Uniprot is a gzipped XML flat-file — we read a pre-processed parquet
@@ -304,7 +302,6 @@ def target(
         .transform(lambda df: _add_tep(df, tep_df, ensg_lookup))
         .transform(_filter_and_sort_protein_ids)
         .transform(_remove_redundant_xrefs)
-        .transform(lambda df: _add_chemical_probes(df, chemical_probes_raw, ensg_lookup))
         .transform(lambda df: _add_orthologues(df, homology_df))
         .transform(lambda df: _add_tractability(df, tractability_df))
         .transform(lambda df: _add_ncbi_synonyms(df, ncbi_df))
@@ -1900,26 +1897,6 @@ def _remove_redundant_xrefs(df: DataFrame) -> DataFrame:
     cols = [c for c in df.columns if c != 'dbXrefs']
     cols.append("filter(dbXrefs, s -> s.source != 'GO' and s.source != 'Ensembl') as dbXrefs")
     return df.selectExpr(*cols)
-
-
-def _add_chemical_probes(df: DataFrame, cp_df: DataFrame, lookup: DataFrame) -> DataFrame:
-    """Join chemical probes using symbol lookup."""
-    cp_with_id = cp_df.join(lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId'))).drop(*[
-        c for c in lookup.columns if c != 'ensgId'
-    ])
-
-    cp_cols = [c for c in cp_df.columns if c != 'ensgId']
-    cp_grouped = (
-        cp_with_id
-        .select(
-            f.col('ensgId').alias('id'),
-            f.struct(*cp_cols).alias('probe'),
-        )
-        .groupBy('id')
-        .agg(f.collect_list('probe').alias('chemicalProbes'))
-    )
-
-    return df.join(f.broadcast(cp_grouped), 'id', 'left_outer')
 
 
 def _add_orthologues(df: DataFrame, orthologs: DataFrame) -> DataFrame:

--- a/src/pts/pyspark/target.py
+++ b/src/pts/pyspark/target.py
@@ -16,9 +16,7 @@ Scala sources ported:
     - Ortholog.scala
     - ProteinClassification.scala
     - Reactome.scala
-    - Safety.scala
     - Tep.scala
-    - Tractability.scala
     - Uniprot.scala
 """
 
@@ -31,7 +29,6 @@ from loguru import logger
 from pyspark.sql import DataFrame
 from pyspark.sql.types import (
     ArrayType,
-    BooleanType,
     DoubleType,
     FloatType,
     IntegerType,
@@ -53,15 +50,10 @@ REQUIRED_OUTPUT_COLUMNS = {
     'approvedSymbol',
     'approvedName',
     'biotype',
-    'transcripts',
-    'transcriptIds',
-    'canonicalExons',
     'genomicLocation',
     'pathways',
     'go',
     'constraint',
-    'safety',
-    'tractability',
     'homologues',
     'subcellularLocations',
     'targetClass',
@@ -73,10 +65,8 @@ REQUIRED_OUTPUT_COLUMNS = {
     'functionDescriptions',
     'proteinIds',
     'dbXrefs',
-    'alternativeGenes',
     'obsoleteSymbols',
     'obsoleteNames',
-    'canonicalTranscript',
     'tss',
 }
 
@@ -157,9 +147,6 @@ def target(
     )
     reactome_pathways_raw = spark.read.option('sep', '\t').csv(source['reactome_pathways'])
     reactome_etl_raw = spark.read.parquet(source['reactome_etl'])
-    tractability_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['tractability'])
-    safety_raw = spark.read.parquet(source['safety_evidence'])
-    diseases_raw = spark.read.parquet(source['diseases'])
     gene_essentiality_raw = spark.read.parquet(source['gene_essentiality'])
 
     # Uniprot is a gzipped XML flat-file — we read a pre-processed parquet
@@ -229,9 +216,6 @@ def target(
 
     logger.info('Building Reactome')
     reactome_df = _build_reactome(reactome_pathways_raw, reactome_etl_raw)
-
-    logger.info('Building Tractability')
-    tractability_df = _build_tractability(tractability_raw)
 
     # --- Uniprot (pre-processed parquet schema mirrors UniprotEntry) --------
     logger.info('Building Uniprot')
@@ -303,9 +287,7 @@ def target(
         .transform(_filter_and_sort_protein_ids)
         .transform(_remove_redundant_xrefs)
         .transform(lambda df: _add_orthologues(df, homology_df))
-        .transform(lambda df: _add_tractability(df, tractability_df))
         .transform(lambda df: _add_ncbi_synonyms(df, ncbi_df))
-        .transform(lambda df: _add_target_safety(df, safety_raw, ensg_lookup, diseases_raw))
         .transform(lambda df: _add_reactome(df, reactome_df))
         .transform(_remove_duplicated_synonyms)
         .transform(_add_tss)
@@ -396,7 +378,8 @@ def _filter_ensembl(df: DataFrame) -> DataFrame:
 def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
     """Build the Ensembl gene DataFrame.
 
-    Applies canonical chromosome filter, joins canonical transcript from GeneCode,
+    Applies canonical chromosome filter, joins canonical transcript from GeneCode
+    (kept internally to derive ``tss``, dropped from the final target output),
     parses protein IDs and signalP, and deduplicates by id.
 
     Args:
@@ -420,17 +403,6 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
             f.col('strand').cast(IntegerType()).alias('strand'),
             f.col('chromosome'),
             f.col('approvedSymbol'),
-            (
-                f.col('transcripts')
-                if has_transcripts
-                else f.lit(None).cast(ArrayType(StructType([StructField('id', StringType())])))
-            ).alias('transcripts_raw'),
-            # transcriptIds: flat array of transcript IDs (Ensembl.scala line 45)
-            (f.col('transcripts.id') if has_transcripts else f.lit(None).cast(ArrayType(StringType()))).alias(
-                'transcriptIds'
-            ),
-            # exons: per-transcript exon arrays for canonicalExons computation
-            (f.col('transcripts.exons') if has_transcripts else f.lit(None)).alias('exons_raw'),
             # translations: flatten transcripts[*].translations[*] into a top-level array
             # so _refactor_ensembl_protein_ids can build ensembl_PRO protein IDs
             (f.flatten(f.col('transcripts.translations')) if has_transcripts else f.lit(None)).alias('translations'),
@@ -442,7 +414,7 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
         .dropDuplicates(['id'])
     )
 
-    # Join canonical transcript
+    # Join canonical transcript (kept internally for tss; dropped from final output)
     ensembl = ensembl.join(
         gene_code.withColumnRenamed('gene_id', 'ct_gene_id'),
         (ensembl['id'] == f.col('ct_gene_id')) & (ensembl['chromosome'] == f.col('canonicalTranscript.chromosome')),
@@ -489,57 +461,20 @@ def _build_ensembl(df: DataFrame, gene_code: DataFrame) -> DataFrame:
         ).cast(id_source_schema),
     )
 
-    # Build canonicalExons: flat array of (start, end) pairs for the canonical transcript
-    # Mirrors addCanonicalExons in Ensembl.scala
-    # Use expr because array_position(col, col) requires SQL expression syntax in PySpark
-    ensembl = ensembl.withColumn(
-        'exonIndex',
-        f.expr('array_position(transcriptIds, canonicalTranscript.id)'),
-    )
-    ensembl = ensembl.withColumn(
-        '_canon_exons_raw',
-        f.when(
-            f.col('exonIndex') > 0,
-            f.element_at(f.col('exons_raw'), f.col('exonIndex').cast(IntegerType())),
-        ),
-    )
-    ensembl = ensembl.withColumn(
-        'canonicalExons',
-        f.when(
-            f.col('_canon_exons_raw').isNotNull(),
-            f.flatten(
-                f.transform(
-                    f.col('_canon_exons_raw'),
-                    lambda x: f.array(x.getField('start'), x.getField('end')),
-                )
-            ),
-        ),
-    ).drop('exonIndex', 'exons_raw', '_canon_exons_raw')
-
-    # Parse transcripts into the structured format (also sets isEnsemblCanonical)
-    ensembl = _parse_ensembl_transcripts(ensembl)
-
     return ensembl.select(
         'id',
         'biotype',
         'approvedName',
-        'alternativeGenes',
         'genomicLocation',
         'approvedSymbol',
         'proteinIds',
-        'transcriptIds',
-        'canonicalExons',
-        'transcripts',
         'signalP',
         'canonicalTranscript',
     )
 
 
 def _refactor_ensembl_protein_ids(df: DataFrame) -> DataFrame:
-    """Build proteinIds from uniprot_swissprot, uniprot_trembl columns.
-
-    Also sets alternativeGenes to null (filled later).
-    """
+    """Build proteinIds from uniprot_swissprot, uniprot_trembl columns."""
     id_source_schema = ArrayType(
         StructType([
             StructField('id', StringType()),
@@ -588,66 +523,7 @@ def _refactor_ensembl_protein_ids(df: DataFrame) -> DataFrame:
         protein_ids = _safe_array_union(f.col('_swiss'), f.col('_trembl'))
         df = df.withColumn('proteinIds', protein_ids).drop('_swiss', '_trembl', 'uniprot_swissprot', 'uniprot_trembl')
 
-    return df.withColumn('alternativeGenes', f.lit(None).cast(ArrayType(StringType())))
-
-
-def _parse_ensembl_transcripts(df: DataFrame) -> DataFrame:
-    """Parse raw transcripts array into structured transcript objects."""
-    transcript_schema = ArrayType(
-        StructType([
-            StructField('transcriptId', StringType()),
-            StructField('biotype', StringType()),
-            StructField('uniprotId', StringType()),
-            StructField('isUniprotReviewed', BooleanType()),
-            StructField('translationId', StringType()),
-            StructField('alphafoldId', StringType()),
-            StructField('uniprotIsoformId', StringType()),
-            StructField('isEnsemblCanonical', BooleanType()),
-        ])
-    )
-
-    if 'transcripts_raw' not in df.columns:
-        return df.withColumn('transcripts', f.lit(None).cast(transcript_schema))
-
-    canon_id = f.col('canonicalTranscript.id')
-
-    parsed = f.when(
-        f.col('transcripts_raw').isNotNull(),
-        f.transform(
-            f.col('transcripts_raw'),
-            lambda tr: f.struct(
-                tr.getField('id').alias('transcriptId'),
-                tr.getField('biotype').alias('biotype'),
-                f
-                .when(tr.getField('uniprot_swissprot').isNotNull(), f.element_at(tr.getField('uniprot_swissprot'), 1))
-                .when(tr.getField('uniprot_trembl').isNotNull(), f.element_at(tr.getField('uniprot_trembl'), 1))
-                .alias('uniprotId'),
-                f
-                .when(tr.getField('uniprot_swissprot').isNotNull(), f.lit(True))
-                .when(tr.getField('uniprot_trembl').isNotNull(), f.lit(False))
-                .alias('isUniprotReviewed'),
-                f.when(
-                    tr.getField('translations').isNotNull(),
-                    f.element_at(tr.getField('translations'), 1).getField('id'),
-                ).alias('translationId'),
-                f.when(
-                    tr.getField('alphafold').isNotNull(),
-                    f.element_at(tr.getField('alphafold'), 1),
-                ).alias('alphafoldId'),
-                f.when(
-                    tr.getField('uniprot_isoform').isNotNull(),
-                    f.element_at(tr.getField('uniprot_isoform'), 1),
-                ).alias('uniprotIsoformId'),
-                # isEnsemblCanonical: true when this transcript is the canonical one
-                f
-                .when(canon_id.isNotNull(), tr.getField('id') == canon_id)
-                .cast(BooleanType())
-                .alias('isEnsemblCanonical'),
-            ),
-        ),
-    ).cast(transcript_schema)
-
-    return df.withColumn('transcripts', parsed).drop('transcripts_raw')
+    return df
 
 
 # ===========================================================================
@@ -1369,43 +1245,6 @@ def _build_reactome(reactome_pathways: DataFrame, reactome_etl: DataFrame) -> Da
 
 
 # ===========================================================================
-# Tractability.scala → _build_tractability
-# ===========================================================================
-
-
-def _build_tractability(df: DataFrame) -> DataFrame:
-    """Build tractability assessments.
-
-    Args:
-        df: Raw tractability TSV. Columns with pattern *_B{N}_* are tractability buckets.
-
-    Returns:
-        DataFrame with [ensemblGeneId, tractability[{modality, id, value}]].
-    """
-    import re
-
-    bucket_cols = [c for c in df.columns if re.match(r'.*_B\d+_.*', c)]
-    tractability = df.select('ensembl_gene_id', *bucket_cols)
-    data_cols = [c for c in tractability.columns if c != 'ensembl_gene_id']
-
-    for col_name in data_cols:
-        parts = col_name.split('_')
-        tractability = tractability.withColumn(
-            col_name,
-            f.struct(
-                f.lit(parts[0]).alias('modality'),
-                f.lit(parts[-1]).alias('id'),
-                f.when(f.col(f'`{col_name}`') == 1, True).otherwise(False).alias('value'),
-            ),
-        )
-
-    return tractability.select(
-        f.col('ensembl_gene_id').alias('ensemblGeneId'),
-        f.array(*data_cols).alias('tractability'),
-    )
-
-
-# ===========================================================================
 # Uniprot (pre-processed parquet) → _build_uniprot
 # ===========================================================================
 
@@ -1545,68 +1384,6 @@ def _map_uniprot_locations_to_ssl(df: DataFrame, ssl_df: DataFrame) -> DataFrame
     )
 
     return df.drop('locations').join(loc_df, 'uniprotId', 'left_outer')
-
-
-# ===========================================================================
-# Safety.scala → _build_safety
-# ===========================================================================
-
-
-def _build_safety(
-    safety_df: DataFrame,
-    ensg_lookup: DataFrame,
-    diseases_df: DataFrame,
-) -> DataFrame:
-    """Build target safety liabilities.
-
-    Args:
-        safety_df: Pre-processed safety evidence parquet.
-        ensg_lookup: ENSG ID lookup table (ensgId, name array).
-        diseases_df: Disease index (id, obsoleteTerms).
-
-    Returns:
-        DataFrame with [id, safetyLiabilities[{event, eventId, effects, ...}]].
-    """
-    # Add missing ENSG IDs for entries that only have symbol (e.g. ToxCast)
-    enriched = (
-        safety_df
-        .join(ensg_lookup, f.array_contains(f.col('name'), f.col('targetFromSourceId')), 'left_outer')
-        .drop(*[c for c in ensg_lookup.columns if c != 'ensgId'])
-        .withColumn('temp_id', f.coalesce(f.col('id'), f.col('ensgId')))
-        .drop('id', 'ensgId')
-        .withColumnRenamed('temp_id', 'id')
-    )
-
-    # Replace obsolete EFOs
-    disease_mapping = diseases_df.select(
-        f.col('id').alias('diseaseId'), f.explode(f.col('obsoleteTerms')).alias('obsoleteTerm')
-    )
-
-    enriched = (
-        enriched
-        .join(disease_mapping, enriched['eventId'] == disease_mapping['obsoleteTerm'], 'left_outer')
-        .withColumn('eventId', f.coalesce(f.col('diseaseId'), f.col('eventId')))
-        .drop('obsoleteTerm', 'diseaseId')
-    )
-
-    return (
-        enriched
-        .select(
-            'id',
-            f.struct(
-                'event',
-                'eventId',
-                'effects',
-                'biosamples',
-                'datasource',
-                'literature',
-                'url',
-                'studies',
-            ).alias('safety'),
-        )
-        .groupBy('id')
-        .agg(f.collect_set('safety').alias('safetyLiabilities'))
-    )
 
 
 # ===========================================================================
@@ -1935,11 +1712,6 @@ def _add_orthologues(df: DataFrame, orthologs: DataFrame) -> DataFrame:
     return df.join(grouped, 'id', 'left_outer').drop('humanGeneId')
 
 
-def _add_tractability(df: DataFrame, tractability: DataFrame) -> DataFrame:
-    """Join tractability data."""
-    return df.join(tractability, f.col('ensemblGeneId') == f.col('id'), 'left_outer').drop('ensemblGeneId')
-
-
 def _add_ncbi_synonyms(df: DataFrame, ncbi: DataFrame) -> DataFrame:
     """Add NCBI Entrez synonyms."""
     ncbi_renamed = (
@@ -1959,17 +1731,6 @@ def _add_ncbi_synonyms(df: DataFrame, ncbi: DataFrame) -> DataFrame:
     )
 
 
-def _add_target_safety(
-    df: DataFrame,
-    safety_raw: DataFrame,
-    ensg_lookup: DataFrame,
-    diseases_df: DataFrame,
-) -> DataFrame:
-    """Add target safety liabilities."""
-    safety = _build_safety(safety_raw, ensg_lookup, diseases_df)
-    return df.join(safety, 'id', 'left_outer')
-
-
 def _add_reactome(df: DataFrame, reactome: DataFrame) -> DataFrame:
     """Add Reactome pathways."""
     return df.join(reactome, 'id', 'left_outer')
@@ -1984,10 +1745,10 @@ def _remove_duplicated_synonyms(df: DataFrame) -> DataFrame:
 
 
 def _add_tss(df: DataFrame) -> DataFrame:
-    """Add transcription start site column."""
+    """Add transcription start site column and drop the now-unneeded canonicalTranscript struct."""
     return df.withColumn(
         'tss',
         f.when(f.col('canonicalTranscript.strand') == '+', f.col('canonicalTranscript.start')).when(
             f.col('canonicalTranscript.strand') == '-', f.col('canonicalTranscript.end')
         ),
-    )
+    ).drop('canonicalTranscript')

--- a/src/pts/pyspark/target_tractability.py
+++ b/src/pts/pyspark/target_tractability.py
@@ -1,0 +1,90 @@
+"""Target tractability dataset generation.
+
+Processes the Open Targets tractability TSV and produces per-target
+tractability bucket assessments across small molecule, antibody, and
+other modalities. Only targets present in output/target are retained.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import DataFrame
+
+from pts.pyspark.common.session import Session
+from pts.pyspark.common.utils import maybe_coalesce
+
+
+def target_tractability(
+    source: dict[str, str],
+    destination: str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Build tractability assessments and write the output dataset.
+
+    Args:
+        source: Mapping with keys ``tractability`` (TSV) and ``target``
+            (output/target parquet used for ID validation).
+        destination: Output path for the tractability parquet.
+        settings: Step settings; supports ``partition_count`` (int, default 2).
+        properties: Spark properties passed to :class:`Session`.
+    """
+    spark = Session(app_name='target_tractability', properties=properties).spark
+
+    logger.info('Reading tractability TSV')
+    tractability_raw = spark.read.option('sep', '\t').option('header', 'true').csv(source['tractability'])
+
+    logger.info('Reading target IDs for validation')
+    target_ids = spark.read.parquet(source['target']).select('id')
+
+    logger.info('Building tractability assessments')
+    result = _build_tractability(tractability_raw, target_ids)
+
+    partition_count = (settings or {}).get('partition_count', 2)
+    logger.info(f'Writing target_tractability to {destination} ({partition_count} partitions)')
+    maybe_coalesce(result, partition_count).write.mode('overwrite').parquet(destination)
+
+
+def _build_tractability(df: DataFrame, target_ids: DataFrame) -> DataFrame:
+    """Build tractability assessments from the tractability TSV.
+
+    Columns matching the pattern ``*_B{N}_*`` are tractability bucket columns.
+    Rows whose ``ensembl_gene_id`` is not present in the target universe are
+    dropped.
+
+    Args:
+        df: Raw tractability TSV DataFrame.
+        target_ids: DataFrame with a single ``id`` column from output/target.
+
+    Returns:
+        DataFrame with columns ``targetId`` and
+        ``tractability`` (``array<struct<modality, id, value>>``).
+    """
+    bucket_cols = [c for c in df.columns if re.match(r'.*_B\d+_.*', c)]
+    tractability = df.select('ensembl_gene_id', *bucket_cols)
+    data_cols = [c for c in tractability.columns if c != 'ensembl_gene_id']
+
+    for col_name in data_cols:
+        parts = col_name.split('_')
+        tractability = tractability.withColumn(
+            col_name,
+            f.struct(
+                f.lit(parts[0]).alias('modality'),
+                f.lit(parts[-1]).alias('id'),
+                f.when(f.col(f'`{col_name}`') == 1, True).otherwise(False).alias('value'),
+            ),
+        )
+
+    return (
+        tractability
+        .select(
+            f.col('ensembl_gene_id').alias('targetId'),
+            f.array(*data_cols).alias('tractability'),
+        )
+        .join(target_ids, f.col('targetId') == f.col('id'), 'inner')
+        .drop('id')
+    )

--- a/src/pts/pyspark/target_tractability.py
+++ b/src/pts/pyspark/target_tractability.py
@@ -1,8 +1,9 @@
 """Target tractability dataset generation.
 
-Processes the Open Targets tractability TSV and produces per-target
-tractability bucket assessments across small molecule, antibody, and
-other modalities. Only targets present in output/target are retained.
+Processes the Open Targets tractability TSV and produces one row per
+tractability bucket assessment (flat schema) across small molecule,
+antibody, and other modalities. Only targets present in output/target are
+retained.
 """
 
 from __future__ import annotations
@@ -61,8 +62,8 @@ def _build_tractability(df: DataFrame, target_ids: DataFrame) -> DataFrame:
         target_ids: DataFrame with a single ``id`` column from output/target.
 
     Returns:
-        DataFrame with columns ``targetId`` and
-        ``tractability`` (``array<struct<modality, id, value>>``).
+        DataFrame with one row per tractability assessment and columns
+        ``targetId``, ``modality``, ``id``, ``value``.
     """
     bucket_cols = [c for c in df.columns if re.match(r'.*_B\d+_.*', c)]
     tractability = df.select('ensembl_gene_id', *bucket_cols)
@@ -87,4 +88,6 @@ def _build_tractability(df: DataFrame, target_ids: DataFrame) -> DataFrame:
         )
         .join(target_ids, f.col('targetId') == f.col('id'), 'inner')
         .drop('id')
+        .select('targetId', f.explode('tractability').alias('assessment'))
+        .select('targetId', 'assessment.modality', 'assessment.id', 'assessment.value')
     )

--- a/src/pts/pyspark/transcript.py
+++ b/src/pts/pyspark/transcript.py
@@ -1,0 +1,213 @@
+"""Transcript index dataset generation.
+
+Produces a per-transcript index by joining GeneCode GFF3 coordinates with
+per-transcript UniProt IDs from the Ensembl parquet produced by pts_pre_target.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pyspark.sql.functions as f
+from loguru import logger
+from pyspark.sql import Column, DataFrame
+from pyspark.sql.types import IntegerType, LongType
+
+from pts.pyspark.common.session import Session
+from pts.pyspark.common.utils import maybe_coalesce, safe_array_union
+
+INCLUDE_CHROMOSOMES = [str(i) for i in range(1, 23)] + ['X', 'Y', 'MT']
+
+
+def transcript(
+    source: dict[str, str],
+    destination: str,
+    settings: dict[str, Any],
+    properties: dict[str, str],
+) -> None:
+    """Generate the transcript index dataset.
+
+    Combines GeneCode GFF3 and Ensembl parquet to produce a per-transcript
+    index with genomic coordinates, biotype, protein/UniProt identifiers, and
+    transcript flags (MANE, APPRIS, Ensembl canonical, GENCODE Primary).
+
+    Args:
+        source: Mapping of logical input names to paths. Expected keys:
+            ``gene_code`` (GFF3 gz) and ``ensembl`` (Ensembl parquet).
+        destination: Output path for the transcript parquet dataset.
+        settings: Step settings; supports ``partition_count`` (int, default 2).
+        properties: Spark session properties passed to :class:`Session`.
+    """
+    spark = Session(app_name='transcript', properties=properties).spark
+
+    gene_code_raw = spark.read.option('sep', '\t').option('comment', '#').csv(source['gene_code'])
+    ensembl_raw = spark.read.parquet(source['ensembl'])
+
+    gff = _parse_gff3(gene_code_raw)
+    uniprot_lut = _build_uniprot_lut(ensembl_raw)
+    result = _join_and_finalise(gff, uniprot_lut)
+
+    partition_count = (settings or {}).get('partition_count', 2)
+    logger.info(f'writing transcript index to {destination} ({partition_count} partitions)')
+    maybe_coalesce(result, partition_count).write.mode('overwrite').parquet(destination)
+
+
+def _parse_gff3(df: DataFrame) -> DataFrame:
+    """Parse transcript rows from a GFF3 DataFrame.
+
+    Filters to transcript features, extracts identifiers from the attributes
+    column, normalises chromosomes, derives transcriptionStartSite from strand,
+    and builds the flags array.
+
+    Args:
+        df: Raw GFF3 DataFrame (tab-separated, comment lines skipped).
+
+    Returns:
+        DataFrame with one row per transcript on canonical chromosomes,
+        containing targetId, transcriptId, biotype, proteinId, chromosome,
+        start, end, orientation, transcriptionStartSite, isEnsemblCanonical,
+        and flags columns.
+    """
+    attrs = f.col('_c8')
+    tags = f.split(f.regexp_extract(attrs, r'tag=([^;]+)', 1), ',')
+
+    return (
+        df
+        .filter(f.col('_c2') == 'transcript')
+        .select(
+            # Strip version suffix by stopping at the first dot
+            f.regexp_extract(attrs, r'gene_id=([^;.]+)', 1).alias('targetId'),
+            f.regexp_extract(attrs, r'transcript_id=([^;.]+)', 1).alias('transcriptId'),
+            f.regexp_extract(attrs, r'transcript_type=([^;]+)', 1).alias('biotype'),
+            # protein_id absent for non-coding transcripts → empty string
+            f.regexp_extract(attrs, r'protein_id=([^;.]+)', 1).alias('_proteinId_raw'),
+            # Extract chromosome number/letter (strips chr-prefix; M handled below)
+            f.regexp_extract(f.col('_c0'), r'([0-9]{1,2}|X|Y|M)$', 1).alias('_chrom_raw'),
+            f.col('_c3').cast(LongType()).alias('start'),
+            f.col('_c4').cast(LongType()).alias('end'),
+            f.col('_c6').alias('orientation'),
+            f.coalesce(f.array_contains(tags, 'Ensembl_canonical'), f.lit(False)).alias('isEnsemblCanonical'),
+            tags.alias('_tags'),
+        )
+        .withColumn('chromosome',
+            f.when(f.col('_chrom_raw') == 'M', 'MT').otherwise(f.col('_chrom_raw'))
+        )
+        .filter(
+            f.col('chromosome').isin(INCLUDE_CHROMOSOMES)
+            & f.col('targetId').startswith('ENSG')
+            & f.col('transcriptId').startswith('ENST')
+        )
+        .withColumn('proteinId',
+            f.when(f.col('_proteinId_raw') != '', f.col('_proteinId_raw'))
+        )
+        .withColumn('transcriptionStartSite',
+            f.when(f.col('orientation') == '+', f.col('start'))
+            .otherwise(f.col('end'))
+            .cast(IntegerType())
+        )
+        .withColumn('flags', _build_flags(f.col('_tags')))
+        .drop('_chrom_raw', '_proteinId_raw', '_tags')
+    )
+
+
+def _build_flags(tags_col: Column) -> Column:
+    """Build a structured flags array from a GFF3 tag array column.
+
+    Static flags (MANE, GENCODE Primary, Ensembl canonical) have fixed values.
+    APPRIS flags have dynamic values extracted from the tag string itself
+    (e.g. ``appris_principal_1`` → ``{label: "appris", value: "principal_1"}``).
+
+    Args:
+        tags_col: Array column of tag strings parsed from the GFF3 attributes field.
+
+    Returns:
+        Array column of ``{label: str, value: str}`` structs.
+    """
+    static = f.array_compact(f.array(
+        f.when(
+            f.array_contains(tags_col, 'MANE_Select'),
+            f.struct(f.lit('mane').alias('label'), f.lit('select').alias('value')),
+        ),
+        f.when(
+            f.array_contains(tags_col, 'MANE_Plus_Clinical'),
+            f.struct(f.lit('mane').alias('label'), f.lit('plus_clinical').alias('value')),
+        ),
+        f.when(
+            f.array_contains(tags_col, 'GENCODE_Primary'),
+            f.struct(f.lit('gencode_primary').alias('label'), f.lit('true').alias('value')),
+        ),
+        f.when(
+            f.array_contains(tags_col, 'Ensembl_canonical'),
+            f.struct(f.lit('ensembl_canonical').alias('label'), f.lit('true').alias('value')),
+        ),
+    ))
+
+    # APPRIS tags carry the tier in the tag name itself: appris_principal_1, appris_alternative_2, ...
+    appris = f.transform(
+        f.filter(tags_col, lambda t: t.startswith('appris_')),
+        lambda t: f.struct(
+            f.lit('appris').alias('label'),
+            f.regexp_extract(t, r'^appris_(.*)', 1).alias('value'),
+        ),
+    )
+
+    return f.concat(static, appris)
+
+
+def _build_uniprot_lut(ensembl_df: DataFrame) -> DataFrame:
+    """Build a (targetId, transcriptId) → uniprotIds lookup from the Ensembl parquet.
+
+    The Ensembl parquet (produced by pts_pre_target) stores per-transcript
+    uniprot_swissprot and uniprot_trembl arrays. Explodes the transcripts array
+    and merges both into a single deduplicated uniprotIds list.
+
+    Args:
+        ensembl_df: Ensembl parquet from ``intermediate/target/ensembl/homo_sapiens.parquet``.
+
+    Returns:
+        DataFrame with columns ``targetId``, ``transcriptId``, and ``uniprotIds``.
+    """
+    return (
+        ensembl_df
+        .select(f.col('id').alias('targetId'), f.explode('transcripts').alias('tx'))
+        .select(
+            f.col('targetId'),
+            f.col('tx.id').alias('transcriptId'),
+            f.col('tx.uniprot_swissprot').alias('_swissprot'),
+            f.col('tx.uniprot_trembl').alias('_trembl'),
+        )
+        .withColumn('uniprotIds',
+            f.array_distinct(safe_array_union(f.col('_swissprot'), f.col('_trembl')))
+        )
+        .select('targetId', 'transcriptId', 'uniprotIds')
+    )
+
+
+def _join_and_finalise(gff: DataFrame, uniprot_lut: DataFrame) -> DataFrame:
+    """Join GFF3 transcript data with per-transcript UniProt IDs.
+
+    Args:
+        gff: Parsed GFF3 DataFrame from :func:`_parse_gff3`.
+        uniprot_lut: Per-transcript UniProt lookup from :func:`_build_uniprot_lut`.
+
+    Returns:
+        DataFrame with the final transcript index schema.
+    """
+    return (
+        gff
+        .join(uniprot_lut, on=['targetId', 'transcriptId'], how='left')
+        .select(
+            'targetId',
+            'transcriptId',
+            'biotype',
+            'proteinId',
+            'uniprotIds',
+            'isEnsemblCanonical',
+            'chromosome',
+            'start',
+            'end',
+            'orientation',
+            'transcriptionStartSite',
+            'flags',
+        )
+    )

--- a/src/pts/pyspark/transcript.py
+++ b/src/pts/pyspark/transcript.py
@@ -66,7 +66,7 @@ def _parse_gff3(df: DataFrame) -> DataFrame:
     Returns:
         DataFrame with one row per transcript on canonical chromosomes,
         containing targetId, transcriptId, biotype, proteinId, chromosome,
-        start, end, orientation, transcriptionStartSite, isEnsemblCanonical,
+        start, end, strand, transcriptionStartSite, isEnsemblCanonical,
         and flags columns.
     """
     attrs = f.col('_c8')
@@ -86,7 +86,7 @@ def _parse_gff3(df: DataFrame) -> DataFrame:
             f.regexp_extract(f.col('_c0'), r'([0-9]{1,2}|X|Y|M)$', 1).alias('_chrom_raw'),
             f.col('_c3').cast(LongType()).alias('start'),
             f.col('_c4').cast(LongType()).alias('end'),
-            f.col('_c6').alias('orientation'),
+            f.col('_c6').alias('strand'),
             f.coalesce(f.array_contains(tags, 'Ensembl_canonical'), f.lit(False)).alias('isEnsemblCanonical'),
             tags.alias('_tags'),
         )
@@ -99,10 +99,10 @@ def _parse_gff3(df: DataFrame) -> DataFrame:
             & f.col('transcriptId').startswith('ENST')
         )
         .withColumn('proteinId',
-            f.when(f.col('_proteinId_raw') != '', f.col('_proteinId_raw'))
+            f.when(f.col('_proteinId_raw') != '', f.col('_proteinId_raw'))  # noqa: PLC1901
         )
         .withColumn('transcriptionStartSite',
-            f.when(f.col('orientation') == '+', f.col('start'))
+            f.when(f.col('strand') == '+', f.col('start'))
             .otherwise(f.col('end'))
             .cast(IntegerType())
         )
@@ -188,7 +188,7 @@ def _parse_exons(df: DataFrame) -> DataFrame:
         .filter(
             f.col('chromosome').isin(INCLUDE_CHROMOSOMES)
             & f.col('transcriptId').startswith('ENST')
-            & (f.col('exonId') != '')
+            & (f.col('exonId') != '')  # noqa: PLC1901
         )
         .drop('_chrom_raw')
     )
@@ -264,7 +264,7 @@ def _join_and_finalise(gff: DataFrame, exon_lut: DataFrame, uniprot_lut: DataFra
             'chromosome',
             'start',
             'end',
-            'orientation',
+            'strand',
             'transcriptionStartSite',
             'flags',
             'exons',

--- a/src/pts/pyspark/transcript.py
+++ b/src/pts/pyspark/transcript.py
@@ -44,8 +44,9 @@ def transcript(
     ensembl_raw = spark.read.parquet(source['ensembl'])
 
     gff = _parse_gff3(gene_code_raw)
+    exon_lut = _parse_exons(gene_code_raw)
     uniprot_lut = _build_uniprot_lut(ensembl_raw)
-    result = _join_and_finalise(gff, uniprot_lut)
+    result = _join_and_finalise(gff, exon_lut, uniprot_lut)
 
     partition_count = (settings or {}).get('partition_count', 2)
     logger.info(f'writing transcript index to {destination} ({partition_count} partitions)')
@@ -154,6 +155,61 @@ def _build_flags(tags_col: Column) -> Column:
     return f.concat(static, appris)
 
 
+def _parse_exons(df: DataFrame) -> DataFrame:
+    """Parse exon rows from a GFF3 DataFrame and group them by transcript.
+
+    Filters to exon features, extracts identifiers and coordinates from the
+    attributes column, applies the same chromosome normalisation as
+    :func:`_parse_gff3`, and aggregates into a per-transcript exons array.
+
+    Args:
+        df: Raw GFF3 DataFrame (tab-separated, comment lines skipped).
+
+    Returns:
+        DataFrame with columns ``transcriptId`` and ``exons``
+        (``array<struct<exonId, chromosome, start, end, strand>>``).
+    """
+    attrs = f.col('_c8')
+
+    exons = (
+        df
+        .filter(f.col('_c2') == 'exon')
+        .select(
+            f.regexp_extract(attrs, r'transcript_id=([^;.]+)', 1).alias('transcriptId'),
+            f.regexp_extract(attrs, r'exon_id=([^;.]+)', 1).alias('exonId'),
+            f.regexp_extract(f.col('_c0'), r'([0-9]{1,2}|X|Y|M)$', 1).alias('_chrom_raw'),
+            f.col('_c3').cast(LongType()).alias('start'),
+            f.col('_c4').cast(LongType()).alias('end'),
+            f.col('_c6').alias('strand'),
+        )
+        .withColumn('chromosome',
+            f.when(f.col('_chrom_raw') == 'M', 'MT').otherwise(f.col('_chrom_raw'))
+        )
+        .filter(
+            f.col('chromosome').isin(INCLUDE_CHROMOSOMES)
+            & f.col('transcriptId').startswith('ENST')
+            & (f.col('exonId') != '')
+        )
+        .drop('_chrom_raw')
+    )
+
+    return (
+        exons
+        .groupBy('transcriptId')
+        .agg(
+            f.collect_list(
+                f.struct(
+                    f.col('exonId'),
+                    f.col('chromosome'),
+                    f.col('start'),
+                    f.col('end'),
+                    f.col('strand'),
+                )
+            ).alias('exons')
+        )
+    )
+
+
 def _build_uniprot_lut(ensembl_df: DataFrame) -> DataFrame:
     """Build a (targetId, transcriptId) → uniprotIds lookup from the Ensembl parquet.
 
@@ -183,11 +239,12 @@ def _build_uniprot_lut(ensembl_df: DataFrame) -> DataFrame:
     )
 
 
-def _join_and_finalise(gff: DataFrame, uniprot_lut: DataFrame) -> DataFrame:
-    """Join GFF3 transcript data with per-transcript UniProt IDs.
+def _join_and_finalise(gff: DataFrame, exon_lut: DataFrame, uniprot_lut: DataFrame) -> DataFrame:
+    """Join GFF3 transcript data with exons and per-transcript UniProt IDs.
 
     Args:
         gff: Parsed GFF3 DataFrame from :func:`_parse_gff3`.
+        exon_lut: Per-transcript exon arrays from :func:`_parse_exons`.
         uniprot_lut: Per-transcript UniProt lookup from :func:`_build_uniprot_lut`.
 
     Returns:
@@ -195,6 +252,7 @@ def _join_and_finalise(gff: DataFrame, uniprot_lut: DataFrame) -> DataFrame:
     """
     return (
         gff
+        .join(exon_lut, on='transcriptId', how='left')
         .join(uniprot_lut, on=['targetId', 'transcriptId'], how='left')
         .select(
             'targetId',
@@ -209,5 +267,6 @@ def _join_and_finalise(gff: DataFrame, uniprot_lut: DataFrame) -> DataFrame:
             'orientation',
             'transcriptionStartSite',
             'flags',
+            'exons',
         )
     )

--- a/test/test_chemical_probes.py
+++ b/test/test_chemical_probes.py
@@ -1,0 +1,149 @@
+"""Tests for the ENSG resolution functions in the chemical_probes module."""
+
+from pyspark.sql import Row
+from pyspark.sql.types import ArrayType, StringType, StructField, StructType
+
+from pts.pyspark.chemical_probes import _build_ensg_lookup, _resolve_targets
+
+# ---------------------------------------------------------------------------
+# Shared schemas and helpers
+# ---------------------------------------------------------------------------
+
+TARGET_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('approvedSymbol', StringType()),
+    StructField('proteinIds', ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))),
+])
+
+EVIDENCE_SCHEMA = StructType([
+    StructField('targetFromSourceId', StringType()),
+    StructField('id', StringType()),
+    StructField('drugFromSourceId', StringType()),
+    StructField('drugId', StringType()),
+])
+
+
+def _target_row(ensg, symbol, protein_ids=None):
+    return Row(
+        id=ensg,
+        approvedSymbol=symbol,
+        proteinIds=[Row(id=p, source='uniprot') for p in (protein_ids or [])],
+    )
+
+
+def _evidence_row(source_id, compound='probe1', drug_source='CP001', drug_id=None):
+    return Row(
+        targetFromSourceId=source_id,
+        id=compound,
+        drugFromSourceId=drug_source,
+        drugId=drug_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_ensg_lookup
+# ---------------------------------------------------------------------------
+
+
+def test_build_ensg_lookup_output_columns(spark):
+    """Output has exactly ensgId and name columns."""
+    rows = [_target_row('ENSG00000001', 'GENE1')]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    assert set(lut.columns) == {'ensgId', 'name'}
+
+
+def test_build_ensg_lookup_includes_symbol(spark):
+    """approvedSymbol appears in the name array."""
+    rows = [_target_row('ENSG00000001', 'GENE1')]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    assert 'GENE1' in lut.first().name
+
+
+def test_build_ensg_lookup_includes_protein_id(spark):
+    """Protein accession IDs appear in the name array."""
+    rows = [_target_row('ENSG00000001', 'GENE1', protein_ids=['P12345'])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    assert 'P12345' in lut.first().name
+
+
+def test_build_ensg_lookup_handles_empty_protein_ids(spark):
+    """Empty proteinIds does not cause an error; symbol still present."""
+    rows = [_target_row('ENSG00000002', 'GENE2', protein_ids=[])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    row = lut.first()
+    assert 'GENE2' in row.name
+
+
+# ---------------------------------------------------------------------------
+# _resolve_targets
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_targets_output_has_target_id(spark):
+    """Output contains a targetId column."""
+    evidence = spark.createDataFrame([_evidence_row('GENE1')], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000001', 'GENE1')], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert 'targetId' in result.columns
+
+
+def test_resolve_targets_resolves_symbol_to_ensg(spark):
+    """targetFromSourceId matching an approvedSymbol maps to the correct ENSG."""
+    evidence = spark.createDataFrame([_evidence_row('GENE1')], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000001', 'GENE1')], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert result.count() == 1
+    assert result.first().targetId == 'ENSG00000001'
+
+
+def test_resolve_targets_resolves_protein_id_to_ensg(spark):
+    """targetFromSourceId matching a protein accession maps to the correct ENSG."""
+    evidence = spark.createDataFrame([_evidence_row('P12345')], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000002', 'GENE2', protein_ids=['P12345'])], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert result.count() == 1
+    assert result.first().targetId == 'ENSG00000002'
+
+
+def test_resolve_targets_keeps_unresolvable_rows_with_null_target_id(spark):
+    """Rows whose targetFromSourceId matches no target are kept with a null targetId.
+
+    drugId/drugFromSourceId on this dataset are consumed independently of
+    target resolution (see drug_molecule), so unresolvable rows must not be
+    dropped here.
+    """
+    evidence = spark.createDataFrame([_evidence_row('UNKNOWN')], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000001', 'GENE1')], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert result.count() == 1
+    assert result.first().targetId is None
+
+
+def test_resolve_targets_retains_target_from_source_id(spark):
+    """targetFromSourceId is preserved alongside the resolved targetId."""
+    evidence = spark.createDataFrame([_evidence_row('GENE1')], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000001', 'GENE1')], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert 'targetFromSourceId' in result.columns
+    assert result.first().targetFromSourceId == 'GENE1'
+
+
+def test_resolve_targets_multiple_probes_same_target(spark):
+    """Multiple probes for the same target each produce their own row."""
+    evidence = spark.createDataFrame([
+        _evidence_row('GENE1', compound='probe_a'),
+        _evidence_row('GENE1', compound='probe_b'),
+    ], EVIDENCE_SCHEMA)
+    target = spark.createDataFrame([_target_row('ENSG00000001', 'GENE1')], TARGET_SCHEMA)
+    lut = _build_ensg_lookup(target)
+    result = _resolve_targets(evidence, lut)
+    assert result.count() == 2
+    assert result.filter('targetId = "ENSG00000001"').count() == 2

--- a/test/test_safety_liability.py
+++ b/test/test_safety_liability.py
@@ -116,7 +116,7 @@ def test_build_ensg_lookup_output_columns(spark):
 
 
 def test_build_safety_liabilities_output_columns(spark):
-    """Output has exactly targetId and safetyLiabilities columns."""
+    """Output has one row per liability record with flat columns."""
     safety = spark.createDataFrame(
         [_safety_row(ensg='ENSG00000001')], SAFETY_SCHEMA
     )
@@ -128,11 +128,14 @@ def test_build_safety_liabilities_output_columns(spark):
     )
     ensg_lut = _build_ensg_lookup(target)
     result = _build_safety_liabilities(safety, ensg_lut, diseases)
-    assert set(result.columns) == {'targetId', 'safetyLiabilities'}
+    assert set(result.columns) == {
+        'targetId', 'event', 'eventId', 'effects', 'biosamples',
+        'datasource', 'literature', 'url', 'studies',
+    }
 
 
-def test_build_safety_liabilities_groups_by_target(spark):
-    """Multiple liabilities for the same target are collected into one row."""
+def test_build_safety_liabilities_one_row_per_liability(spark):
+    """Multiple liabilities for the same target produce separate rows."""
     safety = spark.createDataFrame([
         _safety_row(ensg='ENSG00000001', event='hepatotoxicity', event_id='EFO_0001'),
         _safety_row(ensg='ENSG00000001', event='cardiotoxicity', event_id='EFO_0002'),
@@ -145,9 +148,8 @@ def test_build_safety_liabilities_groups_by_target(spark):
     )
     ensg_lut = _build_ensg_lookup(target)
     result = _build_safety_liabilities(safety, ensg_lut, diseases)
-    assert result.count() == 1
-    row = result.first()
-    assert len(row.safetyLiabilities) == 2
+    assert result.count() == 2
+    assert result.filter('targetId = "ENSG00000001"').count() == 2
 
 
 def test_build_safety_liabilities_resolves_symbol_to_ensg(spark):
@@ -213,8 +215,7 @@ def test_build_safety_liabilities_remaps_obsolete_efo(spark):
     ], DISEASE_SCHEMA)
     ensg_lut = _build_ensg_lookup(target)
     result = _build_safety_liabilities(safety, ensg_lut, diseases)
-    row = result.first()
-    assert row.safetyLiabilities[0].eventId == 'EFO_CURRENT'
+    assert result.first().eventId == 'EFO_CURRENT'
 
 
 def test_build_safety_liabilities_keeps_current_efo_unchanged(spark):
@@ -230,8 +231,7 @@ def test_build_safety_liabilities_keeps_current_efo_unchanged(spark):
     ], DISEASE_SCHEMA)
     ensg_lut = _build_ensg_lookup(target)
     result = _build_safety_liabilities(safety, ensg_lut, diseases)
-    row = result.first()
-    assert row.safetyLiabilities[0].eventId == 'EFO_CURRENT'
+    assert result.first().eventId == 'EFO_CURRENT'
 
 
 def test_build_safety_liabilities_multiple_targets(spark):

--- a/test/test_safety_liability.py
+++ b/test/test_safety_liability.py
@@ -1,0 +1,252 @@
+"""Tests for the safety_liability PySpark module."""
+
+from pyspark.sql import Row
+from pyspark.sql.types import (
+    ArrayType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from pts.pyspark.safety_liability import (
+    _build_ensg_lookup,
+    _build_safety_liabilities,
+)
+
+# ---------------------------------------------------------------------------
+# Shared schemas and helpers
+# ---------------------------------------------------------------------------
+
+SAFETY_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('targetFromSourceId', StringType()),
+    StructField('event', StringType()),
+    StructField('eventId', StringType()),
+    StructField('datasource', StringType()),
+    StructField('effects', ArrayType(StructType([
+        StructField('direction', StringType()),
+        StructField('dosing', StringType()),
+    ]))),
+    StructField('literature', StringType()),
+    StructField('url', StringType()),
+    StructField('biosamples', ArrayType(StructType([
+        StructField('tissueLabel', StringType()),
+        StructField('tissueId', StringType()),
+        StructField('cellLabel', StringType()),
+        StructField('cellFormat', StringType()),
+        StructField('cellId', StringType()),
+    ]))),
+    StructField('studies', ArrayType(StructType([
+        StructField('description', StringType()),
+        StructField('name', StringType()),
+        StructField('type', StringType()),
+    ]))),
+])
+
+TARGET_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('approvedSymbol', StringType()),
+    StructField('proteinIds', ArrayType(StructType([
+        StructField('id', StringType()),
+        StructField('source', StringType()),
+    ]))),
+])
+
+DISEASE_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField('obsoleteTerms', ArrayType(StringType())),
+])
+
+
+def _safety_row(*, ensg=None, source_id=None, event='hepatotoxicity', event_id='EFO_0001234',
+                datasource='AstraZeneca', literature=None, url=None):
+    return Row(
+        id=ensg,
+        targetFromSourceId=source_id,
+        event=event,
+        eventId=event_id,
+        datasource=datasource,
+        effects=None,
+        literature=literature,
+        url=url,
+        biosamples=None,
+        studies=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_ensg_lookup
+# ---------------------------------------------------------------------------
+
+
+def test_build_ensg_lookup_includes_approved_symbol(spark):
+    """approvedSymbol appears in the name array."""
+    rows = [Row(id='ENSG00000001', approvedSymbol='GENE1', proteinIds=[Row(id='P12345', source='uniprot')])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    row = lut.filter('ensgId = "ENSG00000001"').first()
+    assert 'GENE1' in row.name
+
+
+def test_build_ensg_lookup_includes_protein_id(spark):
+    """Protein accession IDs appear in the name array."""
+    rows = [Row(id='ENSG00000001', approvedSymbol='GENE1', proteinIds=[Row(id='P12345', source='uniprot')])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    row = lut.filter('ensgId = "ENSG00000001"').first()
+    assert 'P12345' in row.name
+
+
+def test_build_ensg_lookup_handles_empty_protein_ids(spark):
+    """Empty proteinIds array does not cause an error; symbol still in name."""
+    rows = [Row(id='ENSG00000002', approvedSymbol='GENE2', proteinIds=[])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    row = lut.filter('ensgId = "ENSG00000002"').first()
+    assert 'GENE2' in row.name
+
+
+def test_build_ensg_lookup_output_columns(spark):
+    """Output has exactly ensgId and name columns."""
+    rows = [Row(id='ENSG00000003', approvedSymbol='G3', proteinIds=[])]
+    lut = _build_ensg_lookup(spark.createDataFrame(rows, TARGET_SCHEMA))
+    assert set(lut.columns) == {'ensgId', 'name'}
+
+
+# ---------------------------------------------------------------------------
+# _build_safety_liabilities
+# ---------------------------------------------------------------------------
+
+
+def test_build_safety_liabilities_output_columns(spark):
+    """Output has exactly targetId and safetyLiabilities columns."""
+    safety = spark.createDataFrame(
+        [_safety_row(ensg='ENSG00000001')], SAFETY_SCHEMA
+    )
+    target = spark.createDataFrame(
+        [Row(id='ENSG00000001', approvedSymbol='G1', proteinIds=[])], TARGET_SCHEMA
+    )
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert set(result.columns) == {'targetId', 'safetyLiabilities'}
+
+
+def test_build_safety_liabilities_groups_by_target(spark):
+    """Multiple liabilities for the same target are collected into one row."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg='ENSG00000001', event='hepatotoxicity', event_id='EFO_0001'),
+        _safety_row(ensg='ENSG00000001', event='cardiotoxicity', event_id='EFO_0002'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame(
+        [Row(id='ENSG00000001', approvedSymbol='G1', proteinIds=[])], TARGET_SCHEMA
+    )
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert result.count() == 1
+    row = result.first()
+    assert len(row.safetyLiabilities) == 2
+
+
+def test_build_safety_liabilities_resolves_symbol_to_ensg(spark):
+    """ToxCast rows with null id but known symbol get their ENSG resolved."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg=None, source_id='GENE1', datasource='ToxCast'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000001', approvedSymbol='GENE1', proteinIds=[]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert result.count() == 1
+    assert result.first().targetId == 'ENSG00000001'
+
+
+def test_build_safety_liabilities_resolves_protein_id_to_ensg(spark):
+    """Entries keyed by protein accession are resolved via proteinIds lookup."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg=None, source_id='P12345', datasource='AstraZeneca'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000002', approvedSymbol='GENE2', proteinIds=[Row(id='P12345', source='uniprot')]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert result.count() == 1
+    assert result.first().targetId == 'ENSG00000002'
+
+
+def test_build_safety_liabilities_drops_unresolvable_rows(spark):
+    """Rows with null id that cannot be resolved to an ENSG are dropped."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg=None, source_id='UNKNOWN_SYMBOL', datasource='ToxCast'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000001', approvedSymbol='GENE1', proteinIds=[]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert result.count() == 0
+
+
+def test_build_safety_liabilities_remaps_obsolete_efo(spark):
+    """Obsolete EFO disease IDs in eventId are replaced with current IDs."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg='ENSG00000001', event_id='EFO_OBSOLETE'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000001', approvedSymbol='G1', proteinIds=[]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame([
+        Row(id='EFO_CURRENT', obsoleteTerms=['EFO_OBSOLETE']),
+    ], DISEASE_SCHEMA)
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    row = result.first()
+    assert row.safetyLiabilities[0].eventId == 'EFO_CURRENT'
+
+
+def test_build_safety_liabilities_keeps_current_efo_unchanged(spark):
+    """EFO IDs that are not obsolete are left untouched."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg='ENSG00000001', event_id='EFO_CURRENT'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000001', approvedSymbol='G1', proteinIds=[]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame([
+        Row(id='EFO_OTHER', obsoleteTerms=['EFO_SOMETHINGELSE']),
+    ], DISEASE_SCHEMA)
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    row = result.first()
+    assert row.safetyLiabilities[0].eventId == 'EFO_CURRENT'
+
+
+def test_build_safety_liabilities_multiple_targets(spark):
+    """Liabilities for different targets produce separate rows."""
+    safety = spark.createDataFrame([
+        _safety_row(ensg='ENSG00000001', event='hepatotoxicity'),
+        _safety_row(ensg='ENSG00000002', event='cardiotoxicity'),
+    ], SAFETY_SCHEMA)
+    target = spark.createDataFrame([
+        Row(id='ENSG00000001', approvedSymbol='G1', proteinIds=[]),
+        Row(id='ENSG00000002', approvedSymbol='G2', proteinIds=[]),
+    ], TARGET_SCHEMA)
+    diseases = spark.createDataFrame(
+        [Row(id='EFO_9999', obsoleteTerms=[])], DISEASE_SCHEMA
+    )
+    ensg_lut = _build_ensg_lookup(target)
+    result = _build_safety_liabilities(safety, ensg_lut, diseases)
+    assert result.count() == 2

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -22,7 +22,6 @@ from pts.pyspark.target import (
     _build_hgnc,
     _build_homologues,
     _build_reactome,
-    _build_safety,
     _filter_ensembl,
     _map_uniprot_locations_to_ssl,
     _merge_hgnc_ensembl,
@@ -386,122 +385,7 @@ def test_homologue_whitelist_filtering(spark):
 
 
 # ---------------------------------------------------------------------------
-# 5. Safety evidence aggregation
-# ---------------------------------------------------------------------------
-
-
-def test_safety_evidence_aggregation(spark):
-    """Safety evidence is grouped by ENSG id into safetyLiabilities."""
-    safety_schema = StructType([
-        StructField('id', StringType()),
-        StructField('targetFromSourceId', StringType()),
-        StructField('event', StringType()),
-        StructField('eventId', StringType()),
-        StructField(
-            'effects',
-            ArrayType(
-                StructType([
-                    StructField('direction', StringType()),
-                    StructField('dosing', StringType()),
-                ])
-            ),
-        ),
-        StructField(
-            'biosamples',
-            ArrayType(
-                StructType([
-                    StructField('tissueLabel', StringType()),
-                    StructField('tissueId', StringType()),
-                    StructField('cellLabel', StringType()),
-                    StructField('cellFormat', StringType()),
-                ])
-            ),
-        ),
-        StructField('datasource', StringType()),
-        StructField('literature', StringType()),
-        StructField('url', StringType()),
-        StructField(
-            'studies',
-            ArrayType(
-                StructType([
-                    StructField('name', StringType()),
-                    StructField('description', StringType()),
-                    StructField('type', StringType()),
-                ])
-            ),
-        ),
-    ])
-    safety_data = [
-        Row(
-            id='ENSG00000141510',
-            targetFromSourceId='TP53',
-            event='heart failure',
-            eventId='EFO_0003777',
-            effects=[Row(direction='Activation/Increase/Upregulation', dosing='general')],
-            biosamples=None,
-            datasource='TestSource',
-            literature='12345678',
-            url=None,
-            studies=None,
-        ),
-        Row(
-            id='ENSG00000141510',
-            targetFromSourceId='TP53',
-            event='liver toxicity',
-            eventId='EFO_0001234',
-            effects=None,
-            biosamples=None,
-            datasource='TestSource2',
-            literature=None,
-            url=None,
-            studies=None,
-        ),
-        Row(
-            id='ENSG00000012048',
-            targetFromSourceId='BRCA1',
-            event='breast cancer',
-            eventId='MONDO_0007254',
-            effects=None,
-            biosamples=None,
-            datasource='TestSource',
-            literature=None,
-            url=None,
-            studies=None,
-        ),
-    ]
-    safety_df = spark.createDataFrame(safety_data, safety_schema)
-
-    # lookup df: ensgId -> name (array)
-    lookup_schema = StructType([
-        StructField('ensgId', StringType()),
-        StructField('name', ArrayType(StringType())),
-        StructField('uniprot', ArrayType(StringType())),
-        StructField('HGNC', ArrayType(StringType())),
-        StructField('symbols', ArrayType(StringType())),
-    ])
-    lookup_data = [
-        Row(ensgId='ENSG00000141510', name=['P04637', 'TP53'], uniprot=['P04637'], HGNC=['TP53'], symbols=['TP53']),
-    ]
-    lookup_df = spark.createDataFrame(lookup_data, lookup_schema)
-
-    # disease df for EFO replacement (empty — no obsolete terms to replace)
-    disease_schema = StructType([
-        StructField('id', StringType()),
-        StructField('obsoleteTerms', ArrayType(StringType())),
-    ])
-    disease_df = spark.createDataFrame([], disease_schema)
-
-    result = _build_safety(safety_df, lookup_df, disease_df)
-    rows = {r.id: r for r in result.collect()}
-
-    # Both ENSG ids should appear
-    assert 'ENSG00000141510' in rows
-    # TP53 has 2 safety liabilities
-    assert len(rows['ENSG00000141510'].safetyLiabilities) == 2
-
-
-# ---------------------------------------------------------------------------
-# 6. Genetic constraints
+# 5. Genetic constraints
 # ---------------------------------------------------------------------------
 
 
@@ -570,7 +454,7 @@ def test_genetic_constraints_structure(spark):
 
 
 # ---------------------------------------------------------------------------
-# 7. Hallmarks
+# 6. Hallmarks
 # ---------------------------------------------------------------------------
 
 
@@ -614,7 +498,7 @@ def test_hallmarks_split_cancer_vs_non_cancer(spark):
 
 
 # ---------------------------------------------------------------------------
-# 8. Reactome pathways
+# 7. Reactome pathways
 # ---------------------------------------------------------------------------
 
 
@@ -661,7 +545,7 @@ def test_reactome_pathways(spark):
 
 
 # ---------------------------------------------------------------------------
-# 9. HGNC + Ensembl merge
+# 8. HGNC + Ensembl merge
 # ---------------------------------------------------------------------------
 
 
@@ -779,7 +663,7 @@ def test_merge_hgnc_ensembl_prefers_hgnc_name(spark):
 
 
 # ---------------------------------------------------------------------------
-# 10. Output schema validation
+# 9. Output schema validation
 # ---------------------------------------------------------------------------
 
 REQUIRED_OUTPUT_COLUMNS = {
@@ -787,13 +671,10 @@ REQUIRED_OUTPUT_COLUMNS = {
     'approvedSymbol',
     'approvedName',
     'biotype',
-    'transcripts',
     'genomicLocation',
     'pathways',
     'go',
     'constraint',
-    'safety',
-    'tractability',
     'homologues',
     'subcellularLocations',
     'targetClass',
@@ -810,7 +691,7 @@ def test_output_schema_has_required_columns(spark):
 
 
 # ---------------------------------------------------------------------------
-# 11. Subcellular location struct schema alignment
+# 10. Subcellular location struct schema alignment
 # ---------------------------------------------------------------------------
 
 

--- a/test/test_target.py
+++ b/test/test_target.py
@@ -798,7 +798,6 @@ REQUIRED_OUTPUT_COLUMNS = {
     'subcellularLocations',
     'targetClass',
     'hallmarks',
-    'chemicalProbes',
     'tep',
 }
 

--- a/test/test_target_tractability.py
+++ b/test/test_target_tractability.py
@@ -1,0 +1,108 @@
+"""Tests for the target_tractability PySpark module."""
+
+from pyspark.sql import Row
+from pyspark.sql.types import StringType, StructField, StructType
+
+from pts.pyspark.target_tractability import _build_tractability
+
+# ---------------------------------------------------------------------------
+# Shared schemas and helpers
+# ---------------------------------------------------------------------------
+
+TARGET_SCHEMA = StructType([StructField('id', StringType())])
+
+# Minimal tractability TSV row: ensembl_gene_id + two bucket columns
+TRACT_SCHEMA = StructType([
+    StructField('ensembl_gene_id', StringType()),
+    StructField('SM_B1_existence_sm_tractability_bucket', StringType()),
+    StructField('AB_B1_existence_ab_tractability_bucket', StringType()),
+])
+
+
+def _target(ensg_id):
+    return Row(id=ensg_id)
+
+
+def _tract_row(ensg_id, sm_b1='0', ab_b1='0'):
+    return Row(
+        ensembl_gene_id=ensg_id,
+        SM_B1_existence_sm_tractability_bucket=sm_b1,
+        AB_B1_existence_ab_tractability_bucket=ab_b1,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_tractability
+# ---------------------------------------------------------------------------
+
+
+def test_build_tractability_output_columns(spark):
+    """Output has exactly targetId and tractability columns."""
+    rows = [_tract_row('ENSG00000001')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    assert set(result.columns) == {'targetId', 'tractability'}
+
+
+def test_build_tractability_struct_fields(spark):
+    """Each tractability element has modality, id, and value fields."""
+    rows = [_tract_row('ENSG00000001', sm_b1='1')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    elem = result.first().tractability[0]
+    assert hasattr(elem, 'modality')
+    assert hasattr(elem, 'id')
+    assert hasattr(elem, 'value')
+
+
+def test_build_tractability_value_true_when_bucket_is_1(spark):
+    """value is True when the bucket column contains '1'."""
+    rows = [_tract_row('ENSG00000001', sm_b1='1')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    sm_elem = next(e for e in result.first().tractability if e.modality == 'SM')
+    assert sm_elem.value is True
+
+
+def test_build_tractability_value_false_when_bucket_is_0(spark):
+    """value is False when the bucket column contains '0'."""
+    rows = [_tract_row('ENSG00000001', sm_b1='0')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    sm_elem = next(e for e in result.first().tractability if e.modality == 'SM')
+    assert sm_elem.value is False
+
+
+def test_build_tractability_drops_unknown_target(spark):
+    """Rows whose ensembl_gene_id is not in the target universe are dropped."""
+    rows = [_tract_row('ENSG99999999')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    assert result.count() == 0
+
+
+def test_build_tractability_keeps_known_target(spark):
+    """Rows whose ensembl_gene_id is in the target universe are retained."""
+    rows = [_tract_row('ENSG00000001'), _tract_row('ENSG99999999')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    assert result.count() == 1
+    assert result.first().targetId == 'ENSG00000001'
+
+
+def test_build_tractability_modality_extracted_from_column_name(spark):
+    """Modality label is the first underscore-delimited part of the column name."""
+    rows = [_tract_row('ENSG00000001')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    modalities = {e.modality for e in result.first().tractability}
+    assert modalities == {'SM', 'AB'}
+
+
+def test_build_tractability_bucket_id_extracted_from_column_name(spark):
+    """Bucket id label is the last underscore-delimited part of the column name."""
+    rows = [_tract_row('ENSG00000001')]
+    targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
+    result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
+    ids = {e.id for e in result.first().tractability}
+    assert 'bucket' in ids

--- a/test/test_target_tractability.py
+++ b/test/test_target_tractability.py
@@ -37,22 +37,19 @@ def _tract_row(ensg_id, sm_b1='0', ab_b1='0'):
 
 
 def test_build_tractability_output_columns(spark):
-    """Output has exactly targetId and tractability columns."""
+    """Output has exactly targetId, modality, id, and value columns."""
     rows = [_tract_row('ENSG00000001')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    assert set(result.columns) == {'targetId', 'tractability'}
+    assert set(result.columns) == {'targetId', 'modality', 'id', 'value'}
 
 
-def test_build_tractability_struct_fields(spark):
-    """Each tractability element has modality, id, and value fields."""
-    rows = [_tract_row('ENSG00000001', sm_b1='1')]
+def test_build_tractability_one_row_per_assessment(spark):
+    """Each modality/bucket combination produces its own row."""
+    rows = [_tract_row('ENSG00000001')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    elem = result.first().tractability[0]
-    assert hasattr(elem, 'modality')
-    assert hasattr(elem, 'id')
-    assert hasattr(elem, 'value')
+    assert result.count() == 2
 
 
 def test_build_tractability_value_true_when_bucket_is_1(spark):
@@ -60,8 +57,8 @@ def test_build_tractability_value_true_when_bucket_is_1(spark):
     rows = [_tract_row('ENSG00000001', sm_b1='1')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    sm_elem = next(e for e in result.first().tractability if e.modality == 'SM')
-    assert sm_elem.value is True
+    sm_row = next(r for r in result.collect() if r.modality == 'SM')
+    assert sm_row.value is True
 
 
 def test_build_tractability_value_false_when_bucket_is_0(spark):
@@ -69,8 +66,8 @@ def test_build_tractability_value_false_when_bucket_is_0(spark):
     rows = [_tract_row('ENSG00000001', sm_b1='0')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    sm_elem = next(e for e in result.first().tractability if e.modality == 'SM')
-    assert sm_elem.value is False
+    sm_row = next(r for r in result.collect() if r.modality == 'SM')
+    assert sm_row.value is False
 
 
 def test_build_tractability_drops_unknown_target(spark):
@@ -86,8 +83,8 @@ def test_build_tractability_keeps_known_target(spark):
     rows = [_tract_row('ENSG00000001'), _tract_row('ENSG99999999')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    assert result.count() == 1
-    assert result.first().targetId == 'ENSG00000001'
+    assert result.count() == 2
+    assert {r.targetId for r in result.collect()} == {'ENSG00000001'}
 
 
 def test_build_tractability_modality_extracted_from_column_name(spark):
@@ -95,7 +92,7 @@ def test_build_tractability_modality_extracted_from_column_name(spark):
     rows = [_tract_row('ENSG00000001')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    modalities = {e.modality for e in result.first().tractability}
+    modalities = {r.modality for r in result.collect()}
     assert modalities == {'SM', 'AB'}
 
 
@@ -104,5 +101,5 @@ def test_build_tractability_bucket_id_extracted_from_column_name(spark):
     rows = [_tract_row('ENSG00000001')]
     targets = spark.createDataFrame([_target('ENSG00000001')], TARGET_SCHEMA)
     result = _build_tractability(spark.createDataFrame(rows, TRACT_SCHEMA), targets)
-    ids = {e.id for e in result.first().tractability}
+    ids = {r.id for r in result.collect()}
     assert 'bucket' in ids

--- a/test/test_transcript.py
+++ b/test/test_transcript.py
@@ -1,0 +1,309 @@
+"""Tests for the transcript PySpark module."""
+
+from pyspark.sql import Row
+from pyspark.sql.types import ArrayType, StringType, StructField, StructType
+
+from pts.pyspark.transcript import (
+    _build_flags,
+    _build_uniprot_lut,
+    _join_and_finalise,
+    _parse_exons,
+    _parse_gff3,
+)
+
+# ---------------------------------------------------------------------------
+# Shared schemas and helpers
+# ---------------------------------------------------------------------------
+
+GFF3_SCHEMA = StructType([
+    StructField('_c0', StringType()),
+    StructField('_c1', StringType()),
+    StructField('_c2', StringType()),
+    StructField('_c3', StringType()),
+    StructField('_c4', StringType()),
+    StructField('_c5', StringType()),
+    StructField('_c6', StringType()),
+    StructField('_c7', StringType()),
+    StructField('_c8', StringType()),
+])
+
+ENSEMBL_SCHEMA = StructType([
+    StructField('id', StringType()),
+    StructField(
+        'transcripts',
+        ArrayType(StructType([
+            StructField('id', StringType()),
+            StructField('uniprot_swissprot', ArrayType(StringType())),
+            StructField('uniprot_trembl', ArrayType(StringType())),
+        ])),
+    ),
+])
+
+
+def _gff(chrom, feature, start, end, strand, attrs):
+    return Row(
+        _c0=chrom, _c1='HAVANA', _c2=feature,
+        _c3=str(start), _c4=str(end), _c5='.', _c6=strand, _c7='.', _c8=attrs,
+    )
+
+
+_TX_ATTRS = (
+    'gene_id=ENSG00000186092.7;transcript_id=ENST00000641515.2;'
+    'transcript_type=protein_coding;protein_id=ENSP00000493376.2;'
+    'tag=Ensembl_canonical,GENCODE_Primary,MANE_Select,appris_principal_1'
+)
+_NC_ATTRS = (
+    'gene_id=ENSG00000290825.3;transcript_id=ENST00000832824.1;'
+    'transcript_type=lncRNA;tag=basic'
+)
+_EXON_ATTRS_A = 'transcript_id=ENST00000641515.2;exon_id=ENSE00003899065.1'
+_EXON_ATTRS_B = 'transcript_id=ENST00000641515.2;exon_id=ENSE00001234567.2'
+
+
+# ---------------------------------------------------------------------------
+# _parse_gff3
+# ---------------------------------------------------------------------------
+
+
+def test_parse_gff3_excludes_non_transcript_features(spark):
+    """gene and exon rows are dropped; only transcript rows pass."""
+    rows = [
+        _gff('chr1', 'gene', 65419, 71585, '+', _TX_ATTRS),
+        _gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS),
+        _gff('chr1', 'exon', 65419, 65433, '+', _TX_ATTRS),
+    ]
+    result = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA))
+    assert result.count() == 1
+    assert result.first().transcriptId == 'ENST00000641515'
+
+
+def test_parse_gff3_strips_version_suffix(spark):
+    """Version suffixes (.N) are removed from gene, transcript and protein IDs."""
+    rows = [_gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS)]
+    row = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.targetId == 'ENSG00000186092'
+    assert row.transcriptId == 'ENST00000641515'
+    assert row.proteinId == 'ENSP00000493376'
+
+
+def test_parse_gff3_normalises_chrm_to_mt(spark):
+    """chrM is normalised to MT."""
+    rows = [_gff('chrM', 'transcript', 1000, 2000, '+', _NC_ATTRS.replace('ENSG00000290825', 'ENSG00000000001'))]
+    row = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.chromosome == 'MT'
+
+
+def test_parse_gff3_filters_noncanonical_chromosomes(spark):
+    """Scaffold/patch chromosomes are excluded."""
+    rows = [
+        _gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS),
+        _gff('chr1_KI270706v1_random', 'transcript', 65419, 71585, '+', _TX_ATTRS),
+    ]
+    result = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA))
+    assert result.count() == 1
+    assert result.first().chromosome == '1'
+
+
+def test_parse_gff3_tss_positive_strand(spark):
+    """transcriptionStartSite equals start for + strand transcripts."""
+    rows = [_gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS)]
+    row = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.transcriptionStartSite == 65419
+
+
+def test_parse_gff3_tss_negative_strand(spark):
+    """transcriptionStartSite equals end for - strand transcripts."""
+    rows = [_gff('chr1', 'transcript', 450740, 451678, '-', _TX_ATTRS)]
+    row = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.transcriptionStartSite == 451678
+
+
+def test_parse_gff3_null_protein_id_for_noncoding(spark):
+    """proteinId is null when protein_id is absent from the attributes."""
+    rows = [_gff('chr1', 'transcript', 11121, 14413, '+', _NC_ATTRS)]
+    row = _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.proteinId is None
+
+
+def test_parse_gff3_is_ensembl_canonical_true_when_tagged(spark):
+    """isEnsemblCanonical is True when Ensembl_canonical is in the tag list."""
+    rows = [_gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS)]
+    assert _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first().isEnsemblCanonical is True
+
+
+def test_parse_gff3_is_ensembl_canonical_false_when_not_tagged(spark):
+    """isEnsemblCanonical is False when Ensembl_canonical is absent."""
+    rows = [_gff('chr1', 'transcript', 11121, 14413, '+', _NC_ATTRS)]
+    assert _parse_gff3(spark.createDataFrame(rows, GFF3_SCHEMA)).first().isEnsemblCanonical is False
+
+
+# ---------------------------------------------------------------------------
+# _build_flags
+# ---------------------------------------------------------------------------
+
+
+def _flags_for(spark, tags: list[str]) -> list:
+    tags_col_df = spark.createDataFrame(
+        [Row(tags=tags)],
+        StructType([StructField('tags', ArrayType(StringType()))]),
+    )
+    import pyspark.sql.functions as f
+    return tags_col_df.select(_build_flags(f.col('tags')).alias('flags')).first().flags
+
+
+def test_build_flags_mane_select(spark):
+    flags = _flags_for(spark, ['MANE_Select'])
+    assert any(r.label == 'mane' and r.value == 'select' for r in flags)
+
+
+def test_build_flags_mane_plus_clinical(spark):
+    flags = _flags_for(spark, ['MANE_Plus_Clinical'])
+    assert any(r.label == 'mane' and r.value == 'plus_clinical' for r in flags)
+
+
+def test_build_flags_gencode_primary(spark):
+    flags = _flags_for(spark, ['GENCODE_Primary'])
+    assert any(r.label == 'gencode_primary' and r.value == 'true' for r in flags)
+
+
+def test_build_flags_ensembl_canonical(spark):
+    flags = _flags_for(spark, ['Ensembl_canonical'])
+    assert any(r.label == 'ensembl_canonical' and r.value == 'true' for r in flags)
+
+
+def test_build_flags_appris_principal(spark):
+    flags = _flags_for(spark, ['appris_principal_1'])
+    assert any(r.label == 'appris' and r.value == 'principal_1' for r in flags)
+
+
+def test_build_flags_appris_alternative(spark):
+    flags = _flags_for(spark, ['appris_alternative_2'])
+    assert any(r.label == 'appris' and r.value == 'alternative_2' for r in flags)
+
+
+def test_build_flags_empty_for_irrelevant_tags(spark):
+    flags = _flags_for(spark, ['basic', 'CCDS', 'RNA_Seq_supported_partial'])
+    assert flags == []
+
+
+def test_build_flags_multiple_flags(spark):
+    flags = _flags_for(spark, ['MANE_Select', 'GENCODE_Primary', 'Ensembl_canonical', 'appris_principal_1'])
+    labels = {r.label for r in flags}
+    assert labels == {'mane', 'gencode_primary', 'ensembl_canonical', 'appris'}
+
+
+# ---------------------------------------------------------------------------
+# _parse_exons
+# ---------------------------------------------------------------------------
+
+
+def test_parse_exons_groups_by_transcript(spark):
+    """Multiple exon rows for the same transcript are collected into one array."""
+    rows = [
+        _gff('chr1', 'exon', 65419, 65433, '+', _EXON_ATTRS_A),
+        _gff('chr1', 'exon', 65500, 65600, '+', _EXON_ATTRS_B),
+        _gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS),  # should be ignored
+    ]
+    result = _parse_exons(spark.createDataFrame(rows, GFF3_SCHEMA))
+    assert result.count() == 1
+    row = result.first()
+    assert row.transcriptId == 'ENST00000641515'
+    assert len(row.exons) == 2
+
+
+def test_parse_exons_strips_version_suffix(spark):
+    """Version suffixes are stripped from exon_id and transcript_id."""
+    rows = [_gff('chr1', 'exon', 65419, 65433, '+', _EXON_ATTRS_A)]
+    row = _parse_exons(spark.createDataFrame(rows, GFF3_SCHEMA)).first()
+    assert row.transcriptId == 'ENST00000641515'
+    assert row.exons[0].exonId == 'ENSE00003899065'
+
+
+def test_parse_exons_exon_struct_fields(spark):
+    """Each exon struct has exonId, chromosome, start, end, strand."""
+    rows = [_gff('chr1', 'exon', 65419, 65433, '+', _EXON_ATTRS_A)]
+    exon = _parse_exons(spark.createDataFrame(rows, GFF3_SCHEMA)).first().exons[0]
+    assert exon.chromosome == '1'
+    assert exon.start == 65419
+    assert exon.end == 65433
+    assert exon.strand == '+'
+
+
+# ---------------------------------------------------------------------------
+# _build_uniprot_lut
+# ---------------------------------------------------------------------------
+
+
+def test_build_uniprot_lut_merges_swissprot_and_trembl(spark):
+    """uniprotIds contains both Swiss-Prot and TrEMBL IDs."""
+    data = [Row(id='ENSG00000001', transcripts=[
+        Row(id='ENST00000001', uniprot_swissprot=['P12345'], uniprot_trembl=['A0A001']),
+    ])]
+    result = _build_uniprot_lut(spark.createDataFrame(data, ENSEMBL_SCHEMA))
+    row = result.filter('transcriptId = "ENST00000001"').first()
+    assert set(row.uniprotIds) == {'P12345', 'A0A001'}
+
+
+def test_build_uniprot_lut_handles_null_trembl(spark):
+    """Null uniprot_trembl does not cause an error."""
+    data = [Row(id='ENSG00000002', transcripts=[
+        Row(id='ENST00000002', uniprot_swissprot=['P99999'], uniprot_trembl=None),
+    ])]
+    result = _build_uniprot_lut(spark.createDataFrame(data, ENSEMBL_SCHEMA))
+    row = result.filter('transcriptId = "ENST00000002"').first()
+    assert row.uniprotIds == ['P99999']
+
+
+def test_build_uniprot_lut_deduplicates(spark):
+    """Duplicate IDs appearing in both swissprot and trembl are deduplicated."""
+    data = [Row(id='ENSG00000003', transcripts=[
+        Row(id='ENST00000003', uniprot_swissprot=['P11111'], uniprot_trembl=['P11111']),
+    ])]
+    result = _build_uniprot_lut(spark.createDataFrame(data, ENSEMBL_SCHEMA))
+    row = result.filter('transcriptId = "ENST00000003"').first()
+    assert row.uniprotIds.count('P11111') == 1
+
+
+# ---------------------------------------------------------------------------
+# _join_and_finalise
+# ---------------------------------------------------------------------------
+
+
+def test_join_and_finalise_output_schema(spark):
+    """Output contains exactly the expected columns."""
+    expected_cols = {
+        'targetId', 'transcriptId', 'biotype', 'proteinId', 'uniprotIds',
+        'isEnsemblCanonical', 'chromosome', 'start', 'end', 'strand',
+        'transcriptionStartSite', 'flags', 'exons',
+    }
+    gff_rows = [_gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS)]
+    gff = _parse_gff3(spark.createDataFrame(gff_rows, GFF3_SCHEMA))
+
+    exon_rows = [_gff('chr1', 'exon', 65419, 65433, '+', _EXON_ATTRS_A)]
+    exons = _parse_exons(spark.createDataFrame(exon_rows, GFF3_SCHEMA))
+
+    ensembl_data = [Row(id='ENSG00000186092', transcripts=[
+        Row(id='ENST00000641515', uniprot_swissprot=['A0A2U3U0J3'], uniprot_trembl=None),
+    ])]
+    uniprot = _build_uniprot_lut(spark.createDataFrame(ensembl_data, ENSEMBL_SCHEMA))
+
+    result = _join_and_finalise(gff, exons, uniprot)
+    assert set(result.columns) == expected_cols
+
+
+def test_join_and_finalise_propagates_uniprot_ids(spark):
+    """UniProt IDs from the Ensembl parquet are attached to the correct transcript."""
+    gff_rows = [_gff('chr1', 'transcript', 65419, 71585, '+', _TX_ATTRS)]
+    gff = _parse_gff3(spark.createDataFrame(gff_rows, GFF3_SCHEMA))
+
+    exon_rows = [_gff('chr1', 'exon', 65419, 65433, '+', _EXON_ATTRS_A)]
+    exons = _parse_exons(spark.createDataFrame(exon_rows, GFF3_SCHEMA))
+
+    ensembl_data = [Row(id='ENSG00000186092', transcripts=[
+        Row(id='ENST00000641515', uniprot_swissprot=['A0A2U3U0J3'], uniprot_trembl=None),
+    ])]
+    uniprot = _build_uniprot_lut(spark.createDataFrame(ensembl_data, ENSEMBL_SCHEMA))
+
+    row = _join_and_finalise(gff, exons, uniprot).first()
+    assert row.uniprotIds == ['A0A2U3U0J3']
+    assert len(row.exons) == 1


### PR DESCRIPTION
## Summary

Extracts four datasets out of the monolithic `pts_target` step into standalone PTS modules, per opentargets/issues#4457:

- **`pts_transcript`** — new per-transcript index (targetId, transcriptId, biotype, proteinId, uniprotIds, isEnsemblCanonical, chromosome, start, end, strand, transcriptionStartSite, flags, exons) built from GeneCode/Ensembl.
- **`pts_safety_liability`** — flat (one row per liability, not grouped) safety liability index, with ENSG resolution via `output/target` and obsolete EFO remapping via `output/disease`.
- **`pts_target_tractability`** — tractability assessments, now with target ID validation against `output/target` and `id` renamed to `targetId`.
- **`pts_chemical_probes`** — promoted to a standalone, ENSG-resolved dataset at `output/chemical_probes`. This required removing the `chemicalProbes` field from `pts_target` entirely (not just simplifying it): `pts_chemical_probes` needs `output/target` for ID resolution, so `pts_target` can no longer also depend on `pts_chemical_probes`'s output without creating a circular dependency. Unresolvable-target rows are kept with a null `targetId` (not dropped), since `pts_drug_molecule` also consumes this dataset via `drugId`/`drugFromSourceId`, independent of target resolution.

Companion orchestration DAG/config changes are in opentargets/orchestration#feat/pts-transcript.

Implementation details, schemas, and per-dataset row/stat counts are posted as comments on opentargets/issues#4457.

## Test plan

- [x] Unit tests added for each new/changed module (`test_transcript.py`, `test_safety_liability.py`, `test_target_tractability.py`, `test_chemical_probes.py`); `test_target.py` updated for the removed `chemicalProbes` field
- [x] `ruff check` clean on all changed files
- [x] Each step run end-to-end locally against the 26.06 release dataset
- [x] Full `pts_target` step run end-to-end locally to confirm the `chemicalProbes` removal doesn't break assembly
- [x] Verified the updated orchestration DAG (`unified_pipeline.yaml`) has no cycles